### PR TITLE
Fix presence of executable stack markings for hardened systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (IS_ARMHF_BUILD)
     target_sources(mcpelauncher-client PRIVATE src/armhf_support.cpp src/armhf_support.h)
     target_compile_definitions(mcpelauncher-client PRIVATE USE_ARMHF_SUPPORT)
 else()
-    target_sources(mcpelauncher-client PRIVATE src/cpuid.cpp src/cpuid.h src/xbox_shutdown_patch.cpp src/xbox_shutdown_patch.h src/xbox_shutdown_patch.s src/texel_aa_patch.cpp src/texel_aa_patch.h)
+    target_sources(mcpelauncher-client PRIVATE src/cpuid.cpp src/cpuid.h src/xbox_shutdown_patch.cpp src/xbox_shutdown_patch.h src/xbox_shutdown_patch.S src/texel_aa_patch.cpp src/texel_aa_patch.h)
 endif()
 
 install(TARGETS mcpelauncher-client RUNTIME COMPONENT mcpelauncher-client DESTINATION bin)

--- a/src/xbox_shutdown_patch.S
+++ b/src/xbox_shutdown_patch.S
@@ -38,3 +38,7 @@ xbox_shutdown_patch_run_one_hook_2_1_9:
     mov ecx, [esp+0x5C]
     mov eax, [ecx+0xC]
 ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
See https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart.

I don't know when the xbox_shutdown_patch code is used so I didn't do anything other than fire up and shut down the game to test this.