### PR TITLE
Disable broken GLCore Patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ configure_file(src/build_info.h.in ${CMAKE_CURRENT_BINARY_DIR}/build_info/build_
 add_executable(mcpelauncher-client src/main.cpp src/client_app_platform.cpp src/client_app_platform.h src/store.cpp src/store.h src/xbox_live_patches.cpp src/xbox_live_patches.h src/fake_jni.cpp src/fake_jni.h src/window_callbacks.cpp src/window_callbacks.h src/http_request_stub.cpp src/http_request_stub.h src/xbox_live_helper.cpp src/xbox_live_helper.h src/minecraft_gamepad_mapping.h src/splitscreen_patch.cpp src/splitscreen_patch.h src/cll_upload_auth_step.cpp src/cll_upload_auth_step.h src/gl_core_patch.cpp src/gl_core_patch.h src/tts_patch.cpp src/tts_patch.h src/hbui_patch.cpp src/hbui_patch.h src/utf8_util.h src/shader_error_patch.cpp src/shader_error_patch.h src/xbox_live_game_interface.cpp src/xbox_live_game_interface.h src/legacy/xbox_live_game_interface_legacy_1_2_3.cpp src/legacy/xbox_live_game_interface_legacy_1_2_3.h src/legacy/xbox_live_game_interface_legacy_1_4.cpp src/legacy/xbox_live_game_interface_legacy_1_4.h src/legacy/xbox_live_game_interface_legacy_1_2.cpp src/legacy/xbox_live_game_interface_legacy_1_2.h src/legacy/legacy_patches.cpp src/legacy/legacy_patches.h src/minecraft_game_wrapper.cpp src/minecraft_game_wrapper.h src/legacy/minecraft_game_wrapper_legacy.h src/legacy/xbox_live_game_interface_legacy_0_15_2.cpp src/legacy/xbox_live_game_interface_legacy_0_15_2.h)
 target_link_libraries(mcpelauncher-client logger mcpelauncher-core gamewindow filepicker msa-daemon-client cll-telemetry argparser)
 target_include_directories(mcpelauncher-client PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/build_info/)
+if (APPLE)
+    set_target_properties(mcpelauncher-client PROPERTIES MACOSX_RPATH TRUE INSTALL_RPATH @executable_path/../Frameworks)
+endif()
 
 if (IS_ARMHF_BUILD)
     target_sources(mcpelauncher-client PRIVATE src/armhf_support.cpp src/armhf_support.h)


### PR DESCRIPTION
Minecraft 1.13.0.9+
Using libangle instead (OpenGl ES 2 / 3 on Mac)

**How should I provide libangls dylibs**
**Maybe add rpath to CMakelist to allow running without hint MacOs the location of libEGL.dylib**

Depends on patched [glfw](https://github.com/minecraft-linux/mcpelauncher-manifest/pull/178) and libangle binary x86 32bit MacOs (x64 ones are in Google Chrome app)