### PR TITLE
Rework core patches to be patched in via the linker

### DIFF
--- a/src/core_patches.cpp
+++ b/src/core_patches.cpp
@@ -1,6 +1,25 @@
 #include "core_patches.h"
 
+#include <mcpelauncher/linker.h>
+#include <mcpelauncher/patch_utils.h>
+#include <log.h>
+
 std::shared_ptr<GameWindow> CorePatches::currentGameWindow;
+
+void CorePatches::install(void *handle) {
+    // void* ptr = linker::dlsym(handle, "_ZN3web4http6client7details35verify_cert_chain_platform_specificERN5boost4asio3ssl14verify_contextERKSs");
+    // PatchUtils::patchCallInstruction(ptr, (void*) +[]() { return true; }, true);
+
+    void * appPlatform = linker::dlsym(handle, "_ZTV21AppPlatform_android23");
+    if(appPlatform) {
+        void** vta = &((void**) appPlatform)[2];
+        PatchUtils::VtableReplaceHelper vtr (handle, vta, vta);
+        vtr.replace("_ZN11AppPlatform16hideMousePointerEv", &hideMousePointer);
+        vtr.replace("_ZN11AppPlatform16showMousePointerEv", &showMousePointer);
+    } else {
+        Log::debug("CorePatches", "Failed to patch, vtable _ZTV21AppPlatform_android23 not found");
+    }
+}
 
 void CorePatches::showMousePointer() {
     currentGameWindow->setCursorDisabled(false);

--- a/src/core_patches.cpp
+++ b/src/core_patches.cpp
@@ -1,28 +1,13 @@
 #include "core_patches.h"
 
-#include <mcpelauncher/linker.h>
-#include <mcpelauncher/patch_utils.h>
-#include <log.h>
-
 std::shared_ptr<GameWindow> CorePatches::currentGameWindow;
 
-void CorePatches::install(void *handle) {
-    // void* ptr = linker::dlsym(handle, "_ZN3web4http6client7details35verify_cert_chain_platform_specificERN5boost4asio3ssl14verify_contextERKSs");
-    // PatchUtils::patchCallInstruction(ptr, (void*) +[]() { return true; }, true);
+void CorePatches::showMousePointer() {
+    currentGameWindow->setCursorDisabled(false);
+}
 
-    void * appPlatform = linker::dlsym(handle, "_ZTV21AppPlatform_android23");
-    if(appPlatform) {
-        void** vta = &((void**) appPlatform)[2];
-        PatchUtils::VtableReplaceHelper vtr (handle, vta, vta);
-        vtr.replace("_ZN11AppPlatform16hideMousePointerEv", +[]() {
-            currentGameWindow->setCursorDisabled(true);
-        });
-        vtr.replace("_ZN11AppPlatform16showMousePointerEv", +[]() {
-            currentGameWindow->setCursorDisabled(false);
-        });
-    } else {
-        Log::error("CorePatches", "Failed to patch vtable _ZTV21AppPlatform_android23 not found");
-    }
+void CorePatches::hideMousePointer() {
+    currentGameWindow->setCursorDisabled(true);
 }
 
 void CorePatches::setGameWindow(std::shared_ptr<GameWindow> gameWindow) {

--- a/src/core_patches.h
+++ b/src/core_patches.h
@@ -9,7 +9,9 @@ private:
     static std::shared_ptr<GameWindow> currentGameWindow;
 
 public:
-    static void install(void *handle);
+    static void showMousePointer();
+
+    static void hideMousePointer();
 
     static void setGameWindow(std::shared_ptr<GameWindow> gameWindow);
 

--- a/src/core_patches.h
+++ b/src/core_patches.h
@@ -9,6 +9,8 @@ private:
     static std::shared_ptr<GameWindow> currentGameWindow;
 
 public:
+    static void install(void *handle);
+
     static void showMousePointer();
 
     static void hideMousePointer();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,7 +129,7 @@ int main(int argc, char *argv[]) {
     linker::load_library("libandroid.so", android_syms);
 
     Log::trace("Launcher", "Loading Minecraft library");
-    static void* handle = MinecraftUtils::loadMinecraftLib();
+    static void* handle = MinecraftUtils::loadMinecraftLib(reinterpret_cast<void*>(&CorePatches::showMousePointer), reinterpret_cast<void*>(&CorePatches::hideMousePointer));
     if (!handle) {
       Log::error("Launcher", "Failed to load Minecraft library, please reinstall or wait for an update to support the new release");
       return 51;
@@ -145,7 +145,6 @@ int main(int argc, char *argv[]) {
 
     Log::info("Launcher", "Applying patches");
     SymbolsHelper::initSymbols(handle);
-    CorePatches::install(handle);
 #ifdef __i386__
     TexelAAPatch::install(handle);
     HbuiPatch::install(handle);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,7 @@ int main(int argc, char *argv[]) {
 
     Log::info("Launcher", "Applying patches");
     SymbolsHelper::initSymbols(handle);
+    CorePatches::install(handle);
 #ifdef __i386__
     TexelAAPatch::install(handle);
     HbuiPatch::install(handle);


### PR DESCRIPTION
This fixes mouse support for 1.16.210+ versions.

The callbacks themselves are passed as an argument when loading the Minecraft library.