### PR TITLE
Code Reformatted with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Google
+Standard: Cpp11
+UseTab: Never
+IndentWidth: 4
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 120
+IncludeBlocks: Preserve

--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ BasedOnStyle: Google
 Standard: Cpp11
 UseTab: Never
 IndentWidth: 4
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Attach
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
 ColumnLimit: 120

--- a/src/armhf_support.cpp
+++ b/src/armhf_support.cpp
@@ -6,38 +6,33 @@
 #define WRAP_DEF_FUNC(name, ...) static void name##_wrap(__VA_ARGS__)
 #define WRAP_DEF_FUNC_C(name, ...) name##_orig(__VA_ARGS__);
 
-#define WRAP1(name, sa, da)                                                    \
-  WRAP_DEF_ORIG(name, da);                                                     \
-  WRAP_DEF_FUNC(name, sa v1) { WRAP_DEF_FUNC_C(name, (da &)v1); }
-#define WRAP2(name, sa, sb, da, db)                                            \
-  WRAP_DEF_ORIG(name, da, db);                                                 \
-  WRAP_DEF_FUNC(name, sa v1, sb v2) {                                          \
-    WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2);                                 \
-  }
-#define WRAP3(name, sa, sb, sc, da, db, dc)                                    \
-  WRAP_DEF_ORIG(name, da, db, dc);                                             \
-  WRAP_DEF_FUNC(name, sa v1, sb v2, sc v3) {                                   \
-    WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2, (dc &)v3);                       \
-  }
-#define WRAP4(name, sa, sb, sc, sd, da, db, dc, dd)                            \
-  WRAP_DEF_ORIG(name, da, db, dc, dd);                                         \
-  WRAP_DEF_FUNC(name, sa v1, sb v2, sc v3, sd v4) {                            \
-    WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2, (dc &)v3, (dd &)v4);             \
-  }
+#define WRAP1(name, sa, da)  \
+    WRAP_DEF_ORIG(name, da); \
+    WRAP_DEF_FUNC(name, sa v1) { WRAP_DEF_FUNC_C(name, (da &)v1); }
+#define WRAP2(name, sa, sb, da, db) \
+    WRAP_DEF_ORIG(name, da, db);    \
+    WRAP_DEF_FUNC(name, sa v1, sb v2) { WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2); }
+#define WRAP3(name, sa, sb, sc, da, db, dc) \
+    WRAP_DEF_ORIG(name, da, db, dc);        \
+    WRAP_DEF_FUNC(name, sa v1, sb v2, sc v3) { WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2, (dc &)v3); }
+#define WRAP4(name, sa, sb, sc, sd, da, db, dc, dd) \
+    WRAP_DEF_ORIG(name, da, db, dc, dd);            \
+    WRAP_DEF_FUNC(name, sa v1, sb v2, sc v3, sd v4) { WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2, (dc &)v3, (dd &)v4); }
 
 WRAP4(glClearColor, int, int, int, int, float, float, float, float)
 WRAP2(glUniform1f, int, int, int, float)
 WRAP1(glClearDepthf, int, float)
 WRAP2(glDepthRangef, int, int, float, float)
 
-#define WRAP_INSTALL_GL(name)                                                  \
-  (void *(*&)()) name##_orig = procFunc(#name);                                \
-  overrides[#name] = (void *)name##_wrap;
+#define WRAP_INSTALL_GL(name)                     \
+    (void *(*&)()) name##_orig = procFunc(#name); \
+    overrides[#name] = (void *)name##_wrap;
 
-void ArmhfSupport::install(std::unordered_map<std::string, void *> &overrides) {
-  auto procFunc = GameWindowManager::getManager()->getProcAddrFunc();
-  WRAP_INSTALL_GL(glClearColor)
-  WRAP_INSTALL_GL(glUniform1f)
-  WRAP_INSTALL_GL(glClearDepthf)
-  WRAP_INSTALL_GL(glDepthRangef)
+void ArmhfSupport::install(std::unordered_map<std::string, void *> &overrides)
+{
+    auto procFunc = GameWindowManager::getManager()->getProcAddrFunc();
+    WRAP_INSTALL_GL(glClearColor)
+    WRAP_INSTALL_GL(glUniform1f)
+    WRAP_INSTALL_GL(glClearDepthf)
+    WRAP_INSTALL_GL(glDepthRangef)
 }

--- a/src/armhf_support.cpp
+++ b/src/armhf_support.cpp
@@ -28,8 +28,7 @@ WRAP2(glDepthRangef, int, int, float, float)
     (void *(*&)()) name##_orig = procFunc(#name); \
     overrides[#name] = (void *)name##_wrap;
 
-void ArmhfSupport::install(std::unordered_map<std::string, void *> &overrides)
-{
+void ArmhfSupport::install(std::unordered_map<std::string, void *> &overrides) {
     auto procFunc = GameWindowManager::getManager()->getProcAddrFunc();
     WRAP_INSTALL_GL(glClearColor)
     WRAP_INSTALL_GL(glUniform1f)

--- a/src/armhf_support.cpp
+++ b/src/armhf_support.cpp
@@ -2,29 +2,42 @@
 
 #include <game_window_manager.h>
 
-#define WRAP_DEF_ORIG(name, ...) static void (* name ## _orig)(__VA_ARGS__);
-#define WRAP_DEF_FUNC(name, ...) static void name ## _wrap(__VA_ARGS__)
-#define WRAP_DEF_FUNC_C(name, ...) name ## _orig(__VA_ARGS__);
+#define WRAP_DEF_ORIG(name, ...) static void (*name##_orig)(__VA_ARGS__);
+#define WRAP_DEF_FUNC(name, ...) static void name##_wrap(__VA_ARGS__)
+#define WRAP_DEF_FUNC_C(name, ...) name##_orig(__VA_ARGS__);
 
-#define WRAP1(name, sa, da) WRAP_DEF_ORIG(name, da); WRAP_DEF_FUNC(name, sa v1) { WRAP_DEF_FUNC_C(name, (da&) v1); }
-#define WRAP2(name, sa, sb, da, db) WRAP_DEF_ORIG(name, da, db); WRAP_DEF_FUNC(name, sa v1, sb v2) { WRAP_DEF_FUNC_C(name, (da&) v1, (db&) v2); }
-#define WRAP3(name, sa, sb, sc, da, db, dc) WRAP_DEF_ORIG(name, da, db, dc); WRAP_DEF_FUNC(name, sa v1, sb v2, sc v3) { WRAP_DEF_FUNC_C(name, (da&) v1, (db&) v2, (dc&) v3); }
-#define WRAP4(name, sa, sb, sc, sd, da, db, dc, dd) WRAP_DEF_ORIG(name, da, db, dc, dd); WRAP_DEF_FUNC(name, sa v1, sb v2, sc v3, sd v4) { WRAP_DEF_FUNC_C(name, (da&) v1, (db&) v2, (dc&) v3, (dd&) v4); }
+#define WRAP1(name, sa, da)                                                    \
+  WRAP_DEF_ORIG(name, da);                                                     \
+  WRAP_DEF_FUNC(name, sa v1) { WRAP_DEF_FUNC_C(name, (da &)v1); }
+#define WRAP2(name, sa, sb, da, db)                                            \
+  WRAP_DEF_ORIG(name, da, db);                                                 \
+  WRAP_DEF_FUNC(name, sa v1, sb v2) {                                          \
+    WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2);                                 \
+  }
+#define WRAP3(name, sa, sb, sc, da, db, dc)                                    \
+  WRAP_DEF_ORIG(name, da, db, dc);                                             \
+  WRAP_DEF_FUNC(name, sa v1, sb v2, sc v3) {                                   \
+    WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2, (dc &)v3);                       \
+  }
+#define WRAP4(name, sa, sb, sc, sd, da, db, dc, dd)                            \
+  WRAP_DEF_ORIG(name, da, db, dc, dd);                                         \
+  WRAP_DEF_FUNC(name, sa v1, sb v2, sc v3, sd v4) {                            \
+    WRAP_DEF_FUNC_C(name, (da &)v1, (db &)v2, (dc &)v3, (dd &)v4);             \
+  }
 
 WRAP4(glClearColor, int, int, int, int, float, float, float, float)
 WRAP2(glUniform1f, int, int, int, float)
 WRAP1(glClearDepthf, int, float)
 WRAP2(glDepthRangef, int, int, float, float)
 
+#define WRAP_INSTALL_GL(name)                                                  \
+  (void *(*&)()) name##_orig = procFunc(#name);                                \
+  overrides[#name] = (void *)name##_wrap;
 
-#define WRAP_INSTALL_GL(name) \
-    (void* (*&)()) name ## _orig = procFunc(#name); \
-    overrides[#name] = (void*) name ## _wrap;
-
-void ArmhfSupport::install(std::unordered_map<std::string, void *>& overrides) {
-    auto procFunc = GameWindowManager::getManager()->getProcAddrFunc();
-    WRAP_INSTALL_GL(glClearColor)
-    WRAP_INSTALL_GL(glUniform1f)
-    WRAP_INSTALL_GL(glClearDepthf)
-    WRAP_INSTALL_GL(glDepthRangef)
+void ArmhfSupport::install(std::unordered_map<std::string, void *> &overrides) {
+  auto procFunc = GameWindowManager::getManager()->getProcAddrFunc();
+  WRAP_INSTALL_GL(glClearColor)
+  WRAP_INSTALL_GL(glUniform1f)
+  WRAP_INSTALL_GL(glClearDepthf)
+  WRAP_INSTALL_GL(glDepthRangef)
 }

--- a/src/armhf_support.h
+++ b/src/armhf_support.h
@@ -2,8 +2,7 @@
 #include <string>
 #include <unordered_map>
 
-class ArmhfSupport
-{
+class ArmhfSupport {
    public:
     static void install(std::unordered_map<std::string, void *> &overrides);
 };

--- a/src/armhf_support.h
+++ b/src/armhf_support.h
@@ -2,8 +2,8 @@
 #include <string>
 #include <unordered_map>
 
-class ArmhfSupport {
-
-public:
-  static void install(std::unordered_map<std::string, void *> &overrides);
+class ArmhfSupport
+{
+   public:
+    static void install(std::unordered_map<std::string, void *> &overrides);
 };

--- a/src/armhf_support.h
+++ b/src/armhf_support.h
@@ -1,10 +1,9 @@
 #pragma once
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 class ArmhfSupport {
 
 public:
-    static void install(std::unordered_map<std::string, void *>& overrides);
-
+  static void install(std::unordered_map<std::string, void *> &overrides);
 };

--- a/src/armhfrewrite.h
+++ b/src/armhfrewrite.h
@@ -1,18 +1,23 @@
 #pragma once
 #ifdef __arm__
-template <class T> struct armhfrewrite;
-template <class R, class... arg> struct armhfrewrite<R (*)(arg...)> {
-  template <R (*org)(arg...)>
-  static __attribute__((pcs("aapcs"))) R rewrite(arg... a) {
-    return org(a...);
-  }
+template <class T>
+struct armhfrewrite;
+template <class R, class... arg>
+struct armhfrewrite<R (*)(arg...)>
+{
+    template <R (*org)(arg...)>
+    static __attribute__((pcs("aapcs"))) R rewrite(arg... a)
+    {
+        return org(a...);
+    }
 };
 
 template <class R, class... arg>
-struct armhfrewrite<R (*)(arg...) noexcept> : armhfrewrite<R (*)(arg...)> {};
+struct armhfrewrite<R (*)(arg...) noexcept> : armhfrewrite<R (*)(arg...)>
+{
+};
 
-#define ARMHFREWRITE(func)                                                     \
-  (void *)&armhfrewrite<decltype(&func)>::rewrite<&func>
+#define ARMHFREWRITE(func) (void *)&armhfrewrite<decltype(&func)>::rewrite<&func>
 #else
 #define ARMHFREWRITE(func) func
 #endif

--- a/src/armhfrewrite.h
+++ b/src/armhfrewrite.h
@@ -1,15 +1,18 @@
 #pragma once
 #ifdef __arm__
-template<class T> struct armhfrewrite;
-template<class R, class ... arg > struct armhfrewrite<R (*)(arg...)> {
-    template<R(*org)(arg...)> static __attribute__((pcs("aapcs"))) R rewrite(arg...a) {
-        return org(a...);
-    }
+template <class T> struct armhfrewrite;
+template <class R, class... arg> struct armhfrewrite<R (*)(arg...)> {
+  template <R (*org)(arg...)>
+  static __attribute__((pcs("aapcs"))) R rewrite(arg... a) {
+    return org(a...);
+  }
 };
 
-template<class R, class ... arg > struct armhfrewrite<R (*)(arg...) noexcept> : armhfrewrite<R (*)(arg...)> {};
+template <class R, class... arg>
+struct armhfrewrite<R (*)(arg...) noexcept> : armhfrewrite<R (*)(arg...)> {};
 
-#define ARMHFREWRITE(func) (void*)&armhfrewrite<decltype(&func)>::rewrite<&func>
+#define ARMHFREWRITE(func)                                                     \
+  (void *)&armhfrewrite<decltype(&func)>::rewrite<&func>
 #else
 #define ARMHFREWRITE(func) func
 #endif

--- a/src/armhfrewrite.h
+++ b/src/armhfrewrite.h
@@ -3,19 +3,15 @@
 template <class T>
 struct armhfrewrite;
 template <class R, class... arg>
-struct armhfrewrite<R (*)(arg...)>
-{
+struct armhfrewrite<R (*)(arg...)> {
     template <R (*org)(arg...)>
-    static __attribute__((pcs("aapcs"))) R rewrite(arg... a)
-    {
+    static __attribute__((pcs("aapcs"))) R rewrite(arg... a) {
         return org(a...);
     }
 };
 
 template <class R, class... arg>
-struct armhfrewrite<R (*)(arg...) noexcept> : armhfrewrite<R (*)(arg...)>
-{
-};
+struct armhfrewrite<R (*)(arg...) noexcept> : armhfrewrite<R (*)(arg...)> {};
 
 #define ARMHFREWRITE(func) (void *)&armhfrewrite<decltype(&func)>::rewrite<&func>
 #else

--- a/src/cll_upload_auth_step.cpp
+++ b/src/cll_upload_auth_step.cpp
@@ -3,66 +3,67 @@
 #include <cll/event_batch.h>
 #include <sstream>
 
-void CllUploadAuthStep::setAccount(std::string const& cid) {
-    std::lock_guard<std::recursive_mutex> lock (cidMutex);
-    this->cid = cid;
+void CllUploadAuthStep::setAccount(std::string const &cid) {
+  std::lock_guard<std::recursive_mutex> lock(cidMutex);
+  this->cid = cid;
 }
 
 void CllUploadAuthStep::refreshTokens(bool force) {
-    std::lock_guard<std::recursive_mutex> lock (mutex);
-    {
-        std::lock_guard<std::recursive_mutex> lock2 (cidMutex);
-        if (cid != tokensCid) {
-            tokensCid = cid;
-            msaToken.clear();
-            xToken.clear();
-        }
+  std::lock_guard<std::recursive_mutex> lock(mutex);
+  {
+    std::lock_guard<std::recursive_mutex> lock2(cidMutex);
+    if (cid != tokensCid) {
+      tokensCid = cid;
+      msaToken.clear();
+      xToken.clear();
     }
-    if (msaToken.empty() || force)
-        msaToken = XboxLiveHelper::getInstance().getCllMsaToken(cid);
-    if (xToken.empty() || force)
-        xToken = XboxLiveHelper::getInstance().getCllXToken(force);
+  }
+  if (msaToken.empty() || force)
+    msaToken = XboxLiveHelper::getInstance().getCllMsaToken(cid);
+  if (xToken.empty() || force)
+    xToken = XboxLiveHelper::getInstance().getCllXToken(force);
 }
 
-void CllUploadAuthStep::onRequest(cll::EventUploadRequest& request) {
-    std::lock_guard<std::recursive_mutex> lock (mutex);
-    refreshTokens(false);
-    if (!msaToken.empty())
-        request.headers.emplace_back("X-AuthMsaDeviceTicket", msaToken);
-    if (!xToken.empty())
-        request.headers.emplace_back("X-AuthXToken", xToken);
-    std::map<std::string, std::string> tickets;
-    char const* ptr = request.batch.getData();
-    char const* end = ptr + request.batch.getDataSize();
-    while (true) {
-        char const* e = (char const*) memchr(ptr, '\n', end - ptr);
-        if (e == nullptr)
-            break;
-        nlohmann::json event = nlohmann::json::parse(nlohmann::detail::input_adapter(ptr, e - ptr - 1));
-        for (auto const& ticket : event["ext"]["android"]["tickets"]) {
-            std::string ticketStr = ticket;
-            if (tickets.count(ticketStr) == 0) {
-                auto tk = XboxLiveHelper::getInstance().getCllXTicket(ticketStr);
-                if (!tk.empty())
-                    tickets.insert({ticketStr, "x:" + tk});
-            }
-        }
-        ptr = e + 1;
+void CllUploadAuthStep::onRequest(cll::EventUploadRequest &request) {
+  std::lock_guard<std::recursive_mutex> lock(mutex);
+  refreshTokens(false);
+  if (!msaToken.empty())
+    request.headers.emplace_back("X-AuthMsaDeviceTicket", msaToken);
+  if (!xToken.empty())
+    request.headers.emplace_back("X-AuthXToken", xToken);
+  std::map<std::string, std::string> tickets;
+  char const *ptr = request.batch.getData();
+  char const *end = ptr + request.batch.getDataSize();
+  while (true) {
+    char const *e = (char const *)memchr(ptr, '\n', end - ptr);
+    if (e == nullptr)
+      break;
+    nlohmann::json event = nlohmann::json::parse(
+        nlohmann::detail::input_adapter(ptr, e - ptr - 1));
+    for (auto const &ticket : event["ext"]["android"]["tickets"]) {
+      std::string ticketStr = ticket;
+      if (tickets.count(ticketStr) == 0) {
+        auto tk = XboxLiveHelper::getInstance().getCllXTicket(ticketStr);
+        if (!tk.empty())
+          tickets.insert({ticketStr, "x:" + tk});
+      }
     }
-    if (!tickets.empty()) {
-        std::stringstream ss;
-        bool f = true;
-        for (auto const& ticket : tickets) {
-            if (!f)
-                ss << ';';
-            ss << '"' << ticket.first << "\"=\"" << ticket.second << '"';
-            f = false;
-        }
-        request.headers.emplace_back("X-Tickets", ss.str());
+    ptr = e + 1;
+  }
+  if (!tickets.empty()) {
+    std::stringstream ss;
+    bool f = true;
+    for (auto const &ticket : tickets) {
+      if (!f)
+        ss << ';';
+      ss << '"' << ticket.first << "\"=\"" << ticket.second << '"';
+      f = false;
     }
+    request.headers.emplace_back("X-Tickets", ss.str());
+  }
 }
 
 bool CllUploadAuthStep::onAuthenticationFailed() {
-    refreshTokens(true);
-    return true;
+  refreshTokens(true);
+  return true;
 }

--- a/src/cll_upload_auth_step.cpp
+++ b/src/cll_upload_auth_step.cpp
@@ -3,19 +3,16 @@
 #include <sstream>
 #include "xbox_live_helper.h"
 
-void CllUploadAuthStep::setAccount(std::string const &cid)
-{
+void CllUploadAuthStep::setAccount(std::string const &cid) {
     std::lock_guard<std::recursive_mutex> lock(cidMutex);
     this->cid = cid;
 }
 
-void CllUploadAuthStep::refreshTokens(bool force)
-{
+void CllUploadAuthStep::refreshTokens(bool force) {
     std::lock_guard<std::recursive_mutex> lock(mutex);
     {
         std::lock_guard<std::recursive_mutex> lock2(cidMutex);
-        if (cid != tokensCid)
-        {
+        if (cid != tokensCid) {
             tokensCid = cid;
             msaToken.clear();
             xToken.clear();
@@ -27,8 +24,7 @@ void CllUploadAuthStep::refreshTokens(bool force)
         xToken = XboxLiveHelper::getInstance().getCllXToken(force);
 }
 
-void CllUploadAuthStep::onRequest(cll::EventUploadRequest &request)
-{
+void CllUploadAuthStep::onRequest(cll::EventUploadRequest &request) {
     std::lock_guard<std::recursive_mutex> lock(mutex);
     refreshTokens(false);
     if (!msaToken.empty())
@@ -38,17 +34,14 @@ void CllUploadAuthStep::onRequest(cll::EventUploadRequest &request)
     std::map<std::string, std::string> tickets;
     char const *ptr = request.batch.getData();
     char const *end = ptr + request.batch.getDataSize();
-    while (true)
-    {
+    while (true) {
         char const *e = (char const *)memchr(ptr, '\n', end - ptr);
         if (e == nullptr)
             break;
         nlohmann::json event = nlohmann::json::parse(nlohmann::detail::input_adapter(ptr, e - ptr - 1));
-        for (auto const &ticket : event["ext"]["android"]["tickets"])
-        {
+        for (auto const &ticket : event["ext"]["android"]["tickets"]) {
             std::string ticketStr = ticket;
-            if (tickets.count(ticketStr) == 0)
-            {
+            if (tickets.count(ticketStr) == 0) {
                 auto tk = XboxLiveHelper::getInstance().getCllXTicket(ticketStr);
                 if (!tk.empty())
                     tickets.insert({ticketStr, "x:" + tk});
@@ -56,12 +49,10 @@ void CllUploadAuthStep::onRequest(cll::EventUploadRequest &request)
         }
         ptr = e + 1;
     }
-    if (!tickets.empty())
-    {
+    if (!tickets.empty()) {
         std::stringstream ss;
         bool f = true;
-        for (auto const &ticket : tickets)
-        {
+        for (auto const &ticket : tickets) {
             if (!f)
                 ss << ';';
             ss << '"' << ticket.first << "\"=\"" << ticket.second << '"';
@@ -71,8 +62,7 @@ void CllUploadAuthStep::onRequest(cll::EventUploadRequest &request)
     }
 }
 
-bool CllUploadAuthStep::onAuthenticationFailed()
-{
+bool CllUploadAuthStep::onAuthenticationFailed() {
     refreshTokens(true);
     return true;
 }

--- a/src/cll_upload_auth_step.cpp
+++ b/src/cll_upload_auth_step.cpp
@@ -1,69 +1,78 @@
 #include "cll_upload_auth_step.h"
-#include "xbox_live_helper.h"
 #include <cll/event_batch.h>
 #include <sstream>
+#include "xbox_live_helper.h"
 
-void CllUploadAuthStep::setAccount(std::string const &cid) {
-  std::lock_guard<std::recursive_mutex> lock(cidMutex);
-  this->cid = cid;
+void CllUploadAuthStep::setAccount(std::string const &cid)
+{
+    std::lock_guard<std::recursive_mutex> lock(cidMutex);
+    this->cid = cid;
 }
 
-void CllUploadAuthStep::refreshTokens(bool force) {
-  std::lock_guard<std::recursive_mutex> lock(mutex);
-  {
-    std::lock_guard<std::recursive_mutex> lock2(cidMutex);
-    if (cid != tokensCid) {
-      tokensCid = cid;
-      msaToken.clear();
-      xToken.clear();
+void CllUploadAuthStep::refreshTokens(bool force)
+{
+    std::lock_guard<std::recursive_mutex> lock(mutex);
+    {
+        std::lock_guard<std::recursive_mutex> lock2(cidMutex);
+        if (cid != tokensCid)
+        {
+            tokensCid = cid;
+            msaToken.clear();
+            xToken.clear();
+        }
     }
-  }
-  if (msaToken.empty() || force)
-    msaToken = XboxLiveHelper::getInstance().getCllMsaToken(cid);
-  if (xToken.empty() || force)
-    xToken = XboxLiveHelper::getInstance().getCllXToken(force);
+    if (msaToken.empty() || force)
+        msaToken = XboxLiveHelper::getInstance().getCllMsaToken(cid);
+    if (xToken.empty() || force)
+        xToken = XboxLiveHelper::getInstance().getCllXToken(force);
 }
 
-void CllUploadAuthStep::onRequest(cll::EventUploadRequest &request) {
-  std::lock_guard<std::recursive_mutex> lock(mutex);
-  refreshTokens(false);
-  if (!msaToken.empty())
-    request.headers.emplace_back("X-AuthMsaDeviceTicket", msaToken);
-  if (!xToken.empty())
-    request.headers.emplace_back("X-AuthXToken", xToken);
-  std::map<std::string, std::string> tickets;
-  char const *ptr = request.batch.getData();
-  char const *end = ptr + request.batch.getDataSize();
-  while (true) {
-    char const *e = (char const *)memchr(ptr, '\n', end - ptr);
-    if (e == nullptr)
-      break;
-    nlohmann::json event = nlohmann::json::parse(
-        nlohmann::detail::input_adapter(ptr, e - ptr - 1));
-    for (auto const &ticket : event["ext"]["android"]["tickets"]) {
-      std::string ticketStr = ticket;
-      if (tickets.count(ticketStr) == 0) {
-        auto tk = XboxLiveHelper::getInstance().getCllXTicket(ticketStr);
-        if (!tk.empty())
-          tickets.insert({ticketStr, "x:" + tk});
-      }
+void CllUploadAuthStep::onRequest(cll::EventUploadRequest &request)
+{
+    std::lock_guard<std::recursive_mutex> lock(mutex);
+    refreshTokens(false);
+    if (!msaToken.empty())
+        request.headers.emplace_back("X-AuthMsaDeviceTicket", msaToken);
+    if (!xToken.empty())
+        request.headers.emplace_back("X-AuthXToken", xToken);
+    std::map<std::string, std::string> tickets;
+    char const *ptr = request.batch.getData();
+    char const *end = ptr + request.batch.getDataSize();
+    while (true)
+    {
+        char const *e = (char const *)memchr(ptr, '\n', end - ptr);
+        if (e == nullptr)
+            break;
+        nlohmann::json event = nlohmann::json::parse(nlohmann::detail::input_adapter(ptr, e - ptr - 1));
+        for (auto const &ticket : event["ext"]["android"]["tickets"])
+        {
+            std::string ticketStr = ticket;
+            if (tickets.count(ticketStr) == 0)
+            {
+                auto tk = XboxLiveHelper::getInstance().getCllXTicket(ticketStr);
+                if (!tk.empty())
+                    tickets.insert({ticketStr, "x:" + tk});
+            }
+        }
+        ptr = e + 1;
     }
-    ptr = e + 1;
-  }
-  if (!tickets.empty()) {
-    std::stringstream ss;
-    bool f = true;
-    for (auto const &ticket : tickets) {
-      if (!f)
-        ss << ';';
-      ss << '"' << ticket.first << "\"=\"" << ticket.second << '"';
-      f = false;
+    if (!tickets.empty())
+    {
+        std::stringstream ss;
+        bool f = true;
+        for (auto const &ticket : tickets)
+        {
+            if (!f)
+                ss << ';';
+            ss << '"' << ticket.first << "\"=\"" << ticket.second << '"';
+            f = false;
+        }
+        request.headers.emplace_back("X-Tickets", ss.str());
     }
-    request.headers.emplace_back("X-Tickets", ss.str());
-  }
 }
 
-bool CllUploadAuthStep::onAuthenticationFailed() {
-  refreshTokens(true);
-  return true;
+bool CllUploadAuthStep::onAuthenticationFailed()
+{
+    refreshTokens(true);
+    return true;
 }

--- a/src/cll_upload_auth_step.h
+++ b/src/cll_upload_auth_step.h
@@ -3,8 +3,7 @@
 #include <cll/event_upload_step.h>
 #include <mutex>
 
-class CllUploadAuthStep : public cll::EventUploadStep
-{
+class CllUploadAuthStep : public cll::EventUploadStep {
    private:
     std::recursive_mutex mutex;
     std::recursive_mutex cidMutex;

--- a/src/cll_upload_auth_step.h
+++ b/src/cll_upload_auth_step.h
@@ -3,22 +3,22 @@
 #include <cll/event_upload_step.h>
 #include <mutex>
 
-class CllUploadAuthStep : public cll::EventUploadStep {
+class CllUploadAuthStep : public cll::EventUploadStep
+{
+   private:
+    std::recursive_mutex mutex;
+    std::recursive_mutex cidMutex;
+    std::string cid;
+    std::string tokensCid;
+    std::string msaToken;
+    std::string xToken;
 
-private:
-  std::recursive_mutex mutex;
-  std::recursive_mutex cidMutex;
-  std::string cid;
-  std::string tokensCid;
-  std::string msaToken;
-  std::string xToken;
+    void refreshTokens(bool force = false);
 
-  void refreshTokens(bool force = false);
+   public:
+    void setAccount(std::string const &cid);
 
-public:
-  void setAccount(std::string const &cid);
+    void onRequest(cll::EventUploadRequest &request) override;
 
-  void onRequest(cll::EventUploadRequest &request) override;
-
-  bool onAuthenticationFailed() override;
+    bool onAuthenticationFailed() override;
 };

--- a/src/cll_upload_auth_step.h
+++ b/src/cll_upload_auth_step.h
@@ -1,25 +1,24 @@
 #pragma once
 
-#include <mutex>
 #include <cll/event_upload_step.h>
+#include <mutex>
 
 class CllUploadAuthStep : public cll::EventUploadStep {
 
 private:
-    std::recursive_mutex mutex;
-    std::recursive_mutex cidMutex;
-    std::string cid;
-    std::string tokensCid;
-    std::string msaToken;
-    std::string xToken;
+  std::recursive_mutex mutex;
+  std::recursive_mutex cidMutex;
+  std::string cid;
+  std::string tokensCid;
+  std::string msaToken;
+  std::string xToken;
 
-    void refreshTokens(bool force = false);
+  void refreshTokens(bool force = false);
 
 public:
-    void setAccount(std::string const& cid);
+  void setAccount(std::string const &cid);
 
-    void onRequest(cll::EventUploadRequest& request) override;
+  void onRequest(cll::EventUploadRequest &request) override;
 
-    bool onAuthenticationFailed() override;
-
+  bool onAuthenticationFailed() override;
 };

--- a/src/core_patches.cpp
+++ b/src/core_patches.cpp
@@ -1,34 +1,37 @@
 #include "core_patches.h"
 
+#include <log.h>
 #include <mcpelauncher/linker.h>
 #include <mcpelauncher/patch_utils.h>
-#include <log.h>
 
 std::shared_ptr<GameWindow> CorePatches::currentGameWindow;
 
 void CorePatches::install(void *handle) {
-    // void* ptr = linker::dlsym(handle, "_ZN3web4http6client7details35verify_cert_chain_platform_specificERN5boost4asio3ssl14verify_contextERKSs");
-    // PatchUtils::patchCallInstruction(ptr, (void*) +[]() { return true; }, true);
+  // void* ptr = linker::dlsym(handle,
+  // "_ZN3web4http6client7details35verify_cert_chain_platform_specificERN5boost4asio3ssl14verify_contextERKSs");
+  // PatchUtils::patchCallInstruction(ptr, (void*) +[]() { return true; },
+  // true);
 
-    void * appPlatform = linker::dlsym(handle, "_ZTV21AppPlatform_android23");
-    if(appPlatform) {
-        void** vta = &((void**) appPlatform)[2];
-        PatchUtils::VtableReplaceHelper vtr (handle, vta, vta);
-        vtr.replace("_ZN11AppPlatform16hideMousePointerEv", &hideMousePointer);
-        vtr.replace("_ZN11AppPlatform16showMousePointerEv", &showMousePointer);
-    } else {
-        Log::debug("CorePatches", "Failed to patch, vtable _ZTV21AppPlatform_android23 not found");
-    }
+  void *appPlatform = linker::dlsym(handle, "_ZTV21AppPlatform_android23");
+  if (appPlatform) {
+    void **vta = &((void **)appPlatform)[2];
+    PatchUtils::VtableReplaceHelper vtr(handle, vta, vta);
+    vtr.replace("_ZN11AppPlatform16hideMousePointerEv", &hideMousePointer);
+    vtr.replace("_ZN11AppPlatform16showMousePointerEv", &showMousePointer);
+  } else {
+    Log::debug("CorePatches",
+               "Failed to patch, vtable _ZTV21AppPlatform_android23 not found");
+  }
 }
 
 void CorePatches::showMousePointer() {
-    currentGameWindow->setCursorDisabled(false);
+  currentGameWindow->setCursorDisabled(false);
 }
 
 void CorePatches::hideMousePointer() {
-    currentGameWindow->setCursorDisabled(true);
+  currentGameWindow->setCursorDisabled(true);
 }
 
 void CorePatches::setGameWindow(std::shared_ptr<GameWindow> gameWindow) {
-    currentGameWindow = gameWindow;
+  currentGameWindow = gameWindow;
 }

--- a/src/core_patches.cpp
+++ b/src/core_patches.cpp
@@ -6,32 +6,29 @@
 
 std::shared_ptr<GameWindow> CorePatches::currentGameWindow;
 
-void CorePatches::install(void *handle) {
-  // void* ptr = linker::dlsym(handle,
-  // "_ZN3web4http6client7details35verify_cert_chain_platform_specificERN5boost4asio3ssl14verify_contextERKSs");
-  // PatchUtils::patchCallInstruction(ptr, (void*) +[]() { return true; },
-  // true);
+void CorePatches::install(void *handle)
+{
+    // void* ptr = linker::dlsym(handle,
+    // "_ZN3web4http6client7details35verify_cert_chain_platform_specificERN5boost4asio3ssl14verify_contextERKSs");
+    // PatchUtils::patchCallInstruction(ptr, (void*) +[]() { return true; },
+    // true);
 
-  void *appPlatform = linker::dlsym(handle, "_ZTV21AppPlatform_android23");
-  if (appPlatform) {
-    void **vta = &((void **)appPlatform)[2];
-    PatchUtils::VtableReplaceHelper vtr(handle, vta, vta);
-    vtr.replace("_ZN11AppPlatform16hideMousePointerEv", &hideMousePointer);
-    vtr.replace("_ZN11AppPlatform16showMousePointerEv", &showMousePointer);
-  } else {
-    Log::debug("CorePatches",
-               "Failed to patch, vtable _ZTV21AppPlatform_android23 not found");
-  }
+    void *appPlatform = linker::dlsym(handle, "_ZTV21AppPlatform_android23");
+    if (appPlatform)
+    {
+        void **vta = &((void **)appPlatform)[2];
+        PatchUtils::VtableReplaceHelper vtr(handle, vta, vta);
+        vtr.replace("_ZN11AppPlatform16hideMousePointerEv", &hideMousePointer);
+        vtr.replace("_ZN11AppPlatform16showMousePointerEv", &showMousePointer);
+    }
+    else
+    {
+        Log::debug("CorePatches", "Failed to patch, vtable _ZTV21AppPlatform_android23 not found");
+    }
 }
 
-void CorePatches::showMousePointer() {
-  currentGameWindow->setCursorDisabled(false);
-}
+void CorePatches::showMousePointer() { currentGameWindow->setCursorDisabled(false); }
 
-void CorePatches::hideMousePointer() {
-  currentGameWindow->setCursorDisabled(true);
-}
+void CorePatches::hideMousePointer() { currentGameWindow->setCursorDisabled(true); }
 
-void CorePatches::setGameWindow(std::shared_ptr<GameWindow> gameWindow) {
-  currentGameWindow = gameWindow;
-}
+void CorePatches::setGameWindow(std::shared_ptr<GameWindow> gameWindow) { currentGameWindow = gameWindow; }

--- a/src/core_patches.cpp
+++ b/src/core_patches.cpp
@@ -6,23 +6,19 @@
 
 std::shared_ptr<GameWindow> CorePatches::currentGameWindow;
 
-void CorePatches::install(void *handle)
-{
+void CorePatches::install(void *handle) {
     // void* ptr = linker::dlsym(handle,
     // "_ZN3web4http6client7details35verify_cert_chain_platform_specificERN5boost4asio3ssl14verify_contextERKSs");
     // PatchUtils::patchCallInstruction(ptr, (void*) +[]() { return true; },
     // true);
 
     void *appPlatform = linker::dlsym(handle, "_ZTV21AppPlatform_android23");
-    if (appPlatform)
-    {
+    if (appPlatform) {
         void **vta = &((void **)appPlatform)[2];
         PatchUtils::VtableReplaceHelper vtr(handle, vta, vta);
         vtr.replace("_ZN11AppPlatform16hideMousePointerEv", &hideMousePointer);
         vtr.replace("_ZN11AppPlatform16showMousePointerEv", &showMousePointer);
-    }
-    else
-    {
+    } else {
         Log::debug("CorePatches", "Failed to patch, vtable _ZTV21AppPlatform_android23 not found");
     }
 }

--- a/src/core_patches.h
+++ b/src/core_patches.h
@@ -3,8 +3,7 @@
 #include <game_window.h>
 #include <memory>
 
-class CorePatches
-{
+class CorePatches {
    private:
     static std::shared_ptr<GameWindow> currentGameWindow;
 

--- a/src/core_patches.h
+++ b/src/core_patches.h
@@ -3,17 +3,17 @@
 #include <game_window.h>
 #include <memory>
 
-class CorePatches {
+class CorePatches
+{
+   private:
+    static std::shared_ptr<GameWindow> currentGameWindow;
 
-private:
-  static std::shared_ptr<GameWindow> currentGameWindow;
+   public:
+    static void install(void *handle);
 
-public:
-  static void install(void *handle);
+    static void showMousePointer();
 
-  static void showMousePointer();
+    static void hideMousePointer();
 
-  static void hideMousePointer();
-
-  static void setGameWindow(std::shared_ptr<GameWindow> gameWindow);
+    static void setGameWindow(std::shared_ptr<GameWindow> gameWindow);
 };

--- a/src/core_patches.h
+++ b/src/core_patches.h
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <memory>
 #include <game_window.h>
+#include <memory>
 
 class CorePatches {
 
 private:
-    static std::shared_ptr<GameWindow> currentGameWindow;
+  static std::shared_ptr<GameWindow> currentGameWindow;
 
 public:
-    static void install(void *handle);
+  static void install(void *handle);
 
-    static void showMousePointer();
+  static void showMousePointer();
 
-    static void hideMousePointer();
+  static void hideMousePointer();
 
-    static void setGameWindow(std::shared_ptr<GameWindow> gameWindow);
-
+  static void setGameWindow(std::shared_ptr<GameWindow> gameWindow);
 };

--- a/src/cpuid.cpp
+++ b/src/cpuid.cpp
@@ -2,13 +2,11 @@
 
 #include <string.h>
 
-void CpuId::cpuid(int *data, int leaf)
-{
+void CpuId::cpuid(int *data, int leaf) {
     __asm__("cpuid" : "=a"(data[0]), "=b"(data[1]), "=c"(data[2]), "=d"(data[3]) : "a"(leaf));
 }
 
-CpuId::CpuId()
-{
+CpuId::CpuId() {
     int data[4];
     cpuid(data, 0);
     hiLeaf = (unsigned int)data[0];
@@ -20,15 +18,13 @@ CpuId::CpuId()
     hiExtLeaf = (unsigned int)data[0];
 }
 
-const char *CpuId::getBrandString()
-{
+const char *CpuId::getBrandString() {
     if (hasBrandString)
         return brandString;
     if (hiExtLeaf < 0x80000004)
         return nullptr;
     int data[4];
-    for (int i = 0; i < 3; i++)
-    {
+    for (int i = 0; i < 3; i++) {
         cpuid(data, 0x80000002 + i);
         memcpy(&brandString[i * 16], data, 16);
     }
@@ -36,8 +32,7 @@ const char *CpuId::getBrandString()
     return brandString;
 }
 
-void CpuId::queryFeatureFlags()
-{
+void CpuId::queryFeatureFlags() {
     if (hasFeatureFlags)
         return;
     if (hiLeaf < 1)
@@ -49,8 +44,7 @@ void CpuId::queryFeatureFlags()
     featureFlagsD = data[3];
 }
 
-bool CpuId::queryFeatureFlag(CpuId::FeatureFlag flag)
-{
+bool CpuId::queryFeatureFlag(CpuId::FeatureFlag flag) {
     queryFeatureFlags();
     auto flagi = (unsigned char)flag;
     if (flagi & 128)

--- a/src/cpuid.cpp
+++ b/src/cpuid.cpp
@@ -2,55 +2,59 @@
 
 #include <string.h>
 
-void CpuId::cpuid(int *data, int leaf) {
-  __asm__("cpuid"
-          : "=a"(data[0]), "=b"(data[1]), "=c"(data[2]), "=d"(data[3])
-          : "a"(leaf));
+void CpuId::cpuid(int *data, int leaf)
+{
+    __asm__("cpuid" : "=a"(data[0]), "=b"(data[1]), "=c"(data[2]), "=d"(data[3]) : "a"(leaf));
 }
 
-CpuId::CpuId() {
-  int data[4];
-  cpuid(data, 0);
-  hiLeaf = (unsigned int)data[0];
-  memcpy(&manufacturerId[0], &data[1], 4);
-  memcpy(&manufacturerId[4], &data[3], 4);
-  memcpy(&manufacturerId[8], &data[2], 4);
-  manufacturerId[12] = 0;
-  cpuid(data, 0x80000000);
-  hiExtLeaf = (unsigned int)data[0];
+CpuId::CpuId()
+{
+    int data[4];
+    cpuid(data, 0);
+    hiLeaf = (unsigned int)data[0];
+    memcpy(&manufacturerId[0], &data[1], 4);
+    memcpy(&manufacturerId[4], &data[3], 4);
+    memcpy(&manufacturerId[8], &data[2], 4);
+    manufacturerId[12] = 0;
+    cpuid(data, 0x80000000);
+    hiExtLeaf = (unsigned int)data[0];
 }
 
-const char *CpuId::getBrandString() {
-  if (hasBrandString)
+const char *CpuId::getBrandString()
+{
+    if (hasBrandString)
+        return brandString;
+    if (hiExtLeaf < 0x80000004)
+        return nullptr;
+    int data[4];
+    for (int i = 0; i < 3; i++)
+    {
+        cpuid(data, 0x80000002 + i);
+        memcpy(&brandString[i * 16], data, 16);
+    }
+    brandString[48] = 0;
     return brandString;
-  if (hiExtLeaf < 0x80000004)
-    return nullptr;
-  int data[4];
-  for (int i = 0; i < 3; i++) {
-    cpuid(data, 0x80000002 + i);
-    memcpy(&brandString[i * 16], data, 16);
-  }
-  brandString[48] = 0;
-  return brandString;
 }
 
-void CpuId::queryFeatureFlags() {
-  if (hasFeatureFlags)
-    return;
-  if (hiLeaf < 1)
-    return;
-  hasFeatureFlags = true;
-  int data[4];
-  cpuid(data, 1);
-  featureFlagsC = data[2];
-  featureFlagsD = data[3];
+void CpuId::queryFeatureFlags()
+{
+    if (hasFeatureFlags)
+        return;
+    if (hiLeaf < 1)
+        return;
+    hasFeatureFlags = true;
+    int data[4];
+    cpuid(data, 1);
+    featureFlagsC = data[2];
+    featureFlagsD = data[3];
 }
 
-bool CpuId::queryFeatureFlag(CpuId::FeatureFlag flag) {
-  queryFeatureFlags();
-  auto flagi = (unsigned char)flag;
-  if (flagi & 128)
-    return (featureFlagsD & (1 << (flagi & 0x7f))) != 0;
-  else
-    return (featureFlagsC & (1 << (flagi & 0x7f))) != 0;
+bool CpuId::queryFeatureFlag(CpuId::FeatureFlag flag)
+{
+    queryFeatureFlags();
+    auto flagi = (unsigned char)flag;
+    if (flagi & 128)
+        return (featureFlagsD & (1 << (flagi & 0x7f))) != 0;
+    else
+        return (featureFlagsC & (1 << (flagi & 0x7f))) != 0;
 }

--- a/src/cpuid.cpp
+++ b/src/cpuid.cpp
@@ -3,54 +3,54 @@
 #include <string.h>
 
 void CpuId::cpuid(int *data, int leaf) {
-    __asm__ ("cpuid"
-    : "=a" (data[0]), "=b" (data[1]), "=c" (data[2]), "=d" (data[3])
-    : "a" (leaf));
+  __asm__("cpuid"
+          : "=a"(data[0]), "=b"(data[1]), "=c"(data[2]), "=d"(data[3])
+          : "a"(leaf));
 }
 
 CpuId::CpuId() {
-    int data[4];
-    cpuid(data, 0);
-    hiLeaf = (unsigned int) data[0];
-    memcpy(&manufacturerId[0], &data[1], 4);
-    memcpy(&manufacturerId[4], &data[3], 4);
-    memcpy(&manufacturerId[8], &data[2], 4);
-    manufacturerId[12] = 0;
-    cpuid(data, 0x80000000);
-    hiExtLeaf = (unsigned int) data[0];
+  int data[4];
+  cpuid(data, 0);
+  hiLeaf = (unsigned int)data[0];
+  memcpy(&manufacturerId[0], &data[1], 4);
+  memcpy(&manufacturerId[4], &data[3], 4);
+  memcpy(&manufacturerId[8], &data[2], 4);
+  manufacturerId[12] = 0;
+  cpuid(data, 0x80000000);
+  hiExtLeaf = (unsigned int)data[0];
 }
 
-const char* CpuId::getBrandString() {
-    if (hasBrandString)
-        return brandString;
-    if (hiExtLeaf < 0x80000004)
-        return nullptr;
-    int data[4];
-    for (int i = 0; i < 3; i++) {
-        cpuid(data, 0x80000002 + i);
-        memcpy(&brandString[i * 16], data, 16);
-    }
-    brandString[48] = 0;
+const char *CpuId::getBrandString() {
+  if (hasBrandString)
     return brandString;
+  if (hiExtLeaf < 0x80000004)
+    return nullptr;
+  int data[4];
+  for (int i = 0; i < 3; i++) {
+    cpuid(data, 0x80000002 + i);
+    memcpy(&brandString[i * 16], data, 16);
+  }
+  brandString[48] = 0;
+  return brandString;
 }
 
 void CpuId::queryFeatureFlags() {
-    if (hasFeatureFlags)
-        return;
-    if (hiLeaf < 1)
-        return;
-    hasFeatureFlags = true;
-    int data[4];
-    cpuid(data, 1);
-    featureFlagsC = data[2];
-    featureFlagsD = data[3];
+  if (hasFeatureFlags)
+    return;
+  if (hiLeaf < 1)
+    return;
+  hasFeatureFlags = true;
+  int data[4];
+  cpuid(data, 1);
+  featureFlagsC = data[2];
+  featureFlagsD = data[3];
 }
 
 bool CpuId::queryFeatureFlag(CpuId::FeatureFlag flag) {
-    queryFeatureFlags();
-    auto flagi = (unsigned char) flag;
-    if (flagi & 128)
-        return (featureFlagsD & (1 << (flagi & 0x7f))) != 0;
-    else
-        return (featureFlagsC & (1 << (flagi & 0x7f))) != 0;
+  queryFeatureFlags();
+  auto flagi = (unsigned char)flag;
+  if (flagi & 128)
+    return (featureFlagsD & (1 << (flagi & 0x7f))) != 0;
+  else
+    return (featureFlagsC & (1 << (flagi & 0x7f))) != 0;
 }

--- a/src/cpuid.h
+++ b/src/cpuid.h
@@ -1,28 +1,31 @@
 #pragma once
 
-class CpuId {
+class CpuId
+{
+   private:
+    unsigned int hiLeaf;
+    unsigned int hiExtLeaf;
+    char manufacturerId[4 * 3 + 1];
+    bool hasBrandString = false;
+    char brandString[48 + 1];
+    bool hasFeatureFlags = false;
+    int featureFlagsC = 0, featureFlagsD = 0;
 
-private:
-  unsigned int hiLeaf;
-  unsigned int hiExtLeaf;
-  char manufacturerId[4 * 3 + 1];
-  bool hasBrandString = false;
-  char brandString[48 + 1];
-  bool hasFeatureFlags = false;
-  int featureFlagsC = 0, featureFlagsD = 0;
+    static void cpuid(int data[4], int leaf);
 
-  static void cpuid(int data[4], int leaf);
+    void queryFeatureFlags();
 
-  void queryFeatureFlags();
+   public:
+    enum class FeatureFlag : unsigned char
+    {
+        SSSE3 = 9
+    };
 
-public:
-  enum class FeatureFlag : unsigned char { SSSE3 = 9 };
+    CpuId();
 
-  CpuId();
+    const char *getManufacturer() { return manufacturerId; }
 
-  const char *getManufacturer() { return manufacturerId; }
+    const char *getBrandString();
 
-  const char *getBrandString();
-
-  bool queryFeatureFlag(FeatureFlag flag);
+    bool queryFeatureFlag(FeatureFlag flag);
 };

--- a/src/cpuid.h
+++ b/src/cpuid.h
@@ -1,7 +1,6 @@
 #pragma once
 
-class CpuId
-{
+class CpuId {
    private:
     unsigned int hiLeaf;
     unsigned int hiExtLeaf;
@@ -16,10 +15,7 @@ class CpuId
     void queryFeatureFlags();
 
    public:
-    enum class FeatureFlag : unsigned char
-    {
-        SSSE3 = 9
-    };
+    enum class FeatureFlag : unsigned char { SSSE3 = 9 };
 
     CpuId();
 

--- a/src/cpuid.h
+++ b/src/cpuid.h
@@ -3,31 +3,26 @@
 class CpuId {
 
 private:
-    unsigned int hiLeaf;
-    unsigned int hiExtLeaf;
-    char manufacturerId[4 * 3 + 1];
-    bool hasBrandString = false;
-    char brandString[48 + 1];
-    bool hasFeatureFlags = false;
-    int featureFlagsC = 0, featureFlagsD = 0;
+  unsigned int hiLeaf;
+  unsigned int hiExtLeaf;
+  char manufacturerId[4 * 3 + 1];
+  bool hasBrandString = false;
+  char brandString[48 + 1];
+  bool hasFeatureFlags = false;
+  int featureFlagsC = 0, featureFlagsD = 0;
 
-    static void cpuid(int data[4], int leaf);
+  static void cpuid(int data[4], int leaf);
 
-    void queryFeatureFlags();
+  void queryFeatureFlags();
 
 public:
-    enum class FeatureFlag : unsigned char {
-        SSSE3 = 9
-    };
+  enum class FeatureFlag : unsigned char { SSSE3 = 9 };
 
-    CpuId();
+  CpuId();
 
-    const char* getManufacturer() {
-        return manufacturerId;
-    }
+  const char *getManufacturer() { return manufacturerId; }
 
-    const char* getBrandString();
+  const char *getBrandString();
 
-    bool queryFeatureFlag(FeatureFlag flag);
-
+  bool queryFeatureFlag(FeatureFlag flag);
 };

--- a/src/fake_assetmanager.cpp
+++ b/src/fake_assetmanager.cpp
@@ -1,27 +1,27 @@
+#include "fake_assetmanager.h"
+#include <FileUtil.h>
+#include <android/compat.h>
+#include <cerrno>
 #include <cstdio>
 #include <cstring>
-#include <cerrno>
-#include <FileUtil.h>
-#include <sys/types.h>
 #include <dirent.h>
-#include <log.h>
 #include <libc_shim.h>
-#include <android/compat.h>
-#include "fake_assetmanager.h"
+#include <log.h>
+#include <sys/types.h>
 
 struct AAsset {
-    std::string buffer;
-    off64_t offset = 0;
+  std::string buffer;
+  off64_t offset = 0;
 };
 struct AAssetDir {
-    DIR *dir;
-    dirent *ent;
+  DIR *dir;
+  dirent *ent;
 };
 
 FakeAssetManager::FakeAssetManager(std::string rootDir) {
-    if (!rootDir.empty() && *rootDir.rbegin() != '/')
-        rootDir += '/';
-    this->rootDir = std::move(rootDir);
+  if (!rootDir.empty() && *rootDir.rbegin() != '/')
+    rootDir += '/';
+  this->rootDir = std::move(rootDir);
 }
 
 namespace fake_assetmanager {
@@ -30,176 +30,169 @@ namespace fake_assetmanager {
 // Some calls to AssetManager_open use full paths instead of relative paths
 // I don't know why.
 std::string rewrite_path(std::string path) {
-    for(auto&& from : shim::from_android_data_dir) {
-        // check if path starts with 'from' and 'to' does not
-        if(path.rfind(from,0) == 0 && shim::to_android_data_dir.rfind(from.data(), 0) != 0 ) {
-            return shim::to_android_data_dir + path.substr(from.length());
-        }
+  for (auto &&from : shim::from_android_data_dir) {
+    // check if path starts with 'from' and 'to' does not
+    if (path.rfind(from, 0) == 0 &&
+        shim::to_android_data_dir.rfind(from.data(), 0) != 0) {
+      return shim::to_android_data_dir + path.substr(from.length());
     }
-    return path;
+  }
+  return path;
 }
 
-AAsset *AAssetManager_open(FakeAssetManager *amgr, const char* filename, int mode) {
-    std::string fullPath;
-    if(filename == NULL) {
+AAsset *AAssetManager_open(FakeAssetManager *amgr, const char *filename,
+                           int mode) {
+  std::string fullPath;
+  if (filename == NULL) {
 #ifndef NDEBUG
-        Log::trace("AAssetManager", "Opening file NULLPTR failed.\n");
+    Log::trace("AAssetManager", "Opening file NULLPTR failed.\n");
 #endif
-        return nullptr;
-    }
+    return nullptr;
+  }
 
-    if(filename[0] != '/') {
-        fullPath = amgr->rootDir + filename;
-    } else {
-        fullPath = rewrite_path(filename);
-    }
-
+  if (filename[0] != '/') {
+    fullPath = amgr->rootDir + filename;
+  } else {
+    fullPath = rewrite_path(filename);
+  }
 
 #ifndef NDEBUG
-    Log::trace("AAssetManager", "Opening file '%s' as '%s'\n", filename, fullPath.c_str());
+  Log::trace("AAssetManager", "Opening file '%s' as '%s'\n", filename,
+             fullPath.c_str());
 #endif
 
-    std::string content;
-    if (!FileUtil::readFile(fullPath, content))
-        return nullptr;
+  std::string content;
+  if (!FileUtil::readFile(fullPath, content))
+    return nullptr;
 
-    auto ret = new AAsset;
-    ret->buffer = content;
-    return ret;
+  auto ret = new AAsset;
+  ret->buffer = content;
+  return ret;
 }
 
 AAssetDir *AAssetManager_openDir(FakeAssetManager *amgr, const char *dirname) {
-    if(dirname == NULL) {
+  if (dirname == NULL) {
 #ifndef NDEBUG
-        Log::trace("AAssetManager", "Opening directory NULLPTR failed.\n");
+    Log::trace("AAssetManager", "Opening directory NULLPTR failed.\n");
 #endif
-        return nullptr;
-    }
+    return nullptr;
+  }
 
-    std::string fullPath;
-    if(dirname[0] != '/') {
-        fullPath = amgr->rootDir + dirname;
-    } else {
-        fullPath = rewrite_path(dirname);
-    }
+  std::string fullPath;
+  if (dirname[0] != '/') {
+    fullPath = amgr->rootDir + dirname;
+  } else {
+    fullPath = rewrite_path(dirname);
+  }
 
 #ifndef NDEBUG
-    Log::trace("AAssetManager", "Opening directory '%s' as '%s'\n", dirname, fullPath.c_str());
+  Log::trace("AAssetManager", "Opening directory '%s' as '%s'\n", dirname,
+             fullPath.c_str());
 #endif
 
-    DIR *d = opendir(fullPath.c_str());
-    if (!d)
-        return nullptr;
+  DIR *d = opendir(fullPath.c_str());
+  if (!d)
+    return nullptr;
 
-    auto ret = new AAssetDir;
-    ret->dir = d;
-    ret->ent = nullptr;
-    return ret;
+  auto ret = new AAssetDir;
+  ret->dir = d;
+  ret->ent = nullptr;
+  return ret;
 }
 
-void AAsset_close(AAsset *asset) {
-    delete asset;
-}
+void AAsset_close(AAsset *asset) { delete asset; }
 
-int AAsset_isAllocated(AAsset *asset) {
-    return true;
-}
+int AAsset_isAllocated(AAsset *asset) { return true; }
 
-ssize_t AAsset_read(AAsset *asset, void* buf, size_t count) {
-    if (asset->offset > asset->buffer.size()) {
-        return 0;
-    }
-    size_t max_len = asset->buffer.size() - asset->offset;
-    if(count > max_len) {
-        count = max_len;
-    }
-    if(count == 0) {
-        return 0;
-    }
-    memcpy(buf, &asset->buffer[asset->offset], count);
-    asset->offset += count;
-    return (ssize_t)count;
+ssize_t AAsset_read(AAsset *asset, void *buf, size_t count) {
+  if (asset->offset > asset->buffer.size()) {
+    return 0;
+  }
+  size_t max_len = asset->buffer.size() - asset->offset;
+  if (count > max_len) {
+    count = max_len;
+  }
+  if (count == 0) {
+    return 0;
+  }
+  memcpy(buf, &asset->buffer[asset->offset], count);
+  asset->offset += count;
+  return (ssize_t)count;
 }
 
 off64_t AAsset_seek64(AAsset *asset, off64_t offset, int whence) {
-    off64_t cur_pos = asset->offset;
-    off64_t max_pos = asset->buffer.size();
-    off64_t new_offset;
+  off64_t cur_pos = asset->offset;
+  off64_t max_pos = asset->buffer.size();
+  off64_t new_offset;
 
-    if (whence == SEEK_SET) {
-        new_offset = offset;
-    } else if (whence == SEEK_CUR) {
-        new_offset = cur_pos + offset;
-    } else if (whence == SEEK_END) {
-        new_offset = max_pos + offset;
-    }
-    if (new_offset < 0 || new_offset > max_pos)
-        return -1;
-    asset->offset = new_offset;
-    return new_offset;
+  if (whence == SEEK_SET) {
+    new_offset = offset;
+  } else if (whence == SEEK_CUR) {
+    new_offset = cur_pos + offset;
+  } else if (whence == SEEK_END) {
+    new_offset = max_pos + offset;
+  }
+  if (new_offset < 0 || new_offset > max_pos)
+    return -1;
+  asset->offset = new_offset;
+  return new_offset;
 }
 
 off_t AAsset_seek(AAsset *asset, off_t offset, int whence) {
-    return (off_t) AAsset_seek64(asset, offset, whence);
+  return (off_t)AAsset_seek64(asset, offset, whence);
 }
 
 off64_t AAsset_getLength64(AAsset *asset) {
-    return (off64_t) asset->buffer.size();
+  return (off64_t)asset->buffer.size();
 }
 
-off_t AAsset_getLength(AAsset *asset) {
-    return (off_t) asset->buffer.size();
-}
+off_t AAsset_getLength(AAsset *asset) { return (off_t)asset->buffer.size(); }
 
 off64_t AAsset_getRemainingLength64(AAsset *asset) {
-    return (off64_t) (asset->buffer.size() - asset->offset);
+  return (off64_t)(asset->buffer.size() - asset->offset);
 }
 
 off_t AAsset_getRemainingLength(AAsset *asset) {
-    return (off_t) (asset->buffer.size() - asset->offset);
+  return (off_t)(asset->buffer.size() - asset->offset);
 }
 
-const void *AAsset_getBuffer(AAsset *asset) {
-    return asset->buffer.c_str();
-}
+const void *AAsset_getBuffer(AAsset *asset) { return asset->buffer.c_str(); }
 
 void AAssetDir_close(AAssetDir *assetDir) {
-    if (assetDir)
-        closedir(assetDir->dir);
-    delete assetDir;
+  if (assetDir)
+    closedir(assetDir->dir);
+  delete assetDir;
 }
 
-
-void AAssetDir_rewind(AAssetDir *assetDir) {
-    rewinddir(assetDir->dir);
-}
+void AAssetDir_rewind(AAssetDir *assetDir) { rewinddir(assetDir->dir); }
 
 const char *AAssetDir_getNextFileName(AAssetDir *assetDir) {
-    if (!assetDir)
-        return nullptr;
-    assetDir->ent = readdir(assetDir->dir);
-    if (!assetDir->ent)
-        return nullptr;
-    return assetDir->ent->d_name;
+  if (!assetDir)
+    return nullptr;
+  assetDir->ent = readdir(assetDir->dir);
+  if (!assetDir->ent)
+    return nullptr;
+  return assetDir->ent->d_name;
 }
 
-}
+} // namespace fake_assetmanager
 
-void FakeAssetManager::initHybrisHooks(std::unordered_map<std::string, void*> &syms) {
-    using namespace fake_assetmanager;
-    syms["AAssetManager_open"] = (void *) AAssetManager_open;
-    syms["AAssetManager_openDir"] = (void *) AAssetManager_openDir;
-    syms["AAsset_close"] = (void *) AAsset_close;
-    syms["AAsset_isAllocated"] = (void *) AAsset_isAllocated;
-    syms["AAsset_read"] = (void *) AAsset_read;
-    syms["AAsset_seek64"] = (void *) AAsset_seek64;
-    syms["AAsset_seek"] = (void *) AAsset_seek;
-    syms["AAsset_getLength64"] = (void *) AAsset_getLength64;
-    syms["AAsset_getLength"] = (void *) AAsset_getLength;
-    syms["AAsset_getRemainingLength64"] = (void *) AAsset_getRemainingLength64;
-    syms["AAsset_getRemainingLength"] = (void *) AAsset_getRemainingLength;
-    syms["AAsset_getBuffer"] = (void *) AAsset_getBuffer;
-    syms["AAssetDir_close"] = (void *) AAssetDir_close;
-    syms["AAssetDir_rewind"] = (void *) AAssetDir_rewind;
-    syms["AAssetDir_getNextFileName"] = (void *) AAssetDir_getNextFileName;
+void FakeAssetManager::initHybrisHooks(
+    std::unordered_map<std::string, void *> &syms) {
+  using namespace fake_assetmanager;
+  syms["AAssetManager_open"] = (void *)AAssetManager_open;
+  syms["AAssetManager_openDir"] = (void *)AAssetManager_openDir;
+  syms["AAsset_close"] = (void *)AAsset_close;
+  syms["AAsset_isAllocated"] = (void *)AAsset_isAllocated;
+  syms["AAsset_read"] = (void *)AAsset_read;
+  syms["AAsset_seek64"] = (void *)AAsset_seek64;
+  syms["AAsset_seek"] = (void *)AAsset_seek;
+  syms["AAsset_getLength64"] = (void *)AAsset_getLength64;
+  syms["AAsset_getLength"] = (void *)AAsset_getLength;
+  syms["AAsset_getRemainingLength64"] = (void *)AAsset_getRemainingLength64;
+  syms["AAsset_getRemainingLength"] = (void *)AAsset_getRemainingLength;
+  syms["AAsset_getBuffer"] = (void *)AAsset_getBuffer;
+  syms["AAssetDir_close"] = (void *)AAssetDir_close;
+  syms["AAssetDir_rewind"] = (void *)AAssetDir_rewind;
+  syms["AAssetDir_getNextFileName"] = (void *)AAssetDir_getNextFileName;
 }

--- a/src/fake_assetmanager.cpp
+++ b/src/fake_assetmanager.cpp
@@ -1,198 +1,215 @@
 #include "fake_assetmanager.h"
 #include <FileUtil.h>
 #include <android/compat.h>
-#include <cerrno>
-#include <cstdio>
-#include <cstring>
 #include <dirent.h>
 #include <libc_shim.h>
 #include <log.h>
 #include <sys/types.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 
-struct AAsset {
-  std::string buffer;
-  off64_t offset = 0;
+struct AAsset
+{
+    std::string buffer;
+    off64_t offset = 0;
 };
-struct AAssetDir {
-  DIR *dir;
-  dirent *ent;
+struct AAssetDir
+{
+    DIR *dir;
+    dirent *ent;
 };
 
-FakeAssetManager::FakeAssetManager(std::string rootDir) {
-  if (!rootDir.empty() && *rootDir.rbegin() != '/')
-    rootDir += '/';
-  this->rootDir = std::move(rootDir);
+FakeAssetManager::FakeAssetManager(std::string rootDir)
+{
+    if (!rootDir.empty() && *rootDir.rbegin() != '/')
+        rootDir += '/';
+    this->rootDir = std::move(rootDir);
 }
 
-namespace fake_assetmanager {
+namespace fake_assetmanager
+{
 
 // implement a rewrite function here so we don't need to call shim::open
 // Some calls to AssetManager_open use full paths instead of relative paths
 // I don't know why.
-std::string rewrite_path(std::string path) {
-  for (auto &&from : shim::from_android_data_dir) {
-    // check if path starts with 'from' and 'to' does not
-    if (path.rfind(from, 0) == 0 &&
-        shim::to_android_data_dir.rfind(from.data(), 0) != 0) {
-      return shim::to_android_data_dir + path.substr(from.length());
+std::string rewrite_path(std::string path)
+{
+    for (auto &&from : shim::from_android_data_dir)
+    {
+        // check if path starts with 'from' and 'to' does not
+        if (path.rfind(from, 0) == 0 && shim::to_android_data_dir.rfind(from.data(), 0) != 0)
+        {
+            return shim::to_android_data_dir + path.substr(from.length());
+        }
     }
-  }
-  return path;
+    return path;
 }
 
-AAsset *AAssetManager_open(FakeAssetManager *amgr, const char *filename,
-                           int mode) {
-  std::string fullPath;
-  if (filename == NULL) {
+AAsset *AAssetManager_open(FakeAssetManager *amgr, const char *filename, int mode)
+{
+    std::string fullPath;
+    if (filename == NULL)
+    {
 #ifndef NDEBUG
-    Log::trace("AAssetManager", "Opening file NULLPTR failed.\n");
+        Log::trace("AAssetManager", "Opening file NULLPTR failed.\n");
 #endif
-    return nullptr;
-  }
+        return nullptr;
+    }
 
-  if (filename[0] != '/') {
-    fullPath = amgr->rootDir + filename;
-  } else {
-    fullPath = rewrite_path(filename);
-  }
+    if (filename[0] != '/')
+    {
+        fullPath = amgr->rootDir + filename;
+    }
+    else
+    {
+        fullPath = rewrite_path(filename);
+    }
 
 #ifndef NDEBUG
-  Log::trace("AAssetManager", "Opening file '%s' as '%s'\n", filename,
-             fullPath.c_str());
+    Log::trace("AAssetManager", "Opening file '%s' as '%s'\n", filename, fullPath.c_str());
 #endif
 
-  std::string content;
-  if (!FileUtil::readFile(fullPath, content))
-    return nullptr;
+    std::string content;
+    if (!FileUtil::readFile(fullPath, content))
+        return nullptr;
 
-  auto ret = new AAsset;
-  ret->buffer = content;
-  return ret;
+    auto ret = new AAsset;
+    ret->buffer = content;
+    return ret;
 }
 
-AAssetDir *AAssetManager_openDir(FakeAssetManager *amgr, const char *dirname) {
-  if (dirname == NULL) {
+AAssetDir *AAssetManager_openDir(FakeAssetManager *amgr, const char *dirname)
+{
+    if (dirname == NULL)
+    {
 #ifndef NDEBUG
-    Log::trace("AAssetManager", "Opening directory NULLPTR failed.\n");
+        Log::trace("AAssetManager", "Opening directory NULLPTR failed.\n");
 #endif
-    return nullptr;
-  }
+        return nullptr;
+    }
 
-  std::string fullPath;
-  if (dirname[0] != '/') {
-    fullPath = amgr->rootDir + dirname;
-  } else {
-    fullPath = rewrite_path(dirname);
-  }
+    std::string fullPath;
+    if (dirname[0] != '/')
+    {
+        fullPath = amgr->rootDir + dirname;
+    }
+    else
+    {
+        fullPath = rewrite_path(dirname);
+    }
 
 #ifndef NDEBUG
-  Log::trace("AAssetManager", "Opening directory '%s' as '%s'\n", dirname,
-             fullPath.c_str());
+    Log::trace("AAssetManager", "Opening directory '%s' as '%s'\n", dirname, fullPath.c_str());
 #endif
 
-  DIR *d = opendir(fullPath.c_str());
-  if (!d)
-    return nullptr;
+    DIR *d = opendir(fullPath.c_str());
+    if (!d)
+        return nullptr;
 
-  auto ret = new AAssetDir;
-  ret->dir = d;
-  ret->ent = nullptr;
-  return ret;
+    auto ret = new AAssetDir;
+    ret->dir = d;
+    ret->ent = nullptr;
+    return ret;
 }
 
 void AAsset_close(AAsset *asset) { delete asset; }
 
 int AAsset_isAllocated(AAsset *asset) { return true; }
 
-ssize_t AAsset_read(AAsset *asset, void *buf, size_t count) {
-  if (asset->offset > asset->buffer.size()) {
-    return 0;
-  }
-  size_t max_len = asset->buffer.size() - asset->offset;
-  if (count > max_len) {
-    count = max_len;
-  }
-  if (count == 0) {
-    return 0;
-  }
-  memcpy(buf, &asset->buffer[asset->offset], count);
-  asset->offset += count;
-  return (ssize_t)count;
+ssize_t AAsset_read(AAsset *asset, void *buf, size_t count)
+{
+    if (asset->offset > asset->buffer.size())
+    {
+        return 0;
+    }
+    size_t max_len = asset->buffer.size() - asset->offset;
+    if (count > max_len)
+    {
+        count = max_len;
+    }
+    if (count == 0)
+    {
+        return 0;
+    }
+    memcpy(buf, &asset->buffer[asset->offset], count);
+    asset->offset += count;
+    return (ssize_t)count;
 }
 
-off64_t AAsset_seek64(AAsset *asset, off64_t offset, int whence) {
-  off64_t cur_pos = asset->offset;
-  off64_t max_pos = asset->buffer.size();
-  off64_t new_offset;
+off64_t AAsset_seek64(AAsset *asset, off64_t offset, int whence)
+{
+    off64_t cur_pos = asset->offset;
+    off64_t max_pos = asset->buffer.size();
+    off64_t new_offset;
 
-  if (whence == SEEK_SET) {
-    new_offset = offset;
-  } else if (whence == SEEK_CUR) {
-    new_offset = cur_pos + offset;
-  } else if (whence == SEEK_END) {
-    new_offset = max_pos + offset;
-  }
-  if (new_offset < 0 || new_offset > max_pos)
-    return -1;
-  asset->offset = new_offset;
-  return new_offset;
+    if (whence == SEEK_SET)
+    {
+        new_offset = offset;
+    }
+    else if (whence == SEEK_CUR)
+    {
+        new_offset = cur_pos + offset;
+    }
+    else if (whence == SEEK_END)
+    {
+        new_offset = max_pos + offset;
+    }
+    if (new_offset < 0 || new_offset > max_pos)
+        return -1;
+    asset->offset = new_offset;
+    return new_offset;
 }
 
-off_t AAsset_seek(AAsset *asset, off_t offset, int whence) {
-  return (off_t)AAsset_seek64(asset, offset, whence);
-}
+off_t AAsset_seek(AAsset *asset, off_t offset, int whence) { return (off_t)AAsset_seek64(asset, offset, whence); }
 
-off64_t AAsset_getLength64(AAsset *asset) {
-  return (off64_t)asset->buffer.size();
-}
+off64_t AAsset_getLength64(AAsset *asset) { return (off64_t)asset->buffer.size(); }
 
 off_t AAsset_getLength(AAsset *asset) { return (off_t)asset->buffer.size(); }
 
-off64_t AAsset_getRemainingLength64(AAsset *asset) {
-  return (off64_t)(asset->buffer.size() - asset->offset);
-}
+off64_t AAsset_getRemainingLength64(AAsset *asset) { return (off64_t)(asset->buffer.size() - asset->offset); }
 
-off_t AAsset_getRemainingLength(AAsset *asset) {
-  return (off_t)(asset->buffer.size() - asset->offset);
-}
+off_t AAsset_getRemainingLength(AAsset *asset) { return (off_t)(asset->buffer.size() - asset->offset); }
 
 const void *AAsset_getBuffer(AAsset *asset) { return asset->buffer.c_str(); }
 
-void AAssetDir_close(AAssetDir *assetDir) {
-  if (assetDir)
-    closedir(assetDir->dir);
-  delete assetDir;
+void AAssetDir_close(AAssetDir *assetDir)
+{
+    if (assetDir)
+        closedir(assetDir->dir);
+    delete assetDir;
 }
 
 void AAssetDir_rewind(AAssetDir *assetDir) { rewinddir(assetDir->dir); }
 
-const char *AAssetDir_getNextFileName(AAssetDir *assetDir) {
-  if (!assetDir)
-    return nullptr;
-  assetDir->ent = readdir(assetDir->dir);
-  if (!assetDir->ent)
-    return nullptr;
-  return assetDir->ent->d_name;
+const char *AAssetDir_getNextFileName(AAssetDir *assetDir)
+{
+    if (!assetDir)
+        return nullptr;
+    assetDir->ent = readdir(assetDir->dir);
+    if (!assetDir->ent)
+        return nullptr;
+    return assetDir->ent->d_name;
 }
 
-} // namespace fake_assetmanager
+}  // namespace fake_assetmanager
 
-void FakeAssetManager::initHybrisHooks(
-    std::unordered_map<std::string, void *> &syms) {
-  using namespace fake_assetmanager;
-  syms["AAssetManager_open"] = (void *)AAssetManager_open;
-  syms["AAssetManager_openDir"] = (void *)AAssetManager_openDir;
-  syms["AAsset_close"] = (void *)AAsset_close;
-  syms["AAsset_isAllocated"] = (void *)AAsset_isAllocated;
-  syms["AAsset_read"] = (void *)AAsset_read;
-  syms["AAsset_seek64"] = (void *)AAsset_seek64;
-  syms["AAsset_seek"] = (void *)AAsset_seek;
-  syms["AAsset_getLength64"] = (void *)AAsset_getLength64;
-  syms["AAsset_getLength"] = (void *)AAsset_getLength;
-  syms["AAsset_getRemainingLength64"] = (void *)AAsset_getRemainingLength64;
-  syms["AAsset_getRemainingLength"] = (void *)AAsset_getRemainingLength;
-  syms["AAsset_getBuffer"] = (void *)AAsset_getBuffer;
-  syms["AAssetDir_close"] = (void *)AAssetDir_close;
-  syms["AAssetDir_rewind"] = (void *)AAssetDir_rewind;
-  syms["AAssetDir_getNextFileName"] = (void *)AAssetDir_getNextFileName;
+void FakeAssetManager::initHybrisHooks(std::unordered_map<std::string, void *> &syms)
+{
+    using namespace fake_assetmanager;
+    syms["AAssetManager_open"] = (void *)AAssetManager_open;
+    syms["AAssetManager_openDir"] = (void *)AAssetManager_openDir;
+    syms["AAsset_close"] = (void *)AAsset_close;
+    syms["AAsset_isAllocated"] = (void *)AAsset_isAllocated;
+    syms["AAsset_read"] = (void *)AAsset_read;
+    syms["AAsset_seek64"] = (void *)AAsset_seek64;
+    syms["AAsset_seek"] = (void *)AAsset_seek;
+    syms["AAsset_getLength64"] = (void *)AAsset_getLength64;
+    syms["AAsset_getLength"] = (void *)AAsset_getLength;
+    syms["AAsset_getRemainingLength64"] = (void *)AAsset_getRemainingLength64;
+    syms["AAsset_getRemainingLength"] = (void *)AAsset_getRemainingLength;
+    syms["AAsset_getBuffer"] = (void *)AAsset_getBuffer;
+    syms["AAssetDir_close"] = (void *)AAssetDir_close;
+    syms["AAssetDir_rewind"] = (void *)AAssetDir_rewind;
+    syms["AAssetDir_getNextFileName"] = (void *)AAssetDir_getNextFileName;
 }

--- a/src/fake_assetmanager.h
+++ b/src/fake_assetmanager.h
@@ -7,13 +7,13 @@
 
 struct AAssetManager;
 
-struct FakeAssetManager {
+struct FakeAssetManager
+{
+    std::string rootDir;
 
-  std::string rootDir;
+    FakeAssetManager(std::string rootDir);
 
-  FakeAssetManager(std::string rootDir);
+    static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 
-  static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
-
-  explicit operator AAssetManager *() const { return (AAssetManager *)this; }
+    explicit operator AAssetManager *() const { return (AAssetManager *)this; }
 };

--- a/src/fake_assetmanager.h
+++ b/src/fake_assetmanager.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
 
@@ -9,14 +9,11 @@ struct AAssetManager;
 
 struct FakeAssetManager {
 
-    std::string rootDir;
+  std::string rootDir;
 
-    FakeAssetManager(std::string rootDir);
+  FakeAssetManager(std::string rootDir);
 
-    static void initHybrisHooks(std::unordered_map<std::string, void*> &syms);
+  static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 
-    explicit operator AAssetManager*() const {
-        return (AAssetManager *) this;
-    }
-
+  explicit operator AAssetManager *() const { return (AAssetManager *)this; }
 };

--- a/src/fake_assetmanager.h
+++ b/src/fake_assetmanager.h
@@ -7,8 +7,7 @@
 
 struct AAssetManager;
 
-struct FakeAssetManager
-{
+struct FakeAssetManager {
     std::string rootDir;
 
     FakeAssetManager(std::string rootDir);

--- a/src/fake_egl.cpp
+++ b/src/fake_egl.cpp
@@ -1,310 +1,320 @@
 #include "fake_egl.h"
-#include "gl_core_patch.h"
 #include <map>
+#include "gl_core_patch.h"
 
 #define __ANDROID__
 #include <EGL/egl.h>
 #undef __ANDROID__
-#include <cstring>
 #include <game_window.h>
 #include <log.h>
 #include <mcpelauncher/linker.h>
+#include <cstring>
 #ifdef USE_ARMHF_SUPPORT
 #include "armhf_support.h"
 #endif
 
-namespace fake_egl {
+namespace fake_egl
+{
 
 static thread_local EGLSurface currentDrawSurface;
 static void *(*hostProcAddrFn)(const char *);
 static std::unordered_map<std::string, void *> hostProcOverrides;
 
-EGLBoolean eglInitialize(EGLDisplay display, EGLint *major, EGLint *minor) {
-  if (major)
-    *major = 1;
-  if (minor)
-    *minor = 5;
-  return EGL_TRUE;
+EGLBoolean eglInitialize(EGLDisplay display, EGLint *major, EGLint *minor)
+{
+    if (major)
+        *major = 1;
+    if (minor)
+        *minor = 5;
+    return EGL_TRUE;
 }
 
 EGLBoolean eglTerminate(EGLDisplay display) { return EGL_TRUE; }
 
 EGLint eglGetError() { return EGL_SUCCESS; }
 
-char const *eglQueryString(EGLDisplay display, EGLint name) {
-  if (name == EGL_VENDOR)
-    return "mcpelauncher";
-  if (name == EGL_VERSION)
-    return "1.5 mcpelauncher";
-  if (name == EGL_EXTENSIONS)
-    return "";
-  Log::warn("FakeEGL", "eglQueryString %x", name);
-  return nullptr;
+char const *eglQueryString(EGLDisplay display, EGLint name)
+{
+    if (name == EGL_VENDOR)
+        return "mcpelauncher";
+    if (name == EGL_VERSION)
+        return "1.5 mcpelauncher";
+    if (name == EGL_EXTENSIONS)
+        return "";
+    Log::warn("FakeEGL", "eglQueryString %x", name);
+    return nullptr;
 }
 
 EGLDisplay eglGetDisplay(EGLNativeDisplayType dp) { return (EGLDisplay *)1; }
 
 EGLDisplay eglGetCurrentDisplay() { return (EGLDisplay *)1; }
 
-EGLContext eglGetCurrentContext() {
-  return currentDrawSurface ? (EGLContext *)1 : (EGLContext *)0;
-}
+EGLContext eglGetCurrentContext() { return currentDrawSurface ? (EGLContext *)1 : (EGLContext *)0; }
 
-EGLBoolean eglChooseConfig(EGLDisplay display, EGLint const *attrib_list,
-                           EGLConfig *configs, EGLint config_size,
-                           EGLint *num_config) {
-  *num_config = 1;
-  return EGL_TRUE;
-}
-
-EGLBoolean eglGetConfigAttrib(EGLDisplay display, EGLConfig config,
-                              EGLint attribute, EGLint *value) {
-  if (attribute == EGL_NATIVE_VISUAL_ID) {
-    *value = 0;
+EGLBoolean eglChooseConfig(EGLDisplay display, EGLint const *attrib_list, EGLConfig *configs, EGLint config_size,
+                           EGLint *num_config)
+{
+    *num_config = 1;
     return EGL_TRUE;
-  }
-  if (attribute == EGL_RED_SIZE || attribute == EGL_GREEN_SIZE ||
-      attribute == EGL_BLUE_SIZE || attribute == EGL_ALPHA_SIZE ||
-      attribute == EGL_DEPTH_SIZE || attribute == EGL_STENCIL_SIZE) {
-    *value = 8;
+}
+
+EGLBoolean eglGetConfigAttrib(EGLDisplay display, EGLConfig config, EGLint attribute, EGLint *value)
+{
+    if (attribute == EGL_NATIVE_VISUAL_ID)
+    {
+        *value = 0;
+        return EGL_TRUE;
+    }
+    if (attribute == EGL_RED_SIZE || attribute == EGL_GREEN_SIZE || attribute == EGL_BLUE_SIZE ||
+        attribute == EGL_ALPHA_SIZE || attribute == EGL_DEPTH_SIZE || attribute == EGL_STENCIL_SIZE)
+    {
+        *value = 8;
+        return EGL_TRUE;
+    }
+    Log::warn("FakeEGL", "eglGetConfigAttrib %x", attribute);
     return EGL_TRUE;
-  }
-  Log::warn("FakeEGL", "eglGetConfigAttrib %x", attribute);
-  return EGL_TRUE;
 }
 
-EGLSurface eglCreateWindowSurface(EGLDisplay display, EGLConfig config,
-                                  EGLNativeWindowType native_window,
-                                  EGLint const *attrib_list) {
-  return native_window;
+EGLSurface eglCreateWindowSurface(EGLDisplay display, EGLConfig config, EGLNativeWindowType native_window,
+                                  EGLint const *attrib_list)
+{
+    return native_window;
 }
 
-EGLBoolean eglDestroySurface(EGLDisplay display, EGLSurface surface) {
-  return EGL_TRUE;
+EGLBoolean eglDestroySurface(EGLDisplay display, EGLSurface surface) { return EGL_TRUE; }
+
+EGLContext eglCreateContext(EGLDisplay display, EGLConfig config, EGLContext share_context, EGLint const *attrib_list)
+{
+    return (EGLContext *)1;
 }
 
-EGLContext eglCreateContext(EGLDisplay display, EGLConfig config,
-                            EGLContext share_context,
-                            EGLint const *attrib_list) {
-  return (EGLContext *)1;
-}
+EGLBoolean eglDestroyContext(EGLDisplay display, EGLContext context) { return EGL_TRUE; }
 
-EGLBoolean eglDestroyContext(EGLDisplay display, EGLContext context) {
-  return EGL_TRUE;
-}
-
-EGLBoolean eglMakeCurrent(EGLDisplay display, EGLSurface draw, EGLSurface read,
-                          EGLContext context) {
-  if (draw != nullptr) {
-    ((GameWindow *)draw)->makeCurrent(true);
-  } else {
-    ((GameWindow *)currentDrawSurface)->makeCurrent(false);
-  }
-  currentDrawSurface = draw;
-  return EGL_TRUE;
-}
-
-EGLBoolean eglSwapBuffers(EGLDisplay display, EGLSurface surface) {
-  //    Log::trace("FakeEGL", "eglSwapBuffers");
-  ((GameWindow *)surface)->swapBuffers();
-  return EGL_TRUE;
-}
-
-EGLBoolean eglSwapInterval(EGLDisplay display, EGLint interval) {
-  ((GameWindow *)currentDrawSurface)->setSwapInterval(interval);
-  return EGL_TRUE;
-}
-
-EGLBoolean eglQuerySurface(EGLDisplay display, EGLSurface surface,
-                           EGLint attribute, EGLint *value) {
-  if (attribute == EGL_WIDTH || attribute == EGL_HEIGHT) {
-    int w, h;
-    ((GameWindow *)surface)->getWindowSize(w, h);
-    *value = (attribute == EGL_WIDTH ? w : h);
+EGLBoolean eglMakeCurrent(EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context)
+{
+    if (draw != nullptr)
+    {
+        ((GameWindow *)draw)->makeCurrent(true);
+    }
+    else
+    {
+        ((GameWindow *)currentDrawSurface)->makeCurrent(false);
+    }
+    currentDrawSurface = draw;
     return EGL_TRUE;
-  }
-  Log::warn("FakeEGL", "eglQuerySurface %x", attribute);
-  return EGL_TRUE;
 }
 
-void *eglGetProcAddress(const char *name) {
-  auto it = hostProcOverrides.find(name);
-  if (it != hostProcOverrides.end())
-    return it->second;
-  return hostProcAddrFn(name);
+EGLBoolean eglSwapBuffers(EGLDisplay display, EGLSurface surface)
+{
+    //    Log::trace("FakeEGL", "eglSwapBuffers");
+    ((GameWindow *)surface)->swapBuffers();
+    return EGL_TRUE;
 }
 
-} // namespace fake_egl
+EGLBoolean eglSwapInterval(EGLDisplay display, EGLint interval)
+{
+    ((GameWindow *)currentDrawSurface)->setSwapInterval(interval);
+    return EGL_TRUE;
+}
+
+EGLBoolean eglQuerySurface(EGLDisplay display, EGLSurface surface, EGLint attribute, EGLint *value)
+{
+    if (attribute == EGL_WIDTH || attribute == EGL_HEIGHT)
+    {
+        int w, h;
+        ((GameWindow *)surface)->getWindowSize(w, h);
+        *value = (attribute == EGL_WIDTH ? w : h);
+        return EGL_TRUE;
+    }
+    Log::warn("FakeEGL", "eglQuerySurface %x", attribute);
+    return EGL_TRUE;
+}
+
+void *eglGetProcAddress(const char *name)
+{
+    auto it = hostProcOverrides.find(name);
+    if (it != hostProcOverrides.end())
+        return it->second;
+    return hostProcAddrFn(name);
+}
+
+}  // namespace fake_egl
 
 bool FakeEGL::enableTexturePatch = false;
 
-void FakeEGL::setProcAddrFunction(void *(*fn)(const char *)) {
-  fake_egl::hostProcAddrFn = fn;
+void FakeEGL::setProcAddrFunction(void *(*fn)(const char *)) { fake_egl::hostProcAddrFn = fn; }
+
+void FakeEGL::installLibrary()
+{
+    std::unordered_map<std::string, void *> syms;
+    syms["eglInitialize"] = (void *)fake_egl::eglInitialize;
+    syms["eglTerminate"] = (void *)fake_egl::eglTerminate;
+    syms["eglGetError"] = (void *)fake_egl::eglGetError;
+    syms["eglQueryString"] = (void *)fake_egl::eglQueryString;
+    syms["eglGetDisplay"] = (void *)fake_egl::eglGetDisplay;
+    syms["eglGetCurrentDisplay"] = (void *)fake_egl::eglGetCurrentDisplay;
+    syms["eglGetCurrentContext"] = (void *)fake_egl::eglGetCurrentContext;
+    syms["eglChooseConfig"] = (void *)fake_egl::eglChooseConfig;
+    syms["eglGetConfigAttrib"] = (void *)fake_egl::eglGetConfigAttrib;
+    syms["eglCreateWindowSurface"] = (void *)fake_egl::eglCreateWindowSurface;
+    syms["eglDestroySurface"] = (void *)fake_egl::eglDestroySurface;
+    syms["eglCreateContext"] = (void *)fake_egl::eglCreateContext;
+    syms["eglDestroyContext"] = (void *)fake_egl::eglDestroyContext;
+    syms["eglMakeCurrent"] = (void *)fake_egl::eglMakeCurrent;
+    syms["eglSwapBuffers"] = (void *)fake_egl::eglSwapBuffers;
+    syms["eglSwapInterval"] = (void *)fake_egl::eglSwapInterval;
+    syms["eglQuerySurface"] = (void *)fake_egl::eglQuerySurface;
+    syms["eglGetProcAddress"] = (void *)fake_egl::eglGetProcAddress;
+    syms["eglWaitClient"] = (void *)+[]() -> EGLBoolean { return EGL_TRUE; };
+    linker::load_library("libEGL.so", syms);
 }
 
-void FakeEGL::installLibrary() {
-  std::unordered_map<std::string, void *> syms;
-  syms["eglInitialize"] = (void *)fake_egl::eglInitialize;
-  syms["eglTerminate"] = (void *)fake_egl::eglTerminate;
-  syms["eglGetError"] = (void *)fake_egl::eglGetError;
-  syms["eglQueryString"] = (void *)fake_egl::eglQueryString;
-  syms["eglGetDisplay"] = (void *)fake_egl::eglGetDisplay;
-  syms["eglGetCurrentDisplay"] = (void *)fake_egl::eglGetCurrentDisplay;
-  syms["eglGetCurrentContext"] = (void *)fake_egl::eglGetCurrentContext;
-  syms["eglChooseConfig"] = (void *)fake_egl::eglChooseConfig;
-  syms["eglGetConfigAttrib"] = (void *)fake_egl::eglGetConfigAttrib;
-  syms["eglCreateWindowSurface"] = (void *)fake_egl::eglCreateWindowSurface;
-  syms["eglDestroySurface"] = (void *)fake_egl::eglDestroySurface;
-  syms["eglCreateContext"] = (void *)fake_egl::eglCreateContext;
-  syms["eglDestroyContext"] = (void *)fake_egl::eglDestroyContext;
-  syms["eglMakeCurrent"] = (void *)fake_egl::eglMakeCurrent;
-  syms["eglSwapBuffers"] = (void *)fake_egl::eglSwapBuffers;
-  syms["eglSwapInterval"] = (void *)fake_egl::eglSwapInterval;
-  syms["eglQuerySurface"] = (void *)fake_egl::eglQuerySurface;
-  syms["eglGetProcAddress"] = (void *)fake_egl::eglGetProcAddress;
-  syms["eglWaitClient"] = (void *)+[]() -> EGLBoolean { return EGL_TRUE; };
-  linker::load_library("libEGL.so", syms);
-}
-
-void FakeEGL::setupGLOverrides() {
+void FakeEGL::setupGLOverrides()
+{
 #ifdef USE_ARMHF_SUPPORT
-  ArmhfSupport::install(fake_egl::hostProcOverrides);
+    ArmhfSupport::install(fake_egl::hostProcOverrides);
 #endif
-  fake_egl::hostProcOverrides["glInvalidateFramebuffer"] =
-      (void *)+[]() {}; // Stub for a NVIDIA bug
-  if (FakeEGL::enableTexturePatch) {
-    // Minecraft Intel/Amd Texture Bug 1.16.210-1.17.2 and beyond
-    // This patch reduces the visual glitch of blocks, does not work with high
-    // resolution textures
-    // TODO improve Bugdetection
-    fake_egl::hostProcOverrides["glTexSubImage2D"] =
-        (void *)+[](unsigned int target, int level, int xoffset, int yoffset,
-                    int width, int height, unsigned int format,
-                    unsigned int type, const void *data) {
-          if (width == 1024 && height == 1024) {
-            size_t z = 0;
-            for (long long y = 0; y < height; ++y) {
-              if (*((int32_t *)data + 987 + y * width) ==
-                      *((int32_t *)data + 988 + y * width) &&
-                  *((int32_t *)data + 988 + y * width) ==
-                      *((int32_t *)data + 989 + y * width) &&
-                  *((int32_t *)data + 989 + y * width) ==
-                      *((int32_t *)data + 990 + y * width) &&
-                  *((int32_t *)data + 990 + y * width) !=
-                      *((int32_t *)data + 991 + y * width)) {
-                z++;
-              }
+    fake_egl::hostProcOverrides["glInvalidateFramebuffer"] = (void *)+[]() {};  // Stub for a NVIDIA bug
+    if (FakeEGL::enableTexturePatch)
+    {
+        // Minecraft Intel/Amd Texture Bug 1.16.210-1.17.2 and beyond
+        // This patch reduces the visual glitch of blocks, does not work with high
+        // resolution textures
+        // TODO improve Bugdetection
+        fake_egl::hostProcOverrides["glTexSubImage2D"] =
+            (void *)+[](unsigned int target, int level, int xoffset, int yoffset, int width, int height,
+                        unsigned int format, unsigned int type, const void *data)
+        {
+            if (width == 1024 && height == 1024)
+            {
+                size_t z = 0;
+                for (long long y = 0; y < height; ++y)
+                {
+                    if (*((int32_t *)data + 987 + y * width) == *((int32_t *)data + 988 + y * width) &&
+                        *((int32_t *)data + 988 + y * width) == *((int32_t *)data + 989 + y * width) &&
+                        *((int32_t *)data + 989 + y * width) == *((int32_t *)data + 990 + y * width) &&
+                        *((int32_t *)data + 990 + y * width) != *((int32_t *)data + 991 + y * width))
+                    {
+                        z++;
+                    }
+                }
+                if (z >= 64)
+                {
+                    for (long long y = 0; y < 32; ++y)
+                    {
+                        memmove((char *)data + y * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
+                                width * 4 - 32 * 4);
+                    }
+                    for (long long y = height - 2; y >= 31; --y)
+                    {
+                        memcpy((char *)data + (y + 1) * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
+                               width * 4 - 32 * 4);
+                        memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 32 * 4);
+                    }
+                }
             }
-            if (z >= 64) {
-              for (long long y = 0; y < 32; ++y) {
-                memmove((char *)data + y * width * 4 + 32 * 4,
-                        (char *)data + y * width * 4 + 31 * 4,
-                        width * 4 - 32 * 4);
-              }
-              for (long long y = height - 2; y >= 31; --y) {
-                memcpy((char *)data + (y + 1) * width * 4 + 32 * 4,
-                       (char *)data + y * width * 4 + 31 * 4,
-                       width * 4 - 32 * 4);
-                memcpy((char *)data + (y + 1) * width * 4,
-                       (char *)data + y * width * 4, 32 * 4);
-              }
+            if (width == 2048 && height == 1024)
+            {
+                if (*((int32_t *)data + 989 + 1024) == *((int32_t *)data + 990 + 1024) &&
+                    *((int32_t *)data + 990 + 1024) != *((int32_t *)data + 991 + 1024))
+                {
+                    for (long long y = 0; y < 32; ++y)
+                    {
+                        memmove((char *)data + y * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
+                                width * 4 - 32 * 4);
+                    }
+                    for (long long y = height - 2; y >= 31; --y)
+                    {
+                        memcpy((char *)data + (y + 1) * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
+                               width * 4 - 32 * 4);
+                        memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 32 * 4);
+                    }
+                }
             }
-          }
-          if (width == 2048 && height == 1024) {
-            if (*((int32_t *)data + 989 + 1024) ==
-                    *((int32_t *)data + 990 + 1024) &&
-                *((int32_t *)data + 990 + 1024) !=
-                    *((int32_t *)data + 991 + 1024)) {
-              for (long long y = 0; y < 32; ++y) {
-                memmove((char *)data + y * width * 4 + 32 * 4,
-                        (char *)data + y * width * 4 + 31 * 4,
-                        width * 4 - 32 * 4);
-              }
-              for (long long y = height - 2; y >= 31; --y) {
-                memcpy((char *)data + (y + 1) * width * 4 + 32 * 4,
-                       (char *)data + y * width * 4 + 31 * 4,
-                       width * 4 - 32 * 4);
-                memcpy((char *)data + (y + 1) * width * 4,
-                       (char *)data + y * width * 4, 32 * 4);
-              }
-            }
-          }
 
-          if (width == 512 && height == 512) {
-            size_t uscore = 0;
-            size_t itemscorea = 0, itemscoreb = 0, itemscorec = 0,
-                   itemscored = 0;
-            for (int y = 0; y < height; ++y) {
-              if (*((uint32_t *)data + y * width + 511 - 14) != 0) {
-                ++itemscorea;
-              }
-              if (*((uint32_t *)data + y * width + 511 - 13) != 0) {
-                ++itemscoreb;
-              }
-              if (*((uint32_t *)data + y * width + 511 - 12) != 0) {
-                ++itemscorec;
-              }
-              if (*((uint32_t *)data + y * width + 511 - 11) == 0) {
-                ++itemscored;
-              }
-            }
-            for (int x = 0; x < width; ++x) {
-              if (*((uint32_t *)data + 1 * width + x) != 0) {
-                ++uscore;
-              }
-            }
-            size_t z = 0;
-            for (long long y = 0; y < height; ++y) {
-              if (*((int32_t *)data + 511 - 20 + y * width) ==
-                      *((int32_t *)data + 511 - 19 + y * width) &&
-                  *((int32_t *)data + 511 - 19 + y * width) ==
-                      *((int32_t *)data + 511 - 18 + y * width) &&
-                  *((int32_t *)data + 511 - 18 + y * width) ==
-                      *((int32_t *)data + 511 - 17 + y * width) &&
-                  *((int32_t *)data + 511 - 17 + y * width) !=
-                      *((int32_t *)data + 511 - 16 + y * width)) {
-                z++;
-              }
-            }
-            if (z >= 64 || (itemscorea > 64 && itemscoreb > 64 &&
-                            itemscorec > 64 && itemscored > 64)) {
-              if (z >= 64 || uscore < 16) {
-                for (long long y = 0; y < 16; ++y) {
-                  memmove((char *)data + y * width * 4 + 16 * 4,
-                          (char *)data + y * width * 4 + 15 * 4,
-                          width * 4 - 16 * 4);
+            if (width == 512 && height == 512)
+            {
+                size_t uscore = 0;
+                size_t itemscorea = 0, itemscoreb = 0, itemscorec = 0, itemscored = 0;
+                for (int y = 0; y < height; ++y)
+                {
+                    if (*((uint32_t *)data + y * width + 511 - 14) != 0)
+                    {
+                        ++itemscorea;
+                    }
+                    if (*((uint32_t *)data + y * width + 511 - 13) != 0)
+                    {
+                        ++itemscoreb;
+                    }
+                    if (*((uint32_t *)data + y * width + 511 - 12) != 0)
+                    {
+                        ++itemscorec;
+                    }
+                    if (*((uint32_t *)data + y * width + 511 - 11) == 0)
+                    {
+                        ++itemscored;
+                    }
                 }
-              } else {
-                for (long long y = 15; y >= 0; --y) {
-                  memcpy((char *)data + (y + 1) * width * 4 + 16 * 4,
-                         (char *)data + y * width * 4 + 15 * 4,
-                         width * 4 - 16 * 4);
+                for (int x = 0; x < width; ++x)
+                {
+                    if (*((uint32_t *)data + 1 * width + x) != 0)
+                    {
+                        ++uscore;
+                    }
                 }
-              }
-              if (z >= 64) {
-                for (long long y = height - 2; y >= 16; --y) {
-                  memcpy((char *)data + (y + 1) * width * 4 + 16 * 4,
-                         (char *)data + y * width * 4 + 15 * 4,
-                         width * 4 - 16 * 4);
-                  memcpy((char *)data + (y + 1) * width * 4,
-                         (char *)data + y * width * 4, 16 * 4);
+                size_t z = 0;
+                for (long long y = 0; y < height; ++y)
+                {
+                    if (*((int32_t *)data + 511 - 20 + y * width) == *((int32_t *)data + 511 - 19 + y * width) &&
+                        *((int32_t *)data + 511 - 19 + y * width) == *((int32_t *)data + 511 - 18 + y * width) &&
+                        *((int32_t *)data + 511 - 18 + y * width) == *((int32_t *)data + 511 - 17 + y * width) &&
+                        *((int32_t *)data + 511 - 17 + y * width) != *((int32_t *)data + 511 - 16 + y * width))
+                    {
+                        z++;
+                    }
                 }
-              } else {
-                for (long long y = height - 2; y >= 16; --y) {
-                  memcpy((char *)data + (y + 1) * width * 4 + 4,
-                         (char *)data + y * width * 4 + 0, width * 4 - 4);
+                if (z >= 64 || (itemscorea > 64 && itemscoreb > 64 && itemscorec > 64 && itemscored > 64))
+                {
+                    if (z >= 64 || uscore < 16)
+                    {
+                        for (long long y = 0; y < 16; ++y)
+                        {
+                            memmove((char *)data + y * width * 4 + 16 * 4, (char *)data + y * width * 4 + 15 * 4,
+                                    width * 4 - 16 * 4);
+                        }
+                    }
+                    else
+                    {
+                        for (long long y = 15; y >= 0; --y)
+                        {
+                            memcpy((char *)data + (y + 1) * width * 4 + 16 * 4, (char *)data + y * width * 4 + 15 * 4,
+                                   width * 4 - 16 * 4);
+                        }
+                    }
+                    if (z >= 64)
+                    {
+                        for (long long y = height - 2; y >= 16; --y)
+                        {
+                            memcpy((char *)data + (y + 1) * width * 4 + 16 * 4, (char *)data + y * width * 4 + 15 * 4,
+                                   width * 4 - 16 * 4);
+                            memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 16 * 4);
+                        }
+                    }
+                    else
+                    {
+                        for (long long y = height - 2; y >= 16; --y)
+                        {
+                            memcpy((char *)data + (y + 1) * width * 4 + 4, (char *)data + y * width * 4 + 0,
+                                   width * 4 - 4);
+                        }
+                    }
                 }
-              }
             }
-          }
-          ((void (*)(unsigned int target, int level, int xoffset, int yoffset,
-                     int width, int height, unsigned int format,
-                     unsigned int type, const void *data))(
-              fake_egl::hostProcAddrFn("glTexSubImage2D")))(
-              target, level, xoffset, yoffset, width, height, format, type,
-              data);
+            ((void (*)(unsigned int target, int level, int xoffset, int yoffset, int width, int height,
+                       unsigned int format, unsigned int type,
+                       const void *data))(fake_egl::hostProcAddrFn("glTexSubImage2D")))(
+                target, level, xoffset, yoffset, width, height, format, type, data);
         };
-  }
-  GLCorePatch::installGL(fake_egl::hostProcOverrides,
-                         fake_egl::eglGetProcAddress);
+    }
+    GLCorePatch::installGL(fake_egl::hostProcOverrides, fake_egl::eglGetProcAddress);
 }

--- a/src/fake_egl.cpp
+++ b/src/fake_egl.cpp
@@ -5,9 +5,9 @@
 #define __ANDROID__
 #include <EGL/egl.h>
 #undef __ANDROID__
-#include <log.h>
 #include <cstring>
 #include <game_window.h>
+#include <log.h>
 #include <mcpelauncher/linker.h>
 #ifdef USE_ARMHF_SUPPORT
 #include "armhf_support.h"
@@ -17,246 +17,294 @@ namespace fake_egl {
 
 static thread_local EGLSurface currentDrawSurface;
 static void *(*hostProcAddrFn)(const char *);
-static std::unordered_map<std::string, void*> hostProcOverrides;
+static std::unordered_map<std::string, void *> hostProcOverrides;
 
 EGLBoolean eglInitialize(EGLDisplay display, EGLint *major, EGLint *minor) {
-    if (major)
-        *major = 1;
-    if (minor)
-        *minor = 5;
-    return EGL_TRUE;
+  if (major)
+    *major = 1;
+  if (minor)
+    *minor = 5;
+  return EGL_TRUE;
 }
 
-EGLBoolean eglTerminate(EGLDisplay display) {
-    return EGL_TRUE;
+EGLBoolean eglTerminate(EGLDisplay display) { return EGL_TRUE; }
+
+EGLint eglGetError() { return EGL_SUCCESS; }
+
+char const *eglQueryString(EGLDisplay display, EGLint name) {
+  if (name == EGL_VENDOR)
+    return "mcpelauncher";
+  if (name == EGL_VERSION)
+    return "1.5 mcpelauncher";
+  if (name == EGL_EXTENSIONS)
+    return "";
+  Log::warn("FakeEGL", "eglQueryString %x", name);
+  return nullptr;
 }
 
-EGLint eglGetError() {
-    return EGL_SUCCESS;
-}
+EGLDisplay eglGetDisplay(EGLNativeDisplayType dp) { return (EGLDisplay *)1; }
 
-char const * eglQueryString(EGLDisplay display, EGLint name) {
-    if (name == EGL_VENDOR)
-        return "mcpelauncher";
-    if (name == EGL_VERSION)
-        return "1.5 mcpelauncher";
-    if (name == EGL_EXTENSIONS)
-        return "";
-    Log::warn("FakeEGL", "eglQueryString %x", name);
-    return nullptr;
-}
-
-EGLDisplay eglGetDisplay(EGLNativeDisplayType dp) {
-    return (EGLDisplay *) 1;
-}
-
-EGLDisplay eglGetCurrentDisplay() {
-    return (EGLDisplay *) 1;
-}
+EGLDisplay eglGetCurrentDisplay() { return (EGLDisplay *)1; }
 
 EGLContext eglGetCurrentContext() {
-    return currentDrawSurface ? (EGLContext *) 1 : (EGLContext *) 0;
+  return currentDrawSurface ? (EGLContext *)1 : (EGLContext *)0;
 }
 
-EGLBoolean eglChooseConfig(EGLDisplay display, EGLint const *attrib_list, EGLConfig *configs, EGLint config_size, EGLint *num_config) {
-    *num_config = 1;
+EGLBoolean eglChooseConfig(EGLDisplay display, EGLint const *attrib_list,
+                           EGLConfig *configs, EGLint config_size,
+                           EGLint *num_config) {
+  *num_config = 1;
+  return EGL_TRUE;
+}
+
+EGLBoolean eglGetConfigAttrib(EGLDisplay display, EGLConfig config,
+                              EGLint attribute, EGLint *value) {
+  if (attribute == EGL_NATIVE_VISUAL_ID) {
+    *value = 0;
     return EGL_TRUE;
-}
-
-EGLBoolean eglGetConfigAttrib(EGLDisplay display, EGLConfig config, EGLint attribute, EGLint * value) {
-    if (attribute == EGL_NATIVE_VISUAL_ID) {
-        *value = 0;
-        return EGL_TRUE;
-    }
-    if (attribute == EGL_RED_SIZE || attribute == EGL_GREEN_SIZE || attribute == EGL_BLUE_SIZE || attribute == EGL_ALPHA_SIZE ||attribute == EGL_DEPTH_SIZE || attribute == EGL_STENCIL_SIZE) {
-        *value = 8;
-        return EGL_TRUE;
-    }
-    Log::warn("FakeEGL", "eglGetConfigAttrib %x", attribute);
+  }
+  if (attribute == EGL_RED_SIZE || attribute == EGL_GREEN_SIZE ||
+      attribute == EGL_BLUE_SIZE || attribute == EGL_ALPHA_SIZE ||
+      attribute == EGL_DEPTH_SIZE || attribute == EGL_STENCIL_SIZE) {
+    *value = 8;
     return EGL_TRUE;
+  }
+  Log::warn("FakeEGL", "eglGetConfigAttrib %x", attribute);
+  return EGL_TRUE;
 }
 
-EGLSurface eglCreateWindowSurface(EGLDisplay display, EGLConfig config, EGLNativeWindowType native_window, EGLint const * attrib_list) {
-    return native_window;
+EGLSurface eglCreateWindowSurface(EGLDisplay display, EGLConfig config,
+                                  EGLNativeWindowType native_window,
+                                  EGLint const *attrib_list) {
+  return native_window;
 }
 
 EGLBoolean eglDestroySurface(EGLDisplay display, EGLSurface surface) {
-    return EGL_TRUE;
+  return EGL_TRUE;
 }
 
-EGLContext eglCreateContext(EGLDisplay display, EGLConfig config, EGLContext share_context, EGLint const * attrib_list) {
-    return (EGLContext *) 1;
+EGLContext eglCreateContext(EGLDisplay display, EGLConfig config,
+                            EGLContext share_context,
+                            EGLint const *attrib_list) {
+  return (EGLContext *)1;
 }
 
 EGLBoolean eglDestroyContext(EGLDisplay display, EGLContext context) {
-    return EGL_TRUE;
+  return EGL_TRUE;
 }
 
-EGLBoolean eglMakeCurrent(EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context) {
-    if(draw != nullptr) {
-        ((GameWindow *) draw)->makeCurrent(true);
-    } else {
-        ((GameWindow *) currentDrawSurface)->makeCurrent(false);
-    }
-    currentDrawSurface = draw;
-    return EGL_TRUE;
+EGLBoolean eglMakeCurrent(EGLDisplay display, EGLSurface draw, EGLSurface read,
+                          EGLContext context) {
+  if (draw != nullptr) {
+    ((GameWindow *)draw)->makeCurrent(true);
+  } else {
+    ((GameWindow *)currentDrawSurface)->makeCurrent(false);
+  }
+  currentDrawSurface = draw;
+  return EGL_TRUE;
 }
 
 EGLBoolean eglSwapBuffers(EGLDisplay display, EGLSurface surface) {
-//    Log::trace("FakeEGL", "eglSwapBuffers");
-    ((GameWindow *) surface)->swapBuffers();
-    return EGL_TRUE;
+  //    Log::trace("FakeEGL", "eglSwapBuffers");
+  ((GameWindow *)surface)->swapBuffers();
+  return EGL_TRUE;
 }
 
 EGLBoolean eglSwapInterval(EGLDisplay display, EGLint interval) {
-    ((GameWindow *) currentDrawSurface)->setSwapInterval(interval);
-    return EGL_TRUE;
+  ((GameWindow *)currentDrawSurface)->setSwapInterval(interval);
+  return EGL_TRUE;
 }
 
-EGLBoolean eglQuerySurface(EGLDisplay display, EGLSurface surface, EGLint attribute, EGLint *value) {
-    if (attribute == EGL_WIDTH || attribute == EGL_HEIGHT) {
-        int w, h;
-        ((GameWindow *) surface)->getWindowSize(w, h);
-        *value = (attribute == EGL_WIDTH ? w : h);
-        return EGL_TRUE;
-    }
-    Log::warn("FakeEGL", "eglQuerySurface %x", attribute);
+EGLBoolean eglQuerySurface(EGLDisplay display, EGLSurface surface,
+                           EGLint attribute, EGLint *value) {
+  if (attribute == EGL_WIDTH || attribute == EGL_HEIGHT) {
+    int w, h;
+    ((GameWindow *)surface)->getWindowSize(w, h);
+    *value = (attribute == EGL_WIDTH ? w : h);
     return EGL_TRUE;
+  }
+  Log::warn("FakeEGL", "eglQuerySurface %x", attribute);
+  return EGL_TRUE;
 }
 
 void *eglGetProcAddress(const char *name) {
-    auto it = hostProcOverrides.find(name);
-    if (it != hostProcOverrides.end())
-        return it->second;
-    return hostProcAddrFn(name);
+  auto it = hostProcOverrides.find(name);
+  if (it != hostProcOverrides.end())
+    return it->second;
+  return hostProcAddrFn(name);
 }
 
-}
+} // namespace fake_egl
 
 bool FakeEGL::enableTexturePatch = false;
 
 void FakeEGL::setProcAddrFunction(void *(*fn)(const char *)) {
-    fake_egl::hostProcAddrFn = fn;
+  fake_egl::hostProcAddrFn = fn;
 }
 
 void FakeEGL::installLibrary() {
-    std::unordered_map<std::string, void*> syms;
-    syms["eglInitialize"] = (void *) fake_egl::eglInitialize;
-    syms["eglTerminate"] = (void *) fake_egl::eglTerminate;
-    syms["eglGetError"] = (void *) fake_egl::eglGetError;
-    syms["eglQueryString"] = (void *) fake_egl::eglQueryString;
-    syms["eglGetDisplay"] = (void *) fake_egl::eglGetDisplay;
-    syms["eglGetCurrentDisplay"] = (void *) fake_egl::eglGetCurrentDisplay;
-    syms["eglGetCurrentContext"] = (void *) fake_egl::eglGetCurrentContext;
-    syms["eglChooseConfig"] = (void *) fake_egl::eglChooseConfig;
-    syms["eglGetConfigAttrib"] = (void *) fake_egl::eglGetConfigAttrib;
-    syms["eglCreateWindowSurface"] = (void *) fake_egl::eglCreateWindowSurface;
-    syms["eglDestroySurface"] = (void *) fake_egl::eglDestroySurface;
-    syms["eglCreateContext"] = (void *) fake_egl::eglCreateContext;
-    syms["eglDestroyContext"] = (void *) fake_egl::eglDestroyContext;
-    syms["eglMakeCurrent"] = (void *) fake_egl::eglMakeCurrent;
-    syms["eglSwapBuffers"] = (void *) fake_egl::eglSwapBuffers;
-    syms["eglSwapInterval"] = (void *) fake_egl::eglSwapInterval;
-    syms["eglQuerySurface"] = (void *) fake_egl::eglQuerySurface;
-    syms["eglGetProcAddress"] = (void *) fake_egl::eglGetProcAddress;
-    syms["eglWaitClient"] = (void *) +[]() -> EGLBoolean {
-        return EGL_TRUE;
-    };
-    linker::load_library("libEGL.so", syms);
+  std::unordered_map<std::string, void *> syms;
+  syms["eglInitialize"] = (void *)fake_egl::eglInitialize;
+  syms["eglTerminate"] = (void *)fake_egl::eglTerminate;
+  syms["eglGetError"] = (void *)fake_egl::eglGetError;
+  syms["eglQueryString"] = (void *)fake_egl::eglQueryString;
+  syms["eglGetDisplay"] = (void *)fake_egl::eglGetDisplay;
+  syms["eglGetCurrentDisplay"] = (void *)fake_egl::eglGetCurrentDisplay;
+  syms["eglGetCurrentContext"] = (void *)fake_egl::eglGetCurrentContext;
+  syms["eglChooseConfig"] = (void *)fake_egl::eglChooseConfig;
+  syms["eglGetConfigAttrib"] = (void *)fake_egl::eglGetConfigAttrib;
+  syms["eglCreateWindowSurface"] = (void *)fake_egl::eglCreateWindowSurface;
+  syms["eglDestroySurface"] = (void *)fake_egl::eglDestroySurface;
+  syms["eglCreateContext"] = (void *)fake_egl::eglCreateContext;
+  syms["eglDestroyContext"] = (void *)fake_egl::eglDestroyContext;
+  syms["eglMakeCurrent"] = (void *)fake_egl::eglMakeCurrent;
+  syms["eglSwapBuffers"] = (void *)fake_egl::eglSwapBuffers;
+  syms["eglSwapInterval"] = (void *)fake_egl::eglSwapInterval;
+  syms["eglQuerySurface"] = (void *)fake_egl::eglQuerySurface;
+  syms["eglGetProcAddress"] = (void *)fake_egl::eglGetProcAddress;
+  syms["eglWaitClient"] = (void *)+[]() -> EGLBoolean { return EGL_TRUE; };
+  linker::load_library("libEGL.so", syms);
 }
 
 void FakeEGL::setupGLOverrides() {
 #ifdef USE_ARMHF_SUPPORT
-    ArmhfSupport::install(fake_egl::hostProcOverrides);
+  ArmhfSupport::install(fake_egl::hostProcOverrides);
 #endif
-    fake_egl::hostProcOverrides["glInvalidateFramebuffer"] = (void *) +[]() {}; // Stub for a NVIDIA bug
-    if (FakeEGL::enableTexturePatch) {
-        // Minecraft Intel/Amd Texture Bug 1.16.210-1.17.2 and beyond
-        // This patch reduces the visual glitch of blocks, does not work with high resolution textures
-        // TODO improve Bugdetection
-        fake_egl::hostProcOverrides["glTexSubImage2D"] = (void *) +[](unsigned int target, int level, int xoffset, int yoffset, int width, int height, unsigned int format, unsigned int type, const void * data) {
-            if (width == 1024 && height == 1024) {
-                size_t z = 0;
-                for (long long y = 0; y < height; ++y) {
-                    if (*((int32_t*)data + 987 + y * width) == *((int32_t*)data + 988 + y * width) && *((int32_t*)data + 988 + y * width) == *((int32_t*)data + 989 + y * width) && *((int32_t*)data + 989 + y * width) == *((int32_t*)data + 990 + y * width) && *((int32_t*)data + 990 + y * width) != *((int32_t*)data + 991 + y * width)) {
-                        z++;
-                    }
-                }
-                if (z >= 64)
-                {
-                    for (long long y = 0; y < 32; ++y) {
-                        memmove((char*)data + y * width * 4 + 32 * 4, (char*)data + y * width * 4 + 31 * 4, width * 4 - 32 * 4);
-                    }
-                    for (long long y = height - 2; y >= 31; --y) {
-                        memcpy((char*)data + (y + 1) * width * 4 + 32 * 4, (char*)data + y * width * 4 + 31 * 4, width * 4 - 32 * 4);
-                        memcpy((char*)data + (y + 1) * width * 4, (char*)data + y * width * 4, 32 * 4);
-                    }
-                }
+  fake_egl::hostProcOverrides["glInvalidateFramebuffer"] =
+      (void *)+[]() {}; // Stub for a NVIDIA bug
+  if (FakeEGL::enableTexturePatch) {
+    // Minecraft Intel/Amd Texture Bug 1.16.210-1.17.2 and beyond
+    // This patch reduces the visual glitch of blocks, does not work with high
+    // resolution textures
+    // TODO improve Bugdetection
+    fake_egl::hostProcOverrides["glTexSubImage2D"] =
+        (void *)+[](unsigned int target, int level, int xoffset, int yoffset,
+                    int width, int height, unsigned int format,
+                    unsigned int type, const void *data) {
+          if (width == 1024 && height == 1024) {
+            size_t z = 0;
+            for (long long y = 0; y < height; ++y) {
+              if (*((int32_t *)data + 987 + y * width) ==
+                      *((int32_t *)data + 988 + y * width) &&
+                  *((int32_t *)data + 988 + y * width) ==
+                      *((int32_t *)data + 989 + y * width) &&
+                  *((int32_t *)data + 989 + y * width) ==
+                      *((int32_t *)data + 990 + y * width) &&
+                  *((int32_t *)data + 990 + y * width) !=
+                      *((int32_t *)data + 991 + y * width)) {
+                z++;
+              }
             }
-            if (width == 2048 && height == 1024) {
-                if (*((int32_t*)data + 989 + 1024) == *((int32_t*)data + 990 + 1024) && *((int32_t*)data + 990 + 1024) != *((int32_t*)data + 991 + 1024)) {
-                    for (long long y = 0; y < 32; ++y) {
-                        memmove((char*)data + y * width * 4 + 32 * 4, (char*)data + y * width * 4 + 31 * 4, width * 4 - 32 * 4);
-                    }
-                    for (long long y = height - 2; y >= 31; --y) {
-                        memcpy((char*)data + (y + 1) * width * 4 + 32 * 4, (char*)data + y * width * 4 + 31 * 4, width * 4 - 32 * 4);
-                        memcpy((char*)data + (y + 1) * width * 4, (char*)data + y * width * 4, 32 * 4);
-                    }
-                }
+            if (z >= 64) {
+              for (long long y = 0; y < 32; ++y) {
+                memmove((char *)data + y * width * 4 + 32 * 4,
+                        (char *)data + y * width * 4 + 31 * 4,
+                        width * 4 - 32 * 4);
+              }
+              for (long long y = height - 2; y >= 31; --y) {
+                memcpy((char *)data + (y + 1) * width * 4 + 32 * 4,
+                       (char *)data + y * width * 4 + 31 * 4,
+                       width * 4 - 32 * 4);
+                memcpy((char *)data + (y + 1) * width * 4,
+                       (char *)data + y * width * 4, 32 * 4);
+              }
             }
+          }
+          if (width == 2048 && height == 1024) {
+            if (*((int32_t *)data + 989 + 1024) ==
+                    *((int32_t *)data + 990 + 1024) &&
+                *((int32_t *)data + 990 + 1024) !=
+                    *((int32_t *)data + 991 + 1024)) {
+              for (long long y = 0; y < 32; ++y) {
+                memmove((char *)data + y * width * 4 + 32 * 4,
+                        (char *)data + y * width * 4 + 31 * 4,
+                        width * 4 - 32 * 4);
+              }
+              for (long long y = height - 2; y >= 31; --y) {
+                memcpy((char *)data + (y + 1) * width * 4 + 32 * 4,
+                       (char *)data + y * width * 4 + 31 * 4,
+                       width * 4 - 32 * 4);
+                memcpy((char *)data + (y + 1) * width * 4,
+                       (char *)data + y * width * 4, 32 * 4);
+              }
+            }
+          }
 
-            if (width == 512 && height == 512) {
-                size_t uscore = 0;
-                size_t itemscorea = 0, itemscoreb = 0, itemscorec = 0, itemscored = 0;
-                for (int y = 0; y < height; ++y) {
-                    if (*((uint32_t*)data + y * width + 511 - 14) != 0) {
-                        ++itemscorea;
-                    }
-                    if (*((uint32_t*)data + y * width + 511 - 13) != 0) {
-                        ++itemscoreb;
-                    }
-                    if (*((uint32_t*)data + y * width + 511 - 12) != 0) {
-                        ++itemscorec;
-                    }
-                    if (*((uint32_t*)data + y * width + 511 - 11) == 0) {
-                        ++itemscored;
-                    }
-                }
-                for (int x = 0; x < width; ++x) {
-                    if (*((uint32_t*)data + 1 * width + x) != 0) {
-                        ++uscore;
-                    }
-                }
-                size_t z = 0;
-                for (long long y = 0; y < height; ++y) {
-                    if (*((int32_t*)data + 511 - 20 + y * width) == *((int32_t*)data + 511 - 19 + y * width) && *((int32_t*)data + 511 - 19 + y * width) == *((int32_t*)data + 511 - 18 + y * width) && *((int32_t*)data + 511 - 18 + y * width) == *((int32_t*)data + 511 - 17 + y * width) && *((int32_t*)data + 511 - 17 + y * width) != *((int32_t*)data + 511 - 16 + y * width)) {
-                        z++;
-                    }
-                }
-                if (z >= 64 || (itemscorea > 64 && itemscoreb > 64 && itemscorec > 64 && itemscored > 64)) {
-                    if (z >= 64 || uscore < 16) {
-                        for (long long y = 0; y < 16; ++y) {
-                            memmove((char*)data + y * width * 4 + 16 * 4, (char*)data + y * width * 4 + 15 * 4, width * 4 - 16 * 4);
-                        }
-                    } else {
-                        for (long long y = 15; y >= 0; --y) {
-                            memcpy((char*)data + (y + 1) * width * 4 + 16 * 4, (char*)data + y * width * 4 + 15 * 4, width * 4 - 16 * 4);
-                        }
-                    }
-                    if (z >= 64) {
-                        for (long long y = height - 2; y >= 16; --y) {
-                            memcpy((char*)data + (y + 1) * width * 4 + 16 * 4, (char*)data + y * width * 4 + 15 * 4, width * 4 - 16 * 4);
-                            memcpy((char*)data + (y + 1) * width * 4, (char*)data + y * width * 4, 16 * 4);
-                        }
-                    } else {
-                        for (long long y = height - 2; y >= 16; --y) {
-                            memcpy((char*)data + (y + 1) * width * 4 + 4, (char*)data + y * width * 4 + 0, width * 4 - 4);
-                        }
-                    }
-                }
+          if (width == 512 && height == 512) {
+            size_t uscore = 0;
+            size_t itemscorea = 0, itemscoreb = 0, itemscorec = 0,
+                   itemscored = 0;
+            for (int y = 0; y < height; ++y) {
+              if (*((uint32_t *)data + y * width + 511 - 14) != 0) {
+                ++itemscorea;
+              }
+              if (*((uint32_t *)data + y * width + 511 - 13) != 0) {
+                ++itemscoreb;
+              }
+              if (*((uint32_t *)data + y * width + 511 - 12) != 0) {
+                ++itemscorec;
+              }
+              if (*((uint32_t *)data + y * width + 511 - 11) == 0) {
+                ++itemscored;
+              }
             }
-            ((void(*)(unsigned int target, int level, int xoffset, int yoffset, int width, int height, unsigned int format, unsigned int type, const void * data))(fake_egl::hostProcAddrFn("glTexSubImage2D"))) (target, level, xoffset, yoffset, width, height, format, type, data);
+            for (int x = 0; x < width; ++x) {
+              if (*((uint32_t *)data + 1 * width + x) != 0) {
+                ++uscore;
+              }
+            }
+            size_t z = 0;
+            for (long long y = 0; y < height; ++y) {
+              if (*((int32_t *)data + 511 - 20 + y * width) ==
+                      *((int32_t *)data + 511 - 19 + y * width) &&
+                  *((int32_t *)data + 511 - 19 + y * width) ==
+                      *((int32_t *)data + 511 - 18 + y * width) &&
+                  *((int32_t *)data + 511 - 18 + y * width) ==
+                      *((int32_t *)data + 511 - 17 + y * width) &&
+                  *((int32_t *)data + 511 - 17 + y * width) !=
+                      *((int32_t *)data + 511 - 16 + y * width)) {
+                z++;
+              }
+            }
+            if (z >= 64 || (itemscorea > 64 && itemscoreb > 64 &&
+                            itemscorec > 64 && itemscored > 64)) {
+              if (z >= 64 || uscore < 16) {
+                for (long long y = 0; y < 16; ++y) {
+                  memmove((char *)data + y * width * 4 + 16 * 4,
+                          (char *)data + y * width * 4 + 15 * 4,
+                          width * 4 - 16 * 4);
+                }
+              } else {
+                for (long long y = 15; y >= 0; --y) {
+                  memcpy((char *)data + (y + 1) * width * 4 + 16 * 4,
+                         (char *)data + y * width * 4 + 15 * 4,
+                         width * 4 - 16 * 4);
+                }
+              }
+              if (z >= 64) {
+                for (long long y = height - 2; y >= 16; --y) {
+                  memcpy((char *)data + (y + 1) * width * 4 + 16 * 4,
+                         (char *)data + y * width * 4 + 15 * 4,
+                         width * 4 - 16 * 4);
+                  memcpy((char *)data + (y + 1) * width * 4,
+                         (char *)data + y * width * 4, 16 * 4);
+                }
+              } else {
+                for (long long y = height - 2; y >= 16; --y) {
+                  memcpy((char *)data + (y + 1) * width * 4 + 4,
+                         (char *)data + y * width * 4 + 0, width * 4 - 4);
+                }
+              }
+            }
+          }
+          ((void (*)(unsigned int target, int level, int xoffset, int yoffset,
+                     int width, int height, unsigned int format,
+                     unsigned int type, const void *data))(
+              fake_egl::hostProcAddrFn("glTexSubImage2D")))(
+              target, level, xoffset, yoffset, width, height, format, type,
+              data);
         };
-    }
-    GLCorePatch::installGL(fake_egl::hostProcOverrides, fake_egl::eglGetProcAddress);
+  }
+  GLCorePatch::installGL(fake_egl::hostProcOverrides,
+                         fake_egl::eglGetProcAddress);
 }

--- a/src/fake_egl.cpp
+++ b/src/fake_egl.cpp
@@ -13,15 +13,13 @@
 #include "armhf_support.h"
 #endif
 
-namespace fake_egl
-{
+namespace fake_egl {
 
 static thread_local EGLSurface currentDrawSurface;
 static void *(*hostProcAddrFn)(const char *);
 static std::unordered_map<std::string, void *> hostProcOverrides;
 
-EGLBoolean eglInitialize(EGLDisplay display, EGLint *major, EGLint *minor)
-{
+EGLBoolean eglInitialize(EGLDisplay display, EGLint *major, EGLint *minor) {
     if (major)
         *major = 1;
     if (minor)
@@ -33,8 +31,7 @@ EGLBoolean eglTerminate(EGLDisplay display) { return EGL_TRUE; }
 
 EGLint eglGetError() { return EGL_SUCCESS; }
 
-char const *eglQueryString(EGLDisplay display, EGLint name)
-{
+char const *eglQueryString(EGLDisplay display, EGLint name) {
     if (name == EGL_VENDOR)
         return "mcpelauncher";
     if (name == EGL_VERSION)
@@ -52,22 +49,18 @@ EGLDisplay eglGetCurrentDisplay() { return (EGLDisplay *)1; }
 EGLContext eglGetCurrentContext() { return currentDrawSurface ? (EGLContext *)1 : (EGLContext *)0; }
 
 EGLBoolean eglChooseConfig(EGLDisplay display, EGLint const *attrib_list, EGLConfig *configs, EGLint config_size,
-                           EGLint *num_config)
-{
+                           EGLint *num_config) {
     *num_config = 1;
     return EGL_TRUE;
 }
 
-EGLBoolean eglGetConfigAttrib(EGLDisplay display, EGLConfig config, EGLint attribute, EGLint *value)
-{
-    if (attribute == EGL_NATIVE_VISUAL_ID)
-    {
+EGLBoolean eglGetConfigAttrib(EGLDisplay display, EGLConfig config, EGLint attribute, EGLint *value) {
+    if (attribute == EGL_NATIVE_VISUAL_ID) {
         *value = 0;
         return EGL_TRUE;
     }
     if (attribute == EGL_RED_SIZE || attribute == EGL_GREEN_SIZE || attribute == EGL_BLUE_SIZE ||
-        attribute == EGL_ALPHA_SIZE || attribute == EGL_DEPTH_SIZE || attribute == EGL_STENCIL_SIZE)
-    {
+        attribute == EGL_ALPHA_SIZE || attribute == EGL_DEPTH_SIZE || attribute == EGL_STENCIL_SIZE) {
         *value = 8;
         return EGL_TRUE;
     }
@@ -76,51 +69,41 @@ EGLBoolean eglGetConfigAttrib(EGLDisplay display, EGLConfig config, EGLint attri
 }
 
 EGLSurface eglCreateWindowSurface(EGLDisplay display, EGLConfig config, EGLNativeWindowType native_window,
-                                  EGLint const *attrib_list)
-{
+                                  EGLint const *attrib_list) {
     return native_window;
 }
 
 EGLBoolean eglDestroySurface(EGLDisplay display, EGLSurface surface) { return EGL_TRUE; }
 
-EGLContext eglCreateContext(EGLDisplay display, EGLConfig config, EGLContext share_context, EGLint const *attrib_list)
-{
+EGLContext eglCreateContext(EGLDisplay display, EGLConfig config, EGLContext share_context, EGLint const *attrib_list) {
     return (EGLContext *)1;
 }
 
 EGLBoolean eglDestroyContext(EGLDisplay display, EGLContext context) { return EGL_TRUE; }
 
-EGLBoolean eglMakeCurrent(EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context)
-{
-    if (draw != nullptr)
-    {
+EGLBoolean eglMakeCurrent(EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context) {
+    if (draw != nullptr) {
         ((GameWindow *)draw)->makeCurrent(true);
-    }
-    else
-    {
+    } else {
         ((GameWindow *)currentDrawSurface)->makeCurrent(false);
     }
     currentDrawSurface = draw;
     return EGL_TRUE;
 }
 
-EGLBoolean eglSwapBuffers(EGLDisplay display, EGLSurface surface)
-{
+EGLBoolean eglSwapBuffers(EGLDisplay display, EGLSurface surface) {
     //    Log::trace("FakeEGL", "eglSwapBuffers");
     ((GameWindow *)surface)->swapBuffers();
     return EGL_TRUE;
 }
 
-EGLBoolean eglSwapInterval(EGLDisplay display, EGLint interval)
-{
+EGLBoolean eglSwapInterval(EGLDisplay display, EGLint interval) {
     ((GameWindow *)currentDrawSurface)->setSwapInterval(interval);
     return EGL_TRUE;
 }
 
-EGLBoolean eglQuerySurface(EGLDisplay display, EGLSurface surface, EGLint attribute, EGLint *value)
-{
-    if (attribute == EGL_WIDTH || attribute == EGL_HEIGHT)
-    {
+EGLBoolean eglQuerySurface(EGLDisplay display, EGLSurface surface, EGLint attribute, EGLint *value) {
+    if (attribute == EGL_WIDTH || attribute == EGL_HEIGHT) {
         int w, h;
         ((GameWindow *)surface)->getWindowSize(w, h);
         *value = (attribute == EGL_WIDTH ? w : h);
@@ -130,8 +113,7 @@ EGLBoolean eglQuerySurface(EGLDisplay display, EGLSurface surface, EGLint attrib
     return EGL_TRUE;
 }
 
-void *eglGetProcAddress(const char *name)
-{
+void *eglGetProcAddress(const char *name) {
     auto it = hostProcOverrides.find(name);
     if (it != hostProcOverrides.end())
         return it->second;
@@ -144,8 +126,7 @@ bool FakeEGL::enableTexturePatch = false;
 
 void FakeEGL::setProcAddrFunction(void *(*fn)(const char *)) { fake_egl::hostProcAddrFn = fn; }
 
-void FakeEGL::installLibrary()
-{
+void FakeEGL::installLibrary() {
     std::unordered_map<std::string, void *> syms;
     syms["eglInitialize"] = (void *)fake_egl::eglInitialize;
     syms["eglTerminate"] = (void *)fake_egl::eglTerminate;
@@ -169,152 +150,118 @@ void FakeEGL::installLibrary()
     linker::load_library("libEGL.so", syms);
 }
 
-void FakeEGL::setupGLOverrides()
-{
+void FakeEGL::setupGLOverrides() {
 #ifdef USE_ARMHF_SUPPORT
     ArmhfSupport::install(fake_egl::hostProcOverrides);
 #endif
     fake_egl::hostProcOverrides["glInvalidateFramebuffer"] = (void *)+[]() {};  // Stub for a NVIDIA bug
-    if (FakeEGL::enableTexturePatch)
-    {
+    if (FakeEGL::enableTexturePatch) {
         // Minecraft Intel/Amd Texture Bug 1.16.210-1.17.2 and beyond
         // This patch reduces the visual glitch of blocks, does not work with high
         // resolution textures
         // TODO improve Bugdetection
         fake_egl::hostProcOverrides["glTexSubImage2D"] =
             (void *)+[](unsigned int target, int level, int xoffset, int yoffset, int width, int height,
-                        unsigned int format, unsigned int type, const void *data)
-        {
-            if (width == 1024 && height == 1024)
-            {
-                size_t z = 0;
-                for (long long y = 0; y < height; ++y)
-                {
-                    if (*((int32_t *)data + 987 + y * width) == *((int32_t *)data + 988 + y * width) &&
-                        *((int32_t *)data + 988 + y * width) == *((int32_t *)data + 989 + y * width) &&
-                        *((int32_t *)data + 989 + y * width) == *((int32_t *)data + 990 + y * width) &&
-                        *((int32_t *)data + 990 + y * width) != *((int32_t *)data + 991 + y * width))
-                    {
-                        z++;
+                        unsigned int format, unsigned int type, const void *data) {
+                if (width == 1024 && height == 1024) {
+                    size_t z = 0;
+                    for (long long y = 0; y < height; ++y) {
+                        if (*((int32_t *)data + 987 + y * width) == *((int32_t *)data + 988 + y * width) &&
+                            *((int32_t *)data + 988 + y * width) == *((int32_t *)data + 989 + y * width) &&
+                            *((int32_t *)data + 989 + y * width) == *((int32_t *)data + 990 + y * width) &&
+                            *((int32_t *)data + 990 + y * width) != *((int32_t *)data + 991 + y * width)) {
+                            z++;
+                        }
+                    }
+                    if (z >= 64) {
+                        for (long long y = 0; y < 32; ++y) {
+                            memmove((char *)data + y * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
+                                    width * 4 - 32 * 4);
+                        }
+                        for (long long y = height - 2; y >= 31; --y) {
+                            memcpy((char *)data + (y + 1) * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
+                                   width * 4 - 32 * 4);
+                            memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 32 * 4);
+                        }
                     }
                 }
-                if (z >= 64)
-                {
-                    for (long long y = 0; y < 32; ++y)
-                    {
-                        memmove((char *)data + y * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
-                                width * 4 - 32 * 4);
-                    }
-                    for (long long y = height - 2; y >= 31; --y)
-                    {
-                        memcpy((char *)data + (y + 1) * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
-                               width * 4 - 32 * 4);
-                        memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 32 * 4);
-                    }
-                }
-            }
-            if (width == 2048 && height == 1024)
-            {
-                if (*((int32_t *)data + 989 + 1024) == *((int32_t *)data + 990 + 1024) &&
-                    *((int32_t *)data + 990 + 1024) != *((int32_t *)data + 991 + 1024))
-                {
-                    for (long long y = 0; y < 32; ++y)
-                    {
-                        memmove((char *)data + y * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
-                                width * 4 - 32 * 4);
-                    }
-                    for (long long y = height - 2; y >= 31; --y)
-                    {
-                        memcpy((char *)data + (y + 1) * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
-                               width * 4 - 32 * 4);
-                        memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 32 * 4);
+                if (width == 2048 && height == 1024) {
+                    if (*((int32_t *)data + 989 + 1024) == *((int32_t *)data + 990 + 1024) &&
+                        *((int32_t *)data + 990 + 1024) != *((int32_t *)data + 991 + 1024)) {
+                        for (long long y = 0; y < 32; ++y) {
+                            memmove((char *)data + y * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
+                                    width * 4 - 32 * 4);
+                        }
+                        for (long long y = height - 2; y >= 31; --y) {
+                            memcpy((char *)data + (y + 1) * width * 4 + 32 * 4, (char *)data + y * width * 4 + 31 * 4,
+                                   width * 4 - 32 * 4);
+                            memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 32 * 4);
+                        }
                     }
                 }
-            }
 
-            if (width == 512 && height == 512)
-            {
-                size_t uscore = 0;
-                size_t itemscorea = 0, itemscoreb = 0, itemscorec = 0, itemscored = 0;
-                for (int y = 0; y < height; ++y)
-                {
-                    if (*((uint32_t *)data + y * width + 511 - 14) != 0)
-                    {
-                        ++itemscorea;
-                    }
-                    if (*((uint32_t *)data + y * width + 511 - 13) != 0)
-                    {
-                        ++itemscoreb;
-                    }
-                    if (*((uint32_t *)data + y * width + 511 - 12) != 0)
-                    {
-                        ++itemscorec;
-                    }
-                    if (*((uint32_t *)data + y * width + 511 - 11) == 0)
-                    {
-                        ++itemscored;
-                    }
-                }
-                for (int x = 0; x < width; ++x)
-                {
-                    if (*((uint32_t *)data + 1 * width + x) != 0)
-                    {
-                        ++uscore;
-                    }
-                }
-                size_t z = 0;
-                for (long long y = 0; y < height; ++y)
-                {
-                    if (*((int32_t *)data + 511 - 20 + y * width) == *((int32_t *)data + 511 - 19 + y * width) &&
-                        *((int32_t *)data + 511 - 19 + y * width) == *((int32_t *)data + 511 - 18 + y * width) &&
-                        *((int32_t *)data + 511 - 18 + y * width) == *((int32_t *)data + 511 - 17 + y * width) &&
-                        *((int32_t *)data + 511 - 17 + y * width) != *((int32_t *)data + 511 - 16 + y * width))
-                    {
-                        z++;
-                    }
-                }
-                if (z >= 64 || (itemscorea > 64 && itemscoreb > 64 && itemscorec > 64 && itemscored > 64))
-                {
-                    if (z >= 64 || uscore < 16)
-                    {
-                        for (long long y = 0; y < 16; ++y)
-                        {
-                            memmove((char *)data + y * width * 4 + 16 * 4, (char *)data + y * width * 4 + 15 * 4,
-                                    width * 4 - 16 * 4);
+                if (width == 512 && height == 512) {
+                    size_t uscore = 0;
+                    size_t itemscorea = 0, itemscoreb = 0, itemscorec = 0, itemscored = 0;
+                    for (int y = 0; y < height; ++y) {
+                        if (*((uint32_t *)data + y * width + 511 - 14) != 0) {
+                            ++itemscorea;
+                        }
+                        if (*((uint32_t *)data + y * width + 511 - 13) != 0) {
+                            ++itemscoreb;
+                        }
+                        if (*((uint32_t *)data + y * width + 511 - 12) != 0) {
+                            ++itemscorec;
+                        }
+                        if (*((uint32_t *)data + y * width + 511 - 11) == 0) {
+                            ++itemscored;
                         }
                     }
-                    else
-                    {
-                        for (long long y = 15; y >= 0; --y)
-                        {
-                            memcpy((char *)data + (y + 1) * width * 4 + 16 * 4, (char *)data + y * width * 4 + 15 * 4,
-                                   width * 4 - 16 * 4);
+                    for (int x = 0; x < width; ++x) {
+                        if (*((uint32_t *)data + 1 * width + x) != 0) {
+                            ++uscore;
                         }
                     }
-                    if (z >= 64)
-                    {
-                        for (long long y = height - 2; y >= 16; --y)
-                        {
-                            memcpy((char *)data + (y + 1) * width * 4 + 16 * 4, (char *)data + y * width * 4 + 15 * 4,
-                                   width * 4 - 16 * 4);
-                            memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 16 * 4);
+                    size_t z = 0;
+                    for (long long y = 0; y < height; ++y) {
+                        if (*((int32_t *)data + 511 - 20 + y * width) == *((int32_t *)data + 511 - 19 + y * width) &&
+                            *((int32_t *)data + 511 - 19 + y * width) == *((int32_t *)data + 511 - 18 + y * width) &&
+                            *((int32_t *)data + 511 - 18 + y * width) == *((int32_t *)data + 511 - 17 + y * width) &&
+                            *((int32_t *)data + 511 - 17 + y * width) != *((int32_t *)data + 511 - 16 + y * width)) {
+                            z++;
                         }
                     }
-                    else
-                    {
-                        for (long long y = height - 2; y >= 16; --y)
-                        {
-                            memcpy((char *)data + (y + 1) * width * 4 + 4, (char *)data + y * width * 4 + 0,
-                                   width * 4 - 4);
+                    if (z >= 64 || (itemscorea > 64 && itemscoreb > 64 && itemscorec > 64 && itemscored > 64)) {
+                        if (z >= 64 || uscore < 16) {
+                            for (long long y = 0; y < 16; ++y) {
+                                memmove((char *)data + y * width * 4 + 16 * 4, (char *)data + y * width * 4 + 15 * 4,
+                                        width * 4 - 16 * 4);
+                            }
+                        } else {
+                            for (long long y = 15; y >= 0; --y) {
+                                memcpy((char *)data + (y + 1) * width * 4 + 16 * 4,
+                                       (char *)data + y * width * 4 + 15 * 4, width * 4 - 16 * 4);
+                            }
+                        }
+                        if (z >= 64) {
+                            for (long long y = height - 2; y >= 16; --y) {
+                                memcpy((char *)data + (y + 1) * width * 4 + 16 * 4,
+                                       (char *)data + y * width * 4 + 15 * 4, width * 4 - 16 * 4);
+                                memcpy((char *)data + (y + 1) * width * 4, (char *)data + y * width * 4, 16 * 4);
+                            }
+                        } else {
+                            for (long long y = height - 2; y >= 16; --y) {
+                                memcpy((char *)data + (y + 1) * width * 4 + 4, (char *)data + y * width * 4 + 0,
+                                       width * 4 - 4);
+                            }
                         }
                     }
                 }
-            }
-            ((void (*)(unsigned int target, int level, int xoffset, int yoffset, int width, int height,
-                       unsigned int format, unsigned int type,
-                       const void *data))(fake_egl::hostProcAddrFn("glTexSubImage2D")))(
-                target, level, xoffset, yoffset, width, height, format, type, data);
-        };
+                ((void (*)(unsigned int target, int level, int xoffset, int yoffset, int width, int height,
+                           unsigned int format, unsigned int type,
+                           const void *data))(fake_egl::hostProcAddrFn("glTexSubImage2D")))(
+                    target, level, xoffset, yoffset, width, height, format, type, data);
+            };
     }
     GLCorePatch::installGL(fake_egl::hostProcOverrides, fake_egl::eglGetProcAddress);
 }

--- a/src/fake_egl.h
+++ b/src/fake_egl.h
@@ -1,18 +1,19 @@
 #pragma once
 
-namespace fake_egl {
+namespace fake_egl
+{
 
 void *eglGetProcAddress(const char *name);
 
 }
 
-struct FakeEGL {
+struct FakeEGL
+{
+    static void setProcAddrFunction(void *(*fn)(const char *));
 
-  static void setProcAddrFunction(void *(*fn)(const char *));
+    static void installLibrary();
 
-  static void installLibrary();
+    static void setupGLOverrides();
 
-  static void setupGLOverrides();
-
-  static bool enableTexturePatch;
+    static bool enableTexturePatch;
 };

--- a/src/fake_egl.h
+++ b/src/fake_egl.h
@@ -2,18 +2,17 @@
 
 namespace fake_egl {
 
-    void *eglGetProcAddress(const char *name);
+void *eglGetProcAddress(const char *name);
 
 }
 
 struct FakeEGL {
 
-    static void setProcAddrFunction(void *(*fn)(const char *));
+  static void setProcAddrFunction(void *(*fn)(const char *));
 
-    static void installLibrary();
+  static void installLibrary();
 
-    static void setupGLOverrides();
+  static void setupGLOverrides();
 
-    static bool enableTexturePatch;
-
+  static bool enableTexturePatch;
 };

--- a/src/fake_egl.h
+++ b/src/fake_egl.h
@@ -1,14 +1,12 @@
 #pragma once
 
-namespace fake_egl
-{
+namespace fake_egl {
 
 void *eglGetProcAddress(const char *name);
 
 }
 
-struct FakeEGL
-{
+struct FakeEGL {
     static void setProcAddrFunction(void *(*fn)(const char *));
 
     static void installLibrary();

--- a/src/fake_inputqueue.cpp
+++ b/src/fake_inputqueue.cpp
@@ -1,104 +1,85 @@
 #include "fake_inputqueue.h"
 
-#include "armhfrewrite.h"
 #include <stdexcept>
+#include "armhfrewrite.h"
 
-static float _AMotionEvent_getX(const AInputEvent *event, size_t pointerIndex) {
-  return ((const FakeMotionEvent *)(const void *)event)->x;
+static float _AMotionEvent_getX(const AInputEvent *event, size_t pointerIndex)
+{
+    return ((const FakeMotionEvent *)(const void *)event)->x;
 }
 
-static float _AMotionEvent_getY(const AInputEvent *event, size_t pointerIndex) {
-  return ((const FakeMotionEvent *)(const void *)event)->y;
+static float _AMotionEvent_getY(const AInputEvent *event, size_t pointerIndex)
+{
+    return ((const FakeMotionEvent *)(const void *)event)->y;
 }
 
-static float _AMotionEvent_getAxisValue(const AInputEvent *event, int32_t axis,
-                                        size_t pointerIndex) {
-  return ((const FakeMotionEvent *)(const void *)event)->axisFunction(axis);
+static float _AMotionEvent_getAxisValue(const AInputEvent *event, int32_t axis, size_t pointerIndex)
+{
+    return ((const FakeMotionEvent *)(const void *)event)->axisFunction(axis);
 }
 
-void FakeInputQueue::initHybrisHooks(
-    std::unordered_map<std::string, void *> &syms) {
-  syms["AInputQueue_getEvent"] =
-      (void *)+[](AInputQueue *queue, AInputEvent **outEvent) {
-        return ((FakeInputQueue *)(void *)queue)
-            ->getEvent((FakeInputEvent **)(void **)outEvent);
-      };
-  syms["AInputQueue_finishEvent"] =
-      (void *)+[](AInputQueue *queue, AInputEvent *event, int handled) {
-        ((FakeInputQueue *)(void *)queue)
-            ->finishEvent((FakeInputEvent *)(void *)event);
-      };
-  syms["AInputQueue_preDispatchEvent"] = (void *)+[]() { return 0; };
-  syms["AInputEvent_getSource"] = (void *)+[](const AInputEvent *event) {
-    return ((const FakeInputEvent *)(const void *)event)->source;
-  };
-  syms["AInputEvent_getType"] = (void *)+[](const AInputEvent *event) {
-    return ((const FakeInputEvent *)(const void *)event)->type;
-  };
-  syms["AInputEvent_getDeviceId"] = (void *)+[](const AInputEvent *event) {
-    return ((const FakeInputEvent *)(const void *)event)->deviceId;
-  };
-  syms["AKeyEvent_getAction"] = (void *)+[](const AInputEvent *event) {
-    return ((const FakeKeyEvent *)(const void *)event)->action;
-  };
-  syms["AKeyEvent_getKeyCode"] = (void *)+[](const AInputEvent *event) {
-    return ((const FakeKeyEvent *)(const void *)event)->keyCode;
-  };
-  syms["AKeyEvent_getRepeatCount"] =
-      (void *)+[](const AInputEvent *event) { return (int32_t)0; };
-  syms["AKeyEvent_getMetaState"] =
-      (void *)+[](const AInputEvent *event) { return (int32_t)0; };
-  syms["AMotionEvent_getAction"] = (void *)+[](const AInputEvent *event) {
-    return ((const FakeMotionEvent *)(const void *)event)->action;
-  };
-  syms["AMotionEvent_getPointerCount"] =
-      (void *)+[](const AInputEvent *event) { return 1; };
-  syms["AMotionEvent_getButtonState"] =
-      (void *)+[](const AInputEvent *event) { return 0; };
-  syms["AMotionEvent_getPointerId"] = (void *)+[](const AInputEvent *event) {
-    return ((const FakeMotionEvent *)(const void *)event)->pointerId;
-  };
-  syms["AMotionEvent_getX"] =
-      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getX));
-  syms["AMotionEvent_getY"] =
-      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getY));
-  syms["AMotionEvent_getRawX"] =
-      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getX));
-  syms["AMotionEvent_getRawY"] =
-      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getY));
-  syms["AMotionEvent_getAxisValue"] =
-      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getAxisValue));
+void FakeInputQueue::initHybrisHooks(std::unordered_map<std::string, void *> &syms)
+{
+    syms["AInputQueue_getEvent"] = (void *)+[](AInputQueue *queue, AInputEvent **outEvent)
+    { return ((FakeInputQueue *)(void *)queue)->getEvent((FakeInputEvent **)(void **)outEvent); };
+    syms["AInputQueue_finishEvent"] = (void *)+[](AInputQueue *queue, AInputEvent *event, int handled)
+    { ((FakeInputQueue *)(void *)queue)->finishEvent((FakeInputEvent *)(void *)event); };
+    syms["AInputQueue_preDispatchEvent"] = (void *)+[]() { return 0; };
+    syms["AInputEvent_getSource"] =
+        (void *)+[](const AInputEvent *event) { return ((const FakeInputEvent *)(const void *)event)->source; };
+    syms["AInputEvent_getType"] =
+        (void *)+[](const AInputEvent *event) { return ((const FakeInputEvent *)(const void *)event)->type; };
+    syms["AInputEvent_getDeviceId"] =
+        (void *)+[](const AInputEvent *event) { return ((const FakeInputEvent *)(const void *)event)->deviceId; };
+    syms["AKeyEvent_getAction"] =
+        (void *)+[](const AInputEvent *event) { return ((const FakeKeyEvent *)(const void *)event)->action; };
+    syms["AKeyEvent_getKeyCode"] =
+        (void *)+[](const AInputEvent *event) { return ((const FakeKeyEvent *)(const void *)event)->keyCode; };
+    syms["AKeyEvent_getRepeatCount"] = (void *)+[](const AInputEvent *event) { return (int32_t)0; };
+    syms["AKeyEvent_getMetaState"] = (void *)+[](const AInputEvent *event) { return (int32_t)0; };
+    syms["AMotionEvent_getAction"] =
+        (void *)+[](const AInputEvent *event) { return ((const FakeMotionEvent *)(const void *)event)->action; };
+    syms["AMotionEvent_getPointerCount"] = (void *)+[](const AInputEvent *event) { return 1; };
+    syms["AMotionEvent_getButtonState"] = (void *)+[](const AInputEvent *event) { return 0; };
+    syms["AMotionEvent_getPointerId"] =
+        (void *)+[](const AInputEvent *event) { return ((const FakeMotionEvent *)(const void *)event)->pointerId; };
+    syms["AMotionEvent_getX"] = reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getX));
+    syms["AMotionEvent_getY"] = reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getY));
+    syms["AMotionEvent_getRawX"] = reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getX));
+    syms["AMotionEvent_getRawY"] = reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getY));
+    syms["AMotionEvent_getAxisValue"] = reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getAxisValue));
 }
 
-int FakeInputQueue::getEvent(FakeInputEvent **event) {
-  if (!keyEvents.empty()) {
-    *event = &keyEvents.front();
-    return 0;
-  }
-  if (!motionEvents.empty()) {
-    *event = &motionEvents.front();
-    return 0;
-  }
-  return -1;
+int FakeInputQueue::getEvent(FakeInputEvent **event)
+{
+    if (!keyEvents.empty())
+    {
+        *event = &keyEvents.front();
+        return 0;
+    }
+    if (!motionEvents.empty())
+    {
+        *event = &motionEvents.front();
+        return 0;
+    }
+    return -1;
 }
 
-void FakeInputQueue::finishEvent(FakeInputEvent *event) {
-  if (!keyEvents.empty() && &keyEvents.front() == event) {
-    keyEvents.pop_front();
-    return;
-  }
-  if (!motionEvents.empty() && &motionEvents.front() == event) {
-    motionEvents.pop_front();
-    return;
-  }
-  throw std::runtime_error(
-      "finishEvent: the event is not the event on the front of queue");
+void FakeInputQueue::finishEvent(FakeInputEvent *event)
+{
+    if (!keyEvents.empty() && &keyEvents.front() == event)
+    {
+        keyEvents.pop_front();
+        return;
+    }
+    if (!motionEvents.empty() && &motionEvents.front() == event)
+    {
+        motionEvents.pop_front();
+        return;
+    }
+    throw std::runtime_error("finishEvent: the event is not the event on the front of queue");
 }
 
-void FakeInputQueue::addEvent(FakeKeyEvent event) {
-  keyEvents.push_back(event);
-}
+void FakeInputQueue::addEvent(FakeKeyEvent event) { keyEvents.push_back(event); }
 
-void FakeInputQueue::addEvent(FakeMotionEvent event) {
-  motionEvents.push_back(std::move(event));
-}
+void FakeInputQueue::addEvent(FakeMotionEvent event) { motionEvents.push_back(std::move(event)); }

--- a/src/fake_inputqueue.cpp
+++ b/src/fake_inputqueue.cpp
@@ -1,99 +1,104 @@
 #include "fake_inputqueue.h"
 
-#include <stdexcept>
 #include "armhfrewrite.h"
+#include <stdexcept>
 
 static float _AMotionEvent_getX(const AInputEvent *event, size_t pointerIndex) {
-    return ((const FakeMotionEvent *) (const void *) event)->x;
+  return ((const FakeMotionEvent *)(const void *)event)->x;
 }
 
 static float _AMotionEvent_getY(const AInputEvent *event, size_t pointerIndex) {
-    return ((const FakeMotionEvent *) (const void *) event)->y;
+  return ((const FakeMotionEvent *)(const void *)event)->y;
 }
 
-static float _AMotionEvent_getAxisValue(const AInputEvent *event, int32_t axis, size_t pointerIndex) {
-    return ((const FakeMotionEvent *) (const void *) event)->axisFunction(axis);
+static float _AMotionEvent_getAxisValue(const AInputEvent *event, int32_t axis,
+                                        size_t pointerIndex) {
+  return ((const FakeMotionEvent *)(const void *)event)->axisFunction(axis);
 }
 
-void FakeInputQueue::initHybrisHooks(std::unordered_map<std::string, void*> &syms) {
-    syms["AInputQueue_getEvent"] = (void *) +[](AInputQueue *queue, AInputEvent **outEvent) {
-        return ((FakeInputQueue *) (void *) queue)->getEvent((FakeInputEvent **) (void **) outEvent);
-    };
-    syms["AInputQueue_finishEvent"] = (void *) +[](AInputQueue *queue, AInputEvent *event, int handled) {
-        ((FakeInputQueue *) (void *) queue)->finishEvent((FakeInputEvent *) (void *) event);
-    };
-    syms["AInputQueue_preDispatchEvent"] = (void *) +[]() {
-        return 0;
-    };
-    syms["AInputEvent_getSource"] = (void *) +[](const AInputEvent *event) {
-        return ((const FakeInputEvent *) (const void *) event)->source;
-    };
-    syms["AInputEvent_getType"] = (void *) +[](const AInputEvent *event) {
-        return ((const FakeInputEvent *) (const void *) event)->type;
-    };
-    syms["AInputEvent_getDeviceId"] = (void *) +[](const AInputEvent *event) {
-        return ((const FakeInputEvent *) (const void *) event)->deviceId;
-    };
-    syms["AKeyEvent_getAction"] = (void *) +[](const AInputEvent *event) {
-        return ((const FakeKeyEvent *) (const void *) event)->action;
-    };
-    syms["AKeyEvent_getKeyCode"] = (void *) +[](const AInputEvent *event) {
-        return ((const FakeKeyEvent *) (const void *) event)->keyCode;
-    };
-    syms["AKeyEvent_getRepeatCount"] = (void *) +[](const AInputEvent *event) {
-        return (int32_t) 0;
-    };
-    syms["AKeyEvent_getMetaState"] = (void *) +[](const AInputEvent *event) {
-        return (int32_t) 0;
-    };
-    syms["AMotionEvent_getAction"] = (void *) +[](const AInputEvent *event) {
-        return ((const FakeMotionEvent *) (const void *) event)->action;
-    };
-    syms["AMotionEvent_getPointerCount"] = (void *) +[](const AInputEvent *event) {
-        return 1;
-    };
-    syms["AMotionEvent_getButtonState"] = (void *) +[](const AInputEvent *event) {
-        return 0;
-    };
-    syms["AMotionEvent_getPointerId"] = (void *) +[](const AInputEvent *event) {
-        return ((const FakeMotionEvent *) (const void *) event)->pointerId;
-    };
-    syms["AMotionEvent_getX"] = reinterpret_cast<void*>(ARMHFREWRITE(_AMotionEvent_getX));
-    syms["AMotionEvent_getY"] = reinterpret_cast<void*>(ARMHFREWRITE(_AMotionEvent_getY));
-    syms["AMotionEvent_getRawX"] = reinterpret_cast<void*>(ARMHFREWRITE(_AMotionEvent_getX));
-    syms["AMotionEvent_getRawY"] = reinterpret_cast<void*>(ARMHFREWRITE(_AMotionEvent_getY));
-    syms["AMotionEvent_getAxisValue"] = reinterpret_cast<void*>(ARMHFREWRITE(_AMotionEvent_getAxisValue));
+void FakeInputQueue::initHybrisHooks(
+    std::unordered_map<std::string, void *> &syms) {
+  syms["AInputQueue_getEvent"] =
+      (void *)+[](AInputQueue *queue, AInputEvent **outEvent) {
+        return ((FakeInputQueue *)(void *)queue)
+            ->getEvent((FakeInputEvent **)(void **)outEvent);
+      };
+  syms["AInputQueue_finishEvent"] =
+      (void *)+[](AInputQueue *queue, AInputEvent *event, int handled) {
+        ((FakeInputQueue *)(void *)queue)
+            ->finishEvent((FakeInputEvent *)(void *)event);
+      };
+  syms["AInputQueue_preDispatchEvent"] = (void *)+[]() { return 0; };
+  syms["AInputEvent_getSource"] = (void *)+[](const AInputEvent *event) {
+    return ((const FakeInputEvent *)(const void *)event)->source;
+  };
+  syms["AInputEvent_getType"] = (void *)+[](const AInputEvent *event) {
+    return ((const FakeInputEvent *)(const void *)event)->type;
+  };
+  syms["AInputEvent_getDeviceId"] = (void *)+[](const AInputEvent *event) {
+    return ((const FakeInputEvent *)(const void *)event)->deviceId;
+  };
+  syms["AKeyEvent_getAction"] = (void *)+[](const AInputEvent *event) {
+    return ((const FakeKeyEvent *)(const void *)event)->action;
+  };
+  syms["AKeyEvent_getKeyCode"] = (void *)+[](const AInputEvent *event) {
+    return ((const FakeKeyEvent *)(const void *)event)->keyCode;
+  };
+  syms["AKeyEvent_getRepeatCount"] =
+      (void *)+[](const AInputEvent *event) { return (int32_t)0; };
+  syms["AKeyEvent_getMetaState"] =
+      (void *)+[](const AInputEvent *event) { return (int32_t)0; };
+  syms["AMotionEvent_getAction"] = (void *)+[](const AInputEvent *event) {
+    return ((const FakeMotionEvent *)(const void *)event)->action;
+  };
+  syms["AMotionEvent_getPointerCount"] =
+      (void *)+[](const AInputEvent *event) { return 1; };
+  syms["AMotionEvent_getButtonState"] =
+      (void *)+[](const AInputEvent *event) { return 0; };
+  syms["AMotionEvent_getPointerId"] = (void *)+[](const AInputEvent *event) {
+    return ((const FakeMotionEvent *)(const void *)event)->pointerId;
+  };
+  syms["AMotionEvent_getX"] =
+      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getX));
+  syms["AMotionEvent_getY"] =
+      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getY));
+  syms["AMotionEvent_getRawX"] =
+      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getX));
+  syms["AMotionEvent_getRawY"] =
+      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getY));
+  syms["AMotionEvent_getAxisValue"] =
+      reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getAxisValue));
 }
-
 
 int FakeInputQueue::getEvent(FakeInputEvent **event) {
-    if (!keyEvents.empty()) {
-        *event = &keyEvents.front();
-        return 0;
-    }
-    if (!motionEvents.empty()) {
-        *event = &motionEvents.front();
-        return 0;
-    }
-    return -1;
+  if (!keyEvents.empty()) {
+    *event = &keyEvents.front();
+    return 0;
+  }
+  if (!motionEvents.empty()) {
+    *event = &motionEvents.front();
+    return 0;
+  }
+  return -1;
 }
 
 void FakeInputQueue::finishEvent(FakeInputEvent *event) {
-    if (!keyEvents.empty() && &keyEvents.front() == event) {
-        keyEvents.pop_front();
-        return;
-    }
-    if (!motionEvents.empty() && &motionEvents.front() == event) {
-        motionEvents.pop_front();
-        return;
-    }
-    throw std::runtime_error("finishEvent: the event is not the event on the front of queue");
+  if (!keyEvents.empty() && &keyEvents.front() == event) {
+    keyEvents.pop_front();
+    return;
+  }
+  if (!motionEvents.empty() && &motionEvents.front() == event) {
+    motionEvents.pop_front();
+    return;
+  }
+  throw std::runtime_error(
+      "finishEvent: the event is not the event on the front of queue");
 }
 
 void FakeInputQueue::addEvent(FakeKeyEvent event) {
-    keyEvents.push_back(event);
+  keyEvents.push_back(event);
 }
 
 void FakeInputQueue::addEvent(FakeMotionEvent event) {
-    motionEvents.push_back(std::move(event));
+  motionEvents.push_back(std::move(event));
 }

--- a/src/fake_inputqueue.cpp
+++ b/src/fake_inputqueue.cpp
@@ -3,27 +3,25 @@
 #include <stdexcept>
 #include "armhfrewrite.h"
 
-static float _AMotionEvent_getX(const AInputEvent *event, size_t pointerIndex)
-{
+static float _AMotionEvent_getX(const AInputEvent *event, size_t pointerIndex) {
     return ((const FakeMotionEvent *)(const void *)event)->x;
 }
 
-static float _AMotionEvent_getY(const AInputEvent *event, size_t pointerIndex)
-{
+static float _AMotionEvent_getY(const AInputEvent *event, size_t pointerIndex) {
     return ((const FakeMotionEvent *)(const void *)event)->y;
 }
 
-static float _AMotionEvent_getAxisValue(const AInputEvent *event, int32_t axis, size_t pointerIndex)
-{
+static float _AMotionEvent_getAxisValue(const AInputEvent *event, int32_t axis, size_t pointerIndex) {
     return ((const FakeMotionEvent *)(const void *)event)->axisFunction(axis);
 }
 
-void FakeInputQueue::initHybrisHooks(std::unordered_map<std::string, void *> &syms)
-{
-    syms["AInputQueue_getEvent"] = (void *)+[](AInputQueue *queue, AInputEvent **outEvent)
-    { return ((FakeInputQueue *)(void *)queue)->getEvent((FakeInputEvent **)(void **)outEvent); };
-    syms["AInputQueue_finishEvent"] = (void *)+[](AInputQueue *queue, AInputEvent *event, int handled)
-    { ((FakeInputQueue *)(void *)queue)->finishEvent((FakeInputEvent *)(void *)event); };
+void FakeInputQueue::initHybrisHooks(std::unordered_map<std::string, void *> &syms) {
+    syms["AInputQueue_getEvent"] = (void *)+[](AInputQueue *queue, AInputEvent **outEvent) {
+        return ((FakeInputQueue *)(void *)queue)->getEvent((FakeInputEvent **)(void **)outEvent);
+    };
+    syms["AInputQueue_finishEvent"] = (void *)+[](AInputQueue *queue, AInputEvent *event, int handled) {
+        ((FakeInputQueue *)(void *)queue)->finishEvent((FakeInputEvent *)(void *)event);
+    };
     syms["AInputQueue_preDispatchEvent"] = (void *)+[]() { return 0; };
     syms["AInputEvent_getSource"] =
         (void *)+[](const AInputEvent *event) { return ((const FakeInputEvent *)(const void *)event)->source; };
@@ -50,30 +48,24 @@ void FakeInputQueue::initHybrisHooks(std::unordered_map<std::string, void *> &sy
     syms["AMotionEvent_getAxisValue"] = reinterpret_cast<void *>(ARMHFREWRITE(_AMotionEvent_getAxisValue));
 }
 
-int FakeInputQueue::getEvent(FakeInputEvent **event)
-{
-    if (!keyEvents.empty())
-    {
+int FakeInputQueue::getEvent(FakeInputEvent **event) {
+    if (!keyEvents.empty()) {
         *event = &keyEvents.front();
         return 0;
     }
-    if (!motionEvents.empty())
-    {
+    if (!motionEvents.empty()) {
         *event = &motionEvents.front();
         return 0;
     }
     return -1;
 }
 
-void FakeInputQueue::finishEvent(FakeInputEvent *event)
-{
-    if (!keyEvents.empty() && &keyEvents.front() == event)
-    {
+void FakeInputQueue::finishEvent(FakeInputEvent *event) {
+    if (!keyEvents.empty() && &keyEvents.front() == event) {
         keyEvents.pop_front();
         return;
     }
-    if (!motionEvents.empty() && &motionEvents.front() == event)
-    {
+    if (!motionEvents.empty() && &motionEvents.front() == event) {
         motionEvents.pop_front();
         return;
     }

--- a/src/fake_inputqueue.h
+++ b/src/fake_inputqueue.h
@@ -6,32 +6,24 @@
 #include <string>
 #include <unordered_map>
 
-struct FakeInputEvent
-{
+struct FakeInputEvent {
     int32_t source, type;
     int32_t deviceId = 0;
 
-    FakeInputEvent(int32_t source, int32_t type, int32_t deviceId = 0) : source(source), type(type), deviceId(deviceId)
-    {
-    }
+    FakeInputEvent(int32_t source, int32_t type, int32_t deviceId = 0)
+        : source(source), type(type), deviceId(deviceId) {}
 };
 
-struct FakeKeyEvent : FakeInputEvent
-{
+struct FakeKeyEvent : FakeInputEvent {
     int32_t action, keyCode;
 
     FakeKeyEvent(int32_t action, int32_t keyCode)
-        : FakeInputEvent(AINPUT_SOURCE_KEYBOARD, AINPUT_EVENT_TYPE_KEY), action(action), keyCode(keyCode)
-    {
-    }
+        : FakeInputEvent(AINPUT_SOURCE_KEYBOARD, AINPUT_EVENT_TYPE_KEY), action(action), keyCode(keyCode) {}
     FakeKeyEvent(int32_t source, int32_t deviceId, int32_t action, int32_t keyCode)
-        : FakeInputEvent(source, AINPUT_EVENT_TYPE_KEY, deviceId), action(action), keyCode(keyCode)
-    {
-    }
+        : FakeInputEvent(source, AINPUT_EVENT_TYPE_KEY, deviceId), action(action), keyCode(keyCode) {}
 };
 
-struct FakeMotionEvent : FakeInputEvent
-{
+struct FakeMotionEvent : FakeInputEvent {
     int32_t action;
     int32_t pointerId;
     float x, y;
@@ -42,9 +34,7 @@ struct FakeMotionEvent : FakeInputEvent
           action(action),
           pointerId(pointerId),
           x(x),
-          y(y)
-    {
-    }
+          y(y) {}
     FakeMotionEvent(int32_t source, int32_t deviceId, int32_t action, int32_t pointerId, float x, float y,
                     std::function<float(int32_t axis)> axisFunction)
         : FakeInputEvent(source, AINPUT_EVENT_TYPE_MOTION, deviceId),
@@ -52,13 +42,10 @@ struct FakeMotionEvent : FakeInputEvent
           pointerId(pointerId),
           x(x),
           y(y),
-          axisFunction(std::move(axisFunction))
-    {
-    }
+          axisFunction(std::move(axisFunction)) {}
 };
 
-class FakeInputQueue
-{
+class FakeInputQueue {
    private:
     std::deque<FakeKeyEvent> keyEvents;
     std::deque<FakeMotionEvent> motionEvents;

--- a/src/fake_inputqueue.h
+++ b/src/fake_inputqueue.h
@@ -7,47 +7,58 @@
 #include <unordered_map>
 
 struct FakeInputEvent {
-    int32_t source, type;
-    int32_t deviceId = 0;
+  int32_t source, type;
+  int32_t deviceId = 0;
 
-    FakeInputEvent(int32_t source, int32_t type, int32_t deviceId = 0) : source(source), type(type), deviceId(deviceId) {}
+  FakeInputEvent(int32_t source, int32_t type, int32_t deviceId = 0)
+      : source(source), type(type), deviceId(deviceId) {}
 };
 
 struct FakeKeyEvent : FakeInputEvent {
-    int32_t action, keyCode;
+  int32_t action, keyCode;
 
-    FakeKeyEvent(int32_t action, int32_t keyCode) : FakeInputEvent(AINPUT_SOURCE_KEYBOARD, AINPUT_EVENT_TYPE_KEY), action(action), keyCode(keyCode) {}
-    FakeKeyEvent(int32_t source, int32_t deviceId, int32_t action, int32_t keyCode) : FakeInputEvent(source, AINPUT_EVENT_TYPE_KEY, deviceId), action(action), keyCode(keyCode) {}
+  FakeKeyEvent(int32_t action, int32_t keyCode)
+      : FakeInputEvent(AINPUT_SOURCE_KEYBOARD, AINPUT_EVENT_TYPE_KEY),
+        action(action), keyCode(keyCode) {}
+  FakeKeyEvent(int32_t source, int32_t deviceId, int32_t action,
+               int32_t keyCode)
+      : FakeInputEvent(source, AINPUT_EVENT_TYPE_KEY, deviceId), action(action),
+        keyCode(keyCode) {}
 };
 
 struct FakeMotionEvent : FakeInputEvent {
-    int32_t action;
-    int32_t pointerId;
-    float x, y;
-    std::function<float (int32_t axis)> axisFunction;
+  int32_t action;
+  int32_t pointerId;
+  float x, y;
+  std::function<float(int32_t axis)> axisFunction;
 
-    FakeMotionEvent(int32_t action, int32_t pointerId, float x, float y) : FakeInputEvent(AINPUT_SOURCE_TOUCHSCREEN, AINPUT_EVENT_TYPE_MOTION), action(action), pointerId(pointerId), x(x), y(y) {}
-    FakeMotionEvent(int32_t source, int32_t deviceId, int32_t action, int32_t pointerId, float x, float y, std::function<float (int32_t axis)> axisFunction) : FakeInputEvent(source, AINPUT_EVENT_TYPE_MOTION, deviceId), action(action), pointerId(pointerId), x(x), y(y), axisFunction(std::move(axisFunction)) {}
+  FakeMotionEvent(int32_t action, int32_t pointerId, float x, float y)
+      : FakeInputEvent(AINPUT_SOURCE_TOUCHSCREEN, AINPUT_EVENT_TYPE_MOTION),
+        action(action), pointerId(pointerId), x(x), y(y) {}
+  FakeMotionEvent(int32_t source, int32_t deviceId, int32_t action,
+                  int32_t pointerId, float x, float y,
+                  std::function<float(int32_t axis)> axisFunction)
+      : FakeInputEvent(source, AINPUT_EVENT_TYPE_MOTION, deviceId),
+        action(action), pointerId(pointerId), x(x), y(y),
+        axisFunction(std::move(axisFunction)) {}
 };
 
 class FakeInputQueue {
 
 private:
-    std::deque<FakeKeyEvent> keyEvents;
-    std::deque<FakeMotionEvent> motionEvents;
+  std::deque<FakeKeyEvent> keyEvents;
+  std::deque<FakeMotionEvent> motionEvents;
 
 public:
-    static void initHybrisHooks(std::unordered_map<std::string, void*> &syms);
+  static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 
-    bool hasEvents() const { return !keyEvents.empty() || !motionEvents.empty(); }
+  bool hasEvents() const { return !keyEvents.empty() || !motionEvents.empty(); }
 
-    int getEvent(FakeInputEvent **event);
+  int getEvent(FakeInputEvent **event);
 
-    void finishEvent(FakeInputEvent *event);
+  void finishEvent(FakeInputEvent *event);
 
+  void addEvent(FakeKeyEvent event);
 
-    void addEvent(FakeKeyEvent event);
-
-    void addEvent(FakeMotionEvent event);
-
+  void addEvent(FakeMotionEvent event);
 };

--- a/src/fake_inputqueue.h
+++ b/src/fake_inputqueue.h
@@ -6,59 +6,73 @@
 #include <string>
 #include <unordered_map>
 
-struct FakeInputEvent {
-  int32_t source, type;
-  int32_t deviceId = 0;
+struct FakeInputEvent
+{
+    int32_t source, type;
+    int32_t deviceId = 0;
 
-  FakeInputEvent(int32_t source, int32_t type, int32_t deviceId = 0)
-      : source(source), type(type), deviceId(deviceId) {}
+    FakeInputEvent(int32_t source, int32_t type, int32_t deviceId = 0) : source(source), type(type), deviceId(deviceId)
+    {
+    }
 };
 
-struct FakeKeyEvent : FakeInputEvent {
-  int32_t action, keyCode;
+struct FakeKeyEvent : FakeInputEvent
+{
+    int32_t action, keyCode;
 
-  FakeKeyEvent(int32_t action, int32_t keyCode)
-      : FakeInputEvent(AINPUT_SOURCE_KEYBOARD, AINPUT_EVENT_TYPE_KEY),
-        action(action), keyCode(keyCode) {}
-  FakeKeyEvent(int32_t source, int32_t deviceId, int32_t action,
-               int32_t keyCode)
-      : FakeInputEvent(source, AINPUT_EVENT_TYPE_KEY, deviceId), action(action),
-        keyCode(keyCode) {}
+    FakeKeyEvent(int32_t action, int32_t keyCode)
+        : FakeInputEvent(AINPUT_SOURCE_KEYBOARD, AINPUT_EVENT_TYPE_KEY), action(action), keyCode(keyCode)
+    {
+    }
+    FakeKeyEvent(int32_t source, int32_t deviceId, int32_t action, int32_t keyCode)
+        : FakeInputEvent(source, AINPUT_EVENT_TYPE_KEY, deviceId), action(action), keyCode(keyCode)
+    {
+    }
 };
 
-struct FakeMotionEvent : FakeInputEvent {
-  int32_t action;
-  int32_t pointerId;
-  float x, y;
-  std::function<float(int32_t axis)> axisFunction;
+struct FakeMotionEvent : FakeInputEvent
+{
+    int32_t action;
+    int32_t pointerId;
+    float x, y;
+    std::function<float(int32_t axis)> axisFunction;
 
-  FakeMotionEvent(int32_t action, int32_t pointerId, float x, float y)
-      : FakeInputEvent(AINPUT_SOURCE_TOUCHSCREEN, AINPUT_EVENT_TYPE_MOTION),
-        action(action), pointerId(pointerId), x(x), y(y) {}
-  FakeMotionEvent(int32_t source, int32_t deviceId, int32_t action,
-                  int32_t pointerId, float x, float y,
-                  std::function<float(int32_t axis)> axisFunction)
-      : FakeInputEvent(source, AINPUT_EVENT_TYPE_MOTION, deviceId),
-        action(action), pointerId(pointerId), x(x), y(y),
-        axisFunction(std::move(axisFunction)) {}
+    FakeMotionEvent(int32_t action, int32_t pointerId, float x, float y)
+        : FakeInputEvent(AINPUT_SOURCE_TOUCHSCREEN, AINPUT_EVENT_TYPE_MOTION),
+          action(action),
+          pointerId(pointerId),
+          x(x),
+          y(y)
+    {
+    }
+    FakeMotionEvent(int32_t source, int32_t deviceId, int32_t action, int32_t pointerId, float x, float y,
+                    std::function<float(int32_t axis)> axisFunction)
+        : FakeInputEvent(source, AINPUT_EVENT_TYPE_MOTION, deviceId),
+          action(action),
+          pointerId(pointerId),
+          x(x),
+          y(y),
+          axisFunction(std::move(axisFunction))
+    {
+    }
 };
 
-class FakeInputQueue {
+class FakeInputQueue
+{
+   private:
+    std::deque<FakeKeyEvent> keyEvents;
+    std::deque<FakeMotionEvent> motionEvents;
 
-private:
-  std::deque<FakeKeyEvent> keyEvents;
-  std::deque<FakeMotionEvent> motionEvents;
+   public:
+    static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 
-public:
-  static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
+    bool hasEvents() const { return !keyEvents.empty() || !motionEvents.empty(); }
 
-  bool hasEvents() const { return !keyEvents.empty() || !motionEvents.empty(); }
+    int getEvent(FakeInputEvent **event);
 
-  int getEvent(FakeInputEvent **event);
+    void finishEvent(FakeInputEvent *event);
 
-  void finishEvent(FakeInputEvent *event);
+    void addEvent(FakeKeyEvent event);
 
-  void addEvent(FakeKeyEvent event);
-
-  void addEvent(FakeMotionEvent event);
+    void addEvent(FakeMotionEvent event);
 };

--- a/src/fake_looper.cpp
+++ b/src/fake_looper.cpp
@@ -17,114 +17,110 @@
 JniSupport *FakeLooper::jniSupport;
 thread_local std::unique_ptr<FakeLooper> FakeLooper::currentLooper;
 
-void FakeLooper::initHybrisHooks(
-    std::unordered_map<std::string, void *> &syms) {
-  Log::info("Launcher", "Loading gamepad mappings");
-  WindowCallbacks::loadGamepadMappings();
+void FakeLooper::initHybrisHooks(std::unordered_map<std::string, void *> &syms)
+{
+    Log::info("Launcher", "Loading gamepad mappings");
+    WindowCallbacks::loadGamepadMappings();
 #ifdef MCPELAUNCHER_ENABLE_ERROR_WINDOW
-  GameWindowManager::getManager()->setErrorHandler(
-      std::make_shared<ErrorWindow>());
+    GameWindowManager::getManager()->setErrorHandler(std::make_shared<ErrorWindow>());
 #endif
 
-  Log::info("Launcher", "Creating window");
-  static auto associatedWindow = GameWindowManager::getManager()->createWindow(
-      "Minecraft", options.windowWidth, options.windowHeight,
-      options.graphicsApi);
-  syms["ALooper_prepare"] = (void *)+[]() {
-    if (currentLooper)
-      throw std::runtime_error("Looper already prepared");
-    currentLooper = std::make_unique<FakeLooper>();
-    currentLooper->associatedWindow = associatedWindow;
-    associatedWindow->makeCurrent(false);
-    currentLooper->prepare();
-    return (ALooper *)(void *)currentLooper.get();
-  };
-  syms["ALooper_addFd"] =
-      (void *)+[](ALooper *looper, int fd, int ident, int events,
-                  ALooper_callbackFunc callback, void *data) {
-        return ((FakeLooper *)(void *)looper)
-            ->addFd(fd, ident, events, callback, data);
-      };
-  syms["ALooper_pollAll"] = (void *)+[](int timeoutMillis, int *outFd,
-                                        int *outEvents, void **outData) {
-    return currentLooper->pollAll(timeoutMillis, outFd, outEvents, outData);
-  };
-  syms["AInputQueue_attachLooper"] =
-      (void *)+[](AInputQueue *queue, ALooper *looper, int ident,
-                  ALooper_callbackFunc callback, void *data) {
-        ((FakeLooper *)(void *)looper)->attachInputQueue(ident, callback, data);
-      };
+    Log::info("Launcher", "Creating window");
+    static auto associatedWindow = GameWindowManager::getManager()->createWindow(
+        "Minecraft", options.windowWidth, options.windowHeight, options.graphicsApi);
+    syms["ALooper_prepare"] = (void *)+[]()
+    {
+        if (currentLooper)
+            throw std::runtime_error("Looper already prepared");
+        currentLooper = std::make_unique<FakeLooper>();
+        currentLooper->associatedWindow = associatedWindow;
+        associatedWindow->makeCurrent(false);
+        currentLooper->prepare();
+        return (ALooper *)(void *)currentLooper.get();
+    };
+    syms["ALooper_addFd"] =
+        (void *)+[](ALooper *looper, int fd, int ident, int events, ALooper_callbackFunc callback, void *data)
+    { return ((FakeLooper *)(void *)looper)->addFd(fd, ident, events, callback, data); };
+    syms["ALooper_pollAll"] = (void *)+[](int timeoutMillis, int *outFd, int *outEvents, void **outData)
+    { return currentLooper->pollAll(timeoutMillis, outFd, outEvents, outData); };
+    syms["AInputQueue_attachLooper"] =
+        (void *)+[](AInputQueue *queue, ALooper *looper, int ident, ALooper_callbackFunc callback, void *data)
+    { ((FakeLooper *)(void *)looper)->attachInputQueue(ident, callback, data); };
 
-  syms["ANativeActivity_finish"] = (void *)+[](ANativeActivity *native) {
-    FakeJni::JniEnvContext ctx(*(FakeJni::Jvm *)native->vm);
-    auto activity = std::dynamic_pointer_cast<MainActivity>(
-        ctx.getJniEnv().resolveReference(native->clazz));
-    activity->quitCallback();
-  };
+    syms["ANativeActivity_finish"] = (void *)+[](ANativeActivity *native)
+    {
+        FakeJni::JniEnvContext ctx(*(FakeJni::Jvm *)native->vm);
+        auto activity = std::dynamic_pointer_cast<MainActivity>(ctx.getJniEnv().resolveReference(native->clazz));
+        activity->quitCallback();
+    };
 }
 
-void FakeLooper::prepare() {
-  jniSupport->setLooperRunning(true);
+void FakeLooper::prepare()
+{
+    jniSupport->setLooperRunning(true);
 
-  jniSupport->onWindowCreated((ANativeWindow *)(void *)associatedWindow.get(),
-                              (AInputQueue *)(void *)&fakeInputQueue);
-  associatedWindowCallbacks = std::make_shared<WindowCallbacks>(
-      *associatedWindow, *jniSupport, fakeInputQueue);
-  associatedWindowCallbacks->registerCallbacks();
+    jniSupport->onWindowCreated((ANativeWindow *)(void *)associatedWindow.get(),
+                                (AInputQueue *)(void *)&fakeInputQueue);
+    associatedWindowCallbacks = std::make_shared<WindowCallbacks>(*associatedWindow, *jniSupport, fakeInputQueue);
+    associatedWindowCallbacks->registerCallbacks();
 
-  CorePatches::setGameWindow(associatedWindow);
+    CorePatches::setGameWindow(associatedWindow);
 
-  associatedWindow->show();
-  FakeEGL::setupGLOverrides();
-  SplitscreenPatch::onGLContextCreated();
-  ShaderErrorPatch::onGLContextCreated();
+    associatedWindow->show();
+    FakeEGL::setupGLOverrides();
+    SplitscreenPatch::onGLContextCreated();
+    ShaderErrorPatch::onGLContextCreated();
 }
 
-FakeLooper::~FakeLooper() {
-  CorePatches::setGameWindow(nullptr);
-  associatedWindow.reset();
-  associatedWindowCallbacks.reset();
+FakeLooper::~FakeLooper()
+{
+    CorePatches::setGameWindow(nullptr);
+    associatedWindow.reset();
+    associatedWindowCallbacks.reset();
 }
 
-int FakeLooper::addFd(int fd, int ident, int events,
-                      ALooper_callbackFunc callback, void *data) {
-  if (androidEvent)
-    return -1;
-  if (callback != nullptr)
-    throw std::runtime_error("callback is not supported");
-  androidEvent = EventEntry(fd, ident, events, data);
-  return 1;
+int FakeLooper::addFd(int fd, int ident, int events, ALooper_callbackFunc callback, void *data)
+{
+    if (androidEvent)
+        return -1;
+    if (callback != nullptr)
+        throw std::runtime_error("callback is not supported");
+    androidEvent = EventEntry(fd, ident, events, data);
+    return 1;
 }
 
-void FakeLooper::attachInputQueue(int ident, ALooper_callbackFunc callback,
-                                  void *data) {
-  if (inputEntry)
-    throw std::runtime_error("attachInputQueue already called on this looper");
-  if (callback != nullptr)
-    throw std::runtime_error("callback is not supported");
-  inputEntry = EventEntry(-1, ident, 0, data);
+void FakeLooper::attachInputQueue(int ident, ALooper_callbackFunc callback, void *data)
+{
+    if (inputEntry)
+        throw std::runtime_error("attachInputQueue already called on this looper");
+    if (callback != nullptr)
+        throw std::runtime_error("callback is not supported");
+    inputEntry = EventEntry(-1, ident, 0, data);
 }
 
-int FakeLooper::pollAll(int timeoutMillis, int *outFd, int *outEvents,
-                        void **outData) {
-  if (androidEvent) {
-    pollfd f;
-    f.fd = androidEvent.fd;
-    f.events = androidEvent.events;
-    if (poll(&f, 1, 0) > 0) {
-      androidEvent.fill(outFd, outData);
-      if (outEvents)
-        *outEvents = f.revents;
-      return androidEvent.ident;
+int FakeLooper::pollAll(int timeoutMillis, int *outFd, int *outEvents, void **outData)
+{
+    if (androidEvent)
+    {
+        pollfd f;
+        f.fd = androidEvent.fd;
+        f.events = androidEvent.events;
+        if (poll(&f, 1, 0) > 0)
+        {
+            androidEvent.fill(outFd, outData);
+            if (outEvents)
+                *outEvents = f.revents;
+            return androidEvent.ident;
+        }
     }
-  }
 
-  if (inputEntry && fakeInputQueue.hasEvents()) {
-    inputEntry.fill(outFd, outData);
-    return inputEntry.ident;
-  }
+    if (inputEntry && fakeInputQueue.hasEvents())
+    {
+        inputEntry.fill(outFd, outData);
+        return inputEntry.ident;
+    }
 
-  associatedWindow->pollEvents();
-  associatedWindowCallbacks->markRequeueGamepadInput();
-  return ALOOPER_POLL_TIMEOUT;
+    associatedWindow->pollEvents();
+    associatedWindowCallbacks->markRequeueGamepadInput();
+    return ALOOPER_POLL_TIMEOUT;
 }

--- a/src/fake_looper.cpp
+++ b/src/fake_looper.cpp
@@ -1,10 +1,10 @@
 #include "fake_looper.h"
+#include "core_patches.h"
+#include "fake_egl.h"
+#include "gl_core_patch.h"
 #include "main.h"
 #include "shader_error_patch.h"
 #include "splitscreen_patch.h"
-#include "gl_core_patch.h"
-#include "core_patches.h"
-#include "fake_egl.h"
 
 #include <sys/poll.h>
 
@@ -17,99 +17,114 @@
 JniSupport *FakeLooper::jniSupport;
 thread_local std::unique_ptr<FakeLooper> FakeLooper::currentLooper;
 
-void FakeLooper::initHybrisHooks(std::unordered_map<std::string, void*> &syms) {
-    syms["ALooper_prepare"] = (void *) +[]() {
-        if (currentLooper)
-            throw std::runtime_error("Looper already prepared");
-        currentLooper = std::make_unique<FakeLooper>();
-        currentLooper->prepare();
-        return (ALooper *) (void *) currentLooper.get();
-    };
-    syms["ALooper_addFd"] = (void *) +[](ALooper *looper, int fd, int ident, int events, ALooper_callbackFunc callback, void *data) {
-        return ((FakeLooper *) (void *) looper)->addFd(fd, ident, events, callback, data);
-    };
-    syms["ALooper_pollAll"] = (void *) +[](int timeoutMillis, int *outFd, int *outEvents, void **outData) {
-        return currentLooper->pollAll(timeoutMillis, outFd, outEvents, outData);
-    };
-    syms["AInputQueue_attachLooper"] = (void *) +[](AInputQueue *queue, ALooper *looper, int ident, ALooper_callbackFunc callback, void *data) {
-        ((FakeLooper *) (void *) looper)->attachInputQueue(ident, callback, data);
-    };
+void FakeLooper::initHybrisHooks(
+    std::unordered_map<std::string, void *> &syms) {
+  Log::info("Launcher", "Loading gamepad mappings");
+  WindowCallbacks::loadGamepadMappings();
+#ifdef MCPELAUNCHER_ENABLE_ERROR_WINDOW
+  GameWindowManager::getManager()->setErrorHandler(
+      std::make_shared<ErrorWindow>());
+#endif
 
-    syms["ANativeActivity_finish"] = (void *) +[](ANativeActivity *native) {
-        FakeJni::JniEnvContext ctx (*(FakeJni::Jvm *) native->vm);
-        auto activity = std::dynamic_pointer_cast<MainActivity>(ctx.getJniEnv().resolveReference(native->clazz));
-        activity->quitCallback();
-    };
+  Log::info("Launcher", "Creating window");
+  static auto associatedWindow = GameWindowManager::getManager()->createWindow(
+      "Minecraft", options.windowWidth, options.windowHeight,
+      options.graphicsApi);
+  syms["ALooper_prepare"] = (void *)+[]() {
+    if (currentLooper)
+      throw std::runtime_error("Looper already prepared");
+    currentLooper = std::make_unique<FakeLooper>();
+    currentLooper->associatedWindow = associatedWindow;
+    associatedWindow->makeCurrent(false);
+    currentLooper->prepare();
+    return (ALooper *)(void *)currentLooper.get();
+  };
+  syms["ALooper_addFd"] =
+      (void *)+[](ALooper *looper, int fd, int ident, int events,
+                  ALooper_callbackFunc callback, void *data) {
+        return ((FakeLooper *)(void *)looper)
+            ->addFd(fd, ident, events, callback, data);
+      };
+  syms["ALooper_pollAll"] = (void *)+[](int timeoutMillis, int *outFd,
+                                        int *outEvents, void **outData) {
+    return currentLooper->pollAll(timeoutMillis, outFd, outEvents, outData);
+  };
+  syms["AInputQueue_attachLooper"] =
+      (void *)+[](AInputQueue *queue, ALooper *looper, int ident,
+                  ALooper_callbackFunc callback, void *data) {
+        ((FakeLooper *)(void *)looper)->attachInputQueue(ident, callback, data);
+      };
+
+  syms["ANativeActivity_finish"] = (void *)+[](ANativeActivity *native) {
+    FakeJni::JniEnvContext ctx(*(FakeJni::Jvm *)native->vm);
+    auto activity = std::dynamic_pointer_cast<MainActivity>(
+        ctx.getJniEnv().resolveReference(native->clazz));
+    activity->quitCallback();
+  };
 }
 
 void FakeLooper::prepare() {
-    jniSupport->setLooperRunning(true);
+  jniSupport->setLooperRunning(true);
 
-    Log::info("Launcher", "Loading gamepad mappings");
-    WindowCallbacks::loadGamepadMappings();
-#ifdef MCPELAUNCHER_ENABLE_ERROR_WINDOW
-    GameWindowManager::getManager()->setErrorHandler(std::make_shared<ErrorWindow>());
-#endif
+  jniSupport->onWindowCreated((ANativeWindow *)(void *)associatedWindow.get(),
+                              (AInputQueue *)(void *)&fakeInputQueue);
+  associatedWindowCallbacks = std::make_shared<WindowCallbacks>(
+      *associatedWindow, *jniSupport, fakeInputQueue);
+  associatedWindowCallbacks->registerCallbacks();
 
-    Log::info("Launcher", "Creating window");
-    associatedWindow = GameWindowManager::getManager()->createWindow("Minecraft",
-            options.windowWidth, options.windowHeight, options.graphicsApi);
-    associatedWindow->makeCurrent(false);
-    jniSupport->onWindowCreated((ANativeWindow *) (void *) associatedWindow.get(),
-            (AInputQueue *) (void *) &fakeInputQueue);
-    associatedWindowCallbacks = std::make_shared<WindowCallbacks>(*associatedWindow, *jniSupport, fakeInputQueue);
-    associatedWindowCallbacks->registerCallbacks();
+  CorePatches::setGameWindow(associatedWindow);
 
-    CorePatches::setGameWindow(associatedWindow);
-
-    associatedWindow->show();
-    FakeEGL::setupGLOverrides();
-    SplitscreenPatch::onGLContextCreated();
-    ShaderErrorPatch::onGLContextCreated();
+  associatedWindow->show();
+  FakeEGL::setupGLOverrides();
+  SplitscreenPatch::onGLContextCreated();
+  ShaderErrorPatch::onGLContextCreated();
 }
 
 FakeLooper::~FakeLooper() {
-    CorePatches::setGameWindow(nullptr);
-    associatedWindow.reset();
-    associatedWindowCallbacks.reset();
+  CorePatches::setGameWindow(nullptr);
+  associatedWindow.reset();
+  associatedWindowCallbacks.reset();
 }
 
-int FakeLooper::addFd(int fd, int ident, int events, ALooper_callbackFunc callback, void *data) {
-    if (androidEvent)
-        return -1;
-    if (callback != nullptr)
-        throw std::runtime_error("callback is not supported");
-    androidEvent = EventEntry(fd, ident, events, data);
-    return 1;
+int FakeLooper::addFd(int fd, int ident, int events,
+                      ALooper_callbackFunc callback, void *data) {
+  if (androidEvent)
+    return -1;
+  if (callback != nullptr)
+    throw std::runtime_error("callback is not supported");
+  androidEvent = EventEntry(fd, ident, events, data);
+  return 1;
 }
 
-void FakeLooper::attachInputQueue(int ident, ALooper_callbackFunc callback, void *data) {
-    if (inputEntry)
-        throw std::runtime_error("attachInputQueue already called on this looper");
-    if (callback != nullptr)
-        throw std::runtime_error("callback is not supported");
-    inputEntry = EventEntry(-1, ident, 0, data);
+void FakeLooper::attachInputQueue(int ident, ALooper_callbackFunc callback,
+                                  void *data) {
+  if (inputEntry)
+    throw std::runtime_error("attachInputQueue already called on this looper");
+  if (callback != nullptr)
+    throw std::runtime_error("callback is not supported");
+  inputEntry = EventEntry(-1, ident, 0, data);
 }
 
-int FakeLooper::pollAll(int timeoutMillis, int *outFd, int *outEvents, void **outData) {
-    if (androidEvent) {
-        pollfd f;
-        f.fd = androidEvent.fd;
-        f.events = androidEvent.events;
-        if (poll(&f, 1, 0) > 0) {
-            androidEvent.fill(outFd, outData);
-            if (outEvents)
-                *outEvents = f.revents;
-            return androidEvent.ident;
-        }
+int FakeLooper::pollAll(int timeoutMillis, int *outFd, int *outEvents,
+                        void **outData) {
+  if (androidEvent) {
+    pollfd f;
+    f.fd = androidEvent.fd;
+    f.events = androidEvent.events;
+    if (poll(&f, 1, 0) > 0) {
+      androidEvent.fill(outFd, outData);
+      if (outEvents)
+        *outEvents = f.revents;
+      return androidEvent.ident;
     }
+  }
 
-    if (inputEntry && fakeInputQueue.hasEvents()) {
-        inputEntry.fill(outFd, outData);
-        return inputEntry.ident;
-    }
+  if (inputEntry && fakeInputQueue.hasEvents()) {
+    inputEntry.fill(outFd, outData);
+    return inputEntry.ident;
+  }
 
-    associatedWindow->pollEvents();
-    associatedWindowCallbacks->markRequeueGamepadInput();
-    return ALOOPER_POLL_TIMEOUT;
+  associatedWindow->pollEvents();
+  associatedWindowCallbacks->markRequeueGamepadInput();
+  return ALOOPER_POLL_TIMEOUT;
 }

--- a/src/fake_looper.h
+++ b/src/fake_looper.h
@@ -7,22 +7,19 @@
 #include "jni/jni_support.h"
 #include "window_callbacks.h"
 
-class FakeLooper
-{
+class FakeLooper {
    private:
     static JniSupport *jniSupport;
     static thread_local std::unique_ptr<FakeLooper> currentLooper;
 
-    struct EventEntry
-    {
+    struct EventEntry {
         int fd, ident, events;
         void *data;
 
         EventEntry() : ident(-1) {}
         EventEntry(int fd, int ident, int events, void *data) : fd(fd), ident(ident), events(events), data(data) {}
 
-        void fill(int *outFd, void **outData) const
-        {
+        void fill(int *outFd, void **outData) const {
             if (outFd)
                 *outFd = fd;
             if (outData)

--- a/src/fake_looper.h
+++ b/src/fake_looper.h
@@ -1,55 +1,55 @@
 #pragma once
 
-#include "fake_inputqueue.h"
-#include "jni/jni_support.h"
-#include "window_callbacks.h"
 #include <android/looper.h>
 #include <game_window.h>
 #include <memory>
+#include "fake_inputqueue.h"
+#include "jni/jni_support.h"
+#include "window_callbacks.h"
 
-class FakeLooper {
+class FakeLooper
+{
+   private:
+    static JniSupport *jniSupport;
+    static thread_local std::unique_ptr<FakeLooper> currentLooper;
 
-private:
-  static JniSupport *jniSupport;
-  static thread_local std::unique_ptr<FakeLooper> currentLooper;
+    struct EventEntry
+    {
+        int fd, ident, events;
+        void *data;
 
-  struct EventEntry {
-    int fd, ident, events;
-    void *data;
+        EventEntry() : ident(-1) {}
+        EventEntry(int fd, int ident, int events, void *data) : fd(fd), ident(ident), events(events), data(data) {}
 
-    EventEntry() : ident(-1) {}
-    EventEntry(int fd, int ident, int events, void *data)
-        : fd(fd), ident(ident), events(events), data(data) {}
+        void fill(int *outFd, void **outData) const
+        {
+            if (outFd)
+                *outFd = fd;
+            if (outData)
+                *outData = data;
+        }
 
-    void fill(int *outFd, void **outData) const {
-      if (outFd)
-        *outFd = fd;
-      if (outData)
-        *outData = data;
-    }
+        operator bool const() { return ident != -1; }
+    };
+    EventEntry androidEvent;
+    EventEntry inputEntry;
+    FakeInputQueue fakeInputQueue;
 
-    operator bool const() { return ident != -1; }
-  };
-  EventEntry androidEvent;
-  EventEntry inputEntry;
-  FakeInputQueue fakeInputQueue;
+    std::shared_ptr<GameWindow> associatedWindow;
+    std::shared_ptr<WindowCallbacks> associatedWindowCallbacks;
 
-  std::shared_ptr<GameWindow> associatedWindow;
-  std::shared_ptr<WindowCallbacks> associatedWindowCallbacks;
+   public:
+    static void setJniSupport(JniSupport *support) { jniSupport = support; }
 
-public:
-  static void setJniSupport(JniSupport *support) { jniSupport = support; }
+    ~FakeLooper();
 
-  ~FakeLooper();
+    void prepare();
 
-  void prepare();
+    int addFd(int fd, int ident, int events, ALooper_callbackFunc callback, void *data);
 
-  int addFd(int fd, int ident, int events, ALooper_callbackFunc callback,
-            void *data);
+    void attachInputQueue(int ident, ALooper_callbackFunc callback, void *data);
 
-  void attachInputQueue(int ident, ALooper_callbackFunc callback, void *data);
+    int pollAll(int timeoutMillis, int *outFd, int *outEvents, void **outData);
 
-  int pollAll(int timeoutMillis, int *outFd, int *outEvents, void **outData);
-
-  static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
+    static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 };

--- a/src/fake_looper.h
+++ b/src/fake_looper.h
@@ -1,57 +1,55 @@
 #pragma once
 
-#include <android/looper.h>
-#include <memory>
-#include <game_window.h>
+#include "fake_inputqueue.h"
 #include "jni/jni_support.h"
 #include "window_callbacks.h"
-#include "fake_inputqueue.h"
+#include <android/looper.h>
+#include <game_window.h>
+#include <memory>
 
 class FakeLooper {
 
 private:
-    static JniSupport* jniSupport;
-    static thread_local std::unique_ptr<FakeLooper> currentLooper;
+  static JniSupport *jniSupport;
+  static thread_local std::unique_ptr<FakeLooper> currentLooper;
 
-    struct EventEntry {
-        int fd, ident, events;
-        void *data;
+  struct EventEntry {
+    int fd, ident, events;
+    void *data;
 
-        EventEntry() : ident(-1) {}
-        EventEntry(int fd, int ident, int events, void *data) : fd(fd), ident(ident), events(events), data(data) {}
+    EventEntry() : ident(-1) {}
+    EventEntry(int fd, int ident, int events, void *data)
+        : fd(fd), ident(ident), events(events), data(data) {}
 
-        void fill(int *outFd, void **outData) const {
-            if (outFd) *outFd = fd;
-            if (outData) *outData = data;
-        }
-
-        operator bool const() {
-            return ident != -1;
-        }
-    };
-    EventEntry androidEvent;
-    EventEntry inputEntry;
-    FakeInputQueue fakeInputQueue;
-
-    std::shared_ptr<GameWindow> associatedWindow;
-    std::shared_ptr<WindowCallbacks> associatedWindowCallbacks;
-
-public:
-    static void setJniSupport(JniSupport *support) {
-        jniSupport = support;
+    void fill(int *outFd, void **outData) const {
+      if (outFd)
+        *outFd = fd;
+      if (outData)
+        *outData = data;
     }
 
-    ~FakeLooper();
+    operator bool const() { return ident != -1; }
+  };
+  EventEntry androidEvent;
+  EventEntry inputEntry;
+  FakeInputQueue fakeInputQueue;
 
-    void prepare();
+  std::shared_ptr<GameWindow> associatedWindow;
+  std::shared_ptr<WindowCallbacks> associatedWindowCallbacks;
 
-    int addFd(int fd, int ident, int events, ALooper_callbackFunc callback, void *data);
+public:
+  static void setJniSupport(JniSupport *support) { jniSupport = support; }
 
-    void attachInputQueue(int ident, ALooper_callbackFunc callback, void *data);
+  ~FakeLooper();
 
-    int pollAll(int timeoutMillis, int *outFd, int *outEvents, void **outData);
+  void prepare();
 
+  int addFd(int fd, int ident, int events, ALooper_callbackFunc callback,
+            void *data);
 
-    static void initHybrisHooks(std::unordered_map<std::string, void*> &syms);
+  void attachInputQueue(int ident, ALooper_callbackFunc callback, void *data);
 
+  int pollAll(int timeoutMillis, int *outFd, int *outEvents, void **outData);
+
+  static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 };

--- a/src/fake_window.cpp
+++ b/src/fake_window.cpp
@@ -1,16 +1,18 @@
 #include "fake_window.h"
 #include <game_window.h>
 
-void FakeWindow::initHybrisHooks(
-    std::unordered_map<std::string, void *> &syms) {
-  syms["ANativeWindow_getWidth"] = (void *)+[](void *window) -> int32_t {
-    int width, height;
-    ((GameWindow *)window)->getWindowSize(width, height);
-    return width;
-  };
-  syms["ANativeWindow_getHeight"] = (void *)+[](void *window) -> int32_t {
-    int width, height;
-    ((GameWindow *)window)->getWindowSize(width, height);
-    return height;
-  };
+void FakeWindow::initHybrisHooks(std::unordered_map<std::string, void *> &syms)
+{
+    syms["ANativeWindow_getWidth"] = (void *)+[](void *window) -> int32_t
+    {
+        int width, height;
+        ((GameWindow *)window)->getWindowSize(width, height);
+        return width;
+    };
+    syms["ANativeWindow_getHeight"] = (void *)+[](void *window) -> int32_t
+    {
+        int width, height;
+        ((GameWindow *)window)->getWindowSize(width, height);
+        return height;
+    };
 }

--- a/src/fake_window.cpp
+++ b/src/fake_window.cpp
@@ -1,15 +1,16 @@
 #include "fake_window.h"
 #include <game_window.h>
 
-void FakeWindow::initHybrisHooks(std::unordered_map<std::string, void *> &syms) {
-    syms["ANativeWindow_getWidth"] = (void*)+[](void* window) -> int32_t {
-        int width, height;
-        ((GameWindow*) window)->getWindowSize(width, height);
-        return width;
-    };
-    syms["ANativeWindow_getHeight"] = (void*)+[](void* window) -> int32_t {
-        int width, height;
-        ((GameWindow*) window)->getWindowSize(width, height);
-        return height;
-    };
+void FakeWindow::initHybrisHooks(
+    std::unordered_map<std::string, void *> &syms) {
+  syms["ANativeWindow_getWidth"] = (void *)+[](void *window) -> int32_t {
+    int width, height;
+    ((GameWindow *)window)->getWindowSize(width, height);
+    return width;
+  };
+  syms["ANativeWindow_getHeight"] = (void *)+[](void *window) -> int32_t {
+    int width, height;
+    ((GameWindow *)window)->getWindowSize(width, height);
+    return height;
+  };
 }

--- a/src/fake_window.cpp
+++ b/src/fake_window.cpp
@@ -1,16 +1,13 @@
 #include "fake_window.h"
 #include <game_window.h>
 
-void FakeWindow::initHybrisHooks(std::unordered_map<std::string, void *> &syms)
-{
-    syms["ANativeWindow_getWidth"] = (void *)+[](void *window) -> int32_t
-    {
+void FakeWindow::initHybrisHooks(std::unordered_map<std::string, void *> &syms) {
+    syms["ANativeWindow_getWidth"] = (void *)+[](void *window) -> int32_t {
         int width, height;
         ((GameWindow *)window)->getWindowSize(width, height);
         return width;
     };
-    syms["ANativeWindow_getHeight"] = (void *)+[](void *window) -> int32_t
-    {
+    syms["ANativeWindow_getHeight"] = (void *)+[](void *window) -> int32_t {
         int width, height;
         ((GameWindow *)window)->getWindowSize(width, height);
         return height;

--- a/src/fake_window.h
+++ b/src/fake_window.h
@@ -2,7 +2,8 @@
 #include <string>
 #include <unordered_map>
 
-class FakeWindow {
-public:
-  static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
+class FakeWindow
+{
+   public:
+    static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 };

--- a/src/fake_window.h
+++ b/src/fake_window.h
@@ -4,5 +4,5 @@
 
 class FakeWindow {
 public:
-    static void initHybrisHooks(std::unordered_map<std::string, void*> &syms);
+  static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 };

--- a/src/fake_window.h
+++ b/src/fake_window.h
@@ -2,8 +2,7 @@
 #include <string>
 #include <unordered_map>
 
-class FakeWindow
-{
+class FakeWindow {
    public:
     static void initHybrisHooks(std::unordered_map<std::string, void *> &syms);
 };

--- a/src/gl_core_patch.cpp
+++ b/src/gl_core_patch.cpp
@@ -1,101 +1,113 @@
 #include "gl_core_patch.h"
 
 #include <cstring>
-#include <mcpelauncher/linker.h>
 #include <log.h>
+#include <mcpelauncher/linker.h>
 #include <mcpelauncher/minecraft_version.h>
 #include <mcpelauncher/patch_utils.h>
 #include <stdexcept>
 
 bool GLCorePatch::enabled = false;
 std::unordered_map<unsigned int, unsigned int> GLCorePatch::vaoMap;
-std::pair<int, unsigned int> GLCorePatch::buffers[2] = { {0x8892, 0}, {0x8893, 0} };
-void (*GLCorePatch::glGenVertexArrays)(int n, unsigned int* arrays);
+std::pair<int, unsigned int> GLCorePatch::buffers[2] = {{0x8892, 0},
+                                                        {0x8893, 0}};
+void (*GLCorePatch::glGenVertexArrays)(int n, unsigned int *arrays);
 void (*GLCorePatch::glBindVertexArray)(unsigned int array);
-void (*GLCorePatch::glShaderSource_orig)(unsigned int shader, unsigned int count, const char **string, int *length);
+void (*GLCorePatch::glShaderSource_orig)(unsigned int shader,
+                                         unsigned int count,
+                                         const char **string, int *length);
 void (*GLCorePatch::glLinkProgram_orig)(unsigned int program);
 void (*GLCorePatch::glUseProgram_orig)(unsigned int program);
 void (*GLCorePatch::glBindBuffer_orig)(int target, unsigned int buffer);
 
-void GLCorePatch::install(void* handle) {
+void GLCorePatch::install(void *handle) {
 #if __i386__
-    void *ptr = PatchUtils::patternSearch(handle, "53 83 EC 18 E8 00 00 00 00 5B 81 C3 ?? ?? ?? ?? 8B 83 ?? ?? ?? ?? 85 C0 79 5F 8D 44 24 08 89 04 24 E8 ?? ?? ?? ?? 83 EC 04 8B 44 24 08 83 F8 02");
+  void *ptr = PatchUtils::patternSearch(
+      handle, "53 83 EC 18 E8 00 00 00 00 5B 81 C3 ?? ?? ?? ?? 8B 83 ?? ?? ?? "
+              "?? 85 C0 79 5F 8D 44 24 08 89 04 24 E8 ?? ?? ?? ?? 83 EC 04 8B "
+              "44 24 08 83 F8 02");
 #elif __x86_64__
-    void *ptr = PatchUtils::patternSearch(handle, "8B 15 ?? ?? ?? ?? 85 D2 78 07 83 FA 01 0F 94 C0 C3 50 E8 ?? ?? ?? ?? C1 EA 10 F7 D2 83 E2 01 89");
+  void *ptr = PatchUtils::patternSearch(
+      handle, "8B 15 ?? ?? ?? ?? 85 D2 78 07 83 FA 01 0F 94 C0 C3 50 E8 ?? ?? "
+              "?? ?? C1 EA 10 F7 D2 83 E2 01 89");
 #else
-    void *ptr = nullptr;
+  void *ptr = nullptr;
 #endif
-    if (!ptr) {
-        ptr = linker::dlsym(handle, "_ZN2gl21supportsImmediateModeEv");
-    }
-    if (!ptr)
-        throw std::runtime_error("Failed to find gl::supportsImmediateMode");
-    unsigned char replace[6] = { 0xB8, 0x00, 0x00, 0x00, 0x00, 0xC3 };
-    memcpy(ptr, replace, 6);
+  if (!ptr) {
+    ptr = linker::dlsym(handle, "_ZN2gl21supportsImmediateModeEv");
+  }
+  if (!ptr)
+    throw std::runtime_error("Failed to find gl::supportsImmediateMode");
+  unsigned char replace[6] = {0xB8, 0x00, 0x00, 0x00, 0x00, 0xC3};
+  memcpy(ptr, replace, 6);
 
-    enabled = true;
+  enabled = true;
 }
 
-void GLCorePatch::installGL(std::unordered_map<std::string, void *> &overrides, void *(*resolver)(const char *)) {
-    if (!enabled)
-        return;
+void GLCorePatch::installGL(std::unordered_map<std::string, void *> &overrides,
+                            void *(*resolver)(const char *)) {
+  if (!enabled)
+    return;
 
-    glGenVertexArrays = (void (*)(int, unsigned int*)) resolver("glGenVertexArrays");
-    glBindVertexArray = (void (*)(unsigned int)) resolver("glBindVertexArray");
+  glGenVertexArrays =
+      (void (*)(int, unsigned int *))resolver("glGenVertexArrays");
+  glBindVertexArray = (void (*)(unsigned int))resolver("glBindVertexArray");
 
-    glShaderSource_orig = (void (*)(unsigned int, unsigned int, const char **, int *)) resolver("glShaderSource");
-    glLinkProgram_orig = (void (*)(unsigned int)) resolver("glLinkProgram");
-    glUseProgram_orig = (void (*)(unsigned int)) resolver("glUseProgram");
-    glBindBuffer_orig = (void (*)(int, unsigned int)) resolver("glBindBuffer");
+  glShaderSource_orig = (void (*)(unsigned int, unsigned int, const char **,
+                                  int *))resolver("glShaderSource");
+  glLinkProgram_orig = (void (*)(unsigned int))resolver("glLinkProgram");
+  glUseProgram_orig = (void (*)(unsigned int))resolver("glUseProgram");
+  glBindBuffer_orig = (void (*)(int, unsigned int))resolver("glBindBuffer");
 
-    overrides["glShaderSource"] = (void *) glShaderSource;
-    overrides["glLinkProgram"] = (void *) glLinkProgram;
-    overrides["glUseProgram"] = (void *) glUseProgram;
-    overrides["glBindBuffer"] = (void *) glBindBuffer;
+  overrides["glShaderSource"] = (void *)glShaderSource;
+  overrides["glLinkProgram"] = (void *)glLinkProgram;
+  overrides["glUseProgram"] = (void *)glUseProgram;
+  overrides["glBindBuffer"] = (void *)glBindBuffer;
 }
 
-void GLCorePatch::glShaderSource(unsigned int shader, unsigned int count, const char **string, int *length) {
-    if (*length > 0 && !strcmp(string[0], "#version 300 es\n")) {
-        string[0] = "#version 410\n";
-        length[0] = strlen("#version 410\n");
-    }
-    glShaderSource_orig(shader, count, string, length);
+void GLCorePatch::glShaderSource(unsigned int shader, unsigned int count,
+                                 const char **string, int *length) {
+  if (*length > 0 && !strcmp(string[0], "#version 300 es\n")) {
+    string[0] = "#version 410\n";
+    length[0] = strlen("#version 410\n");
+  }
+  glShaderSource_orig(shader, count, string, length);
 }
 
 void GLCorePatch::glLinkProgram(unsigned int program) {
-    glLinkProgram_orig(program);
+  glLinkProgram_orig(program);
 
-    unsigned int vertexArr;
-    glGenVertexArrays(1, &vertexArr);
-    glBindVertexArray(vertexArr);
-    vaoMap[program] = vertexArr;
+  unsigned int vertexArr;
+  glGenVertexArrays(1, &vertexArr);
+  glBindVertexArray(vertexArr);
+  vaoMap[program] = vertexArr;
 }
 
 void GLCorePatch::glUseProgram(unsigned int program) {
-    glUseProgram_orig(program);
+  glUseProgram_orig(program);
 
-    if (program != 0) {
-        glBindVertexArray(vaoMap.at(program));
-        for (auto &e : GLCorePatch::buffers)
-            glBindBuffer_orig(e.first, e.second);
-    }
+  if (program != 0) {
+    glBindVertexArray(vaoMap.at(program));
+    for (auto &e : GLCorePatch::buffers)
+      glBindBuffer_orig(e.first, e.second);
+  }
 }
 
 void GLCorePatch::glBindBuffer(int target, unsigned int buffer) {
-    glBindBuffer_orig(target, buffer);
+  glBindBuffer_orig(target, buffer);
 
-    for (auto &e : GLCorePatch::buffers) {
-        if (e.first == target) {
-            e.second = buffer;
-            return;
-        }
+  for (auto &e : GLCorePatch::buffers) {
+    if (e.first == target) {
+      e.second = buffer;
+      return;
     }
+  }
 }
 
 bool GLCorePatch::mustUseDesktopGL() {
 #ifdef __APPLE__
-    return true;
+  return true;
 #else
-    return false;
+  return false;
 #endif
 }

--- a/src/gl_core_patch.cpp
+++ b/src/gl_core_patch.cpp
@@ -17,8 +17,7 @@ void (*GLCorePatch::glLinkProgram_orig)(unsigned int program);
 void (*GLCorePatch::glUseProgram_orig)(unsigned int program);
 void (*GLCorePatch::glBindBuffer_orig)(int target, unsigned int buffer);
 
-void GLCorePatch::install(void *handle)
-{
+void GLCorePatch::install(void *handle) {
 #if __i386__
     void *ptr = PatchUtils::patternSearch(handle,
                                           "53 83 EC 18 E8 00 00 00 00 5B 81 C3 ?? ?? ?? ?? 8B 83 ?? ?? ?? "
@@ -31,8 +30,7 @@ void GLCorePatch::install(void *handle)
 #else
     void *ptr = nullptr;
 #endif
-    if (!ptr)
-    {
+    if (!ptr) {
         ptr = linker::dlsym(handle, "_ZN2gl21supportsImmediateModeEv");
     }
     if (!ptr)
@@ -43,8 +41,7 @@ void GLCorePatch::install(void *handle)
     enabled = true;
 }
 
-void GLCorePatch::installGL(std::unordered_map<std::string, void *> &overrides, void *(*resolver)(const char *))
-{
+void GLCorePatch::installGL(std::unordered_map<std::string, void *> &overrides, void *(*resolver)(const char *)) {
     if (!enabled)
         return;
 
@@ -62,18 +59,15 @@ void GLCorePatch::installGL(std::unordered_map<std::string, void *> &overrides, 
     overrides["glBindBuffer"] = (void *)glBindBuffer;
 }
 
-void GLCorePatch::glShaderSource(unsigned int shader, unsigned int count, const char **string, int *length)
-{
-    if (*length > 0 && !strcmp(string[0], "#version 300 es\n"))
-    {
+void GLCorePatch::glShaderSource(unsigned int shader, unsigned int count, const char **string, int *length) {
+    if (*length > 0 && !strcmp(string[0], "#version 300 es\n")) {
         string[0] = "#version 410\n";
         length[0] = strlen("#version 410\n");
     }
     glShaderSource_orig(shader, count, string, length);
 }
 
-void GLCorePatch::glLinkProgram(unsigned int program)
-{
+void GLCorePatch::glLinkProgram(unsigned int program) {
     glLinkProgram_orig(program);
 
     unsigned int vertexArr;
@@ -82,33 +76,27 @@ void GLCorePatch::glLinkProgram(unsigned int program)
     vaoMap[program] = vertexArr;
 }
 
-void GLCorePatch::glUseProgram(unsigned int program)
-{
+void GLCorePatch::glUseProgram(unsigned int program) {
     glUseProgram_orig(program);
 
-    if (program != 0)
-    {
+    if (program != 0) {
         glBindVertexArray(vaoMap.at(program));
         for (auto &e : GLCorePatch::buffers) glBindBuffer_orig(e.first, e.second);
     }
 }
 
-void GLCorePatch::glBindBuffer(int target, unsigned int buffer)
-{
+void GLCorePatch::glBindBuffer(int target, unsigned int buffer) {
     glBindBuffer_orig(target, buffer);
 
-    for (auto &e : GLCorePatch::buffers)
-    {
-        if (e.first == target)
-        {
+    for (auto &e : GLCorePatch::buffers) {
+        if (e.first == target) {
             e.second = buffer;
             return;
         }
     }
 }
 
-bool GLCorePatch::mustUseDesktopGL()
-{
+bool GLCorePatch::mustUseDesktopGL() {
 #ifdef __APPLE__
     return true;
 #else

--- a/src/gl_core_patch.cpp
+++ b/src/gl_core_patch.cpp
@@ -1,113 +1,117 @@
 #include "gl_core_patch.h"
 
-#include <cstring>
 #include <log.h>
 #include <mcpelauncher/linker.h>
 #include <mcpelauncher/minecraft_version.h>
 #include <mcpelauncher/patch_utils.h>
+#include <cstring>
 #include <stdexcept>
 
 bool GLCorePatch::enabled = false;
 std::unordered_map<unsigned int, unsigned int> GLCorePatch::vaoMap;
-std::pair<int, unsigned int> GLCorePatch::buffers[2] = {{0x8892, 0},
-                                                        {0x8893, 0}};
+std::pair<int, unsigned int> GLCorePatch::buffers[2] = {{0x8892, 0}, {0x8893, 0}};
 void (*GLCorePatch::glGenVertexArrays)(int n, unsigned int *arrays);
 void (*GLCorePatch::glBindVertexArray)(unsigned int array);
-void (*GLCorePatch::glShaderSource_orig)(unsigned int shader,
-                                         unsigned int count,
-                                         const char **string, int *length);
+void (*GLCorePatch::glShaderSource_orig)(unsigned int shader, unsigned int count, const char **string, int *length);
 void (*GLCorePatch::glLinkProgram_orig)(unsigned int program);
 void (*GLCorePatch::glUseProgram_orig)(unsigned int program);
 void (*GLCorePatch::glBindBuffer_orig)(int target, unsigned int buffer);
 
-void GLCorePatch::install(void *handle) {
+void GLCorePatch::install(void *handle)
+{
 #if __i386__
-  void *ptr = PatchUtils::patternSearch(
-      handle, "53 83 EC 18 E8 00 00 00 00 5B 81 C3 ?? ?? ?? ?? 8B 83 ?? ?? ?? "
-              "?? 85 C0 79 5F 8D 44 24 08 89 04 24 E8 ?? ?? ?? ?? 83 EC 04 8B "
-              "44 24 08 83 F8 02");
+    void *ptr = PatchUtils::patternSearch(handle,
+                                          "53 83 EC 18 E8 00 00 00 00 5B 81 C3 ?? ?? ?? ?? 8B 83 ?? ?? ?? "
+                                          "?? 85 C0 79 5F 8D 44 24 08 89 04 24 E8 ?? ?? ?? ?? 83 EC 04 8B "
+                                          "44 24 08 83 F8 02");
 #elif __x86_64__
-  void *ptr = PatchUtils::patternSearch(
-      handle, "8B 15 ?? ?? ?? ?? 85 D2 78 07 83 FA 01 0F 94 C0 C3 50 E8 ?? ?? "
-              "?? ?? C1 EA 10 F7 D2 83 E2 01 89");
+    void *ptr = PatchUtils::patternSearch(handle,
+                                          "8B 15 ?? ?? ?? ?? 85 D2 78 07 83 FA 01 0F 94 C0 C3 50 E8 ?? ?? "
+                                          "?? ?? C1 EA 10 F7 D2 83 E2 01 89");
 #else
-  void *ptr = nullptr;
+    void *ptr = nullptr;
 #endif
-  if (!ptr) {
-    ptr = linker::dlsym(handle, "_ZN2gl21supportsImmediateModeEv");
-  }
-  if (!ptr)
-    throw std::runtime_error("Failed to find gl::supportsImmediateMode");
-  unsigned char replace[6] = {0xB8, 0x00, 0x00, 0x00, 0x00, 0xC3};
-  memcpy(ptr, replace, 6);
-
-  enabled = true;
-}
-
-void GLCorePatch::installGL(std::unordered_map<std::string, void *> &overrides,
-                            void *(*resolver)(const char *)) {
-  if (!enabled)
-    return;
-
-  glGenVertexArrays =
-      (void (*)(int, unsigned int *))resolver("glGenVertexArrays");
-  glBindVertexArray = (void (*)(unsigned int))resolver("glBindVertexArray");
-
-  glShaderSource_orig = (void (*)(unsigned int, unsigned int, const char **,
-                                  int *))resolver("glShaderSource");
-  glLinkProgram_orig = (void (*)(unsigned int))resolver("glLinkProgram");
-  glUseProgram_orig = (void (*)(unsigned int))resolver("glUseProgram");
-  glBindBuffer_orig = (void (*)(int, unsigned int))resolver("glBindBuffer");
-
-  overrides["glShaderSource"] = (void *)glShaderSource;
-  overrides["glLinkProgram"] = (void *)glLinkProgram;
-  overrides["glUseProgram"] = (void *)glUseProgram;
-  overrides["glBindBuffer"] = (void *)glBindBuffer;
-}
-
-void GLCorePatch::glShaderSource(unsigned int shader, unsigned int count,
-                                 const char **string, int *length) {
-  if (*length > 0 && !strcmp(string[0], "#version 300 es\n")) {
-    string[0] = "#version 410\n";
-    length[0] = strlen("#version 410\n");
-  }
-  glShaderSource_orig(shader, count, string, length);
-}
-
-void GLCorePatch::glLinkProgram(unsigned int program) {
-  glLinkProgram_orig(program);
-
-  unsigned int vertexArr;
-  glGenVertexArrays(1, &vertexArr);
-  glBindVertexArray(vertexArr);
-  vaoMap[program] = vertexArr;
-}
-
-void GLCorePatch::glUseProgram(unsigned int program) {
-  glUseProgram_orig(program);
-
-  if (program != 0) {
-    glBindVertexArray(vaoMap.at(program));
-    for (auto &e : GLCorePatch::buffers)
-      glBindBuffer_orig(e.first, e.second);
-  }
-}
-
-void GLCorePatch::glBindBuffer(int target, unsigned int buffer) {
-  glBindBuffer_orig(target, buffer);
-
-  for (auto &e : GLCorePatch::buffers) {
-    if (e.first == target) {
-      e.second = buffer;
-      return;
+    if (!ptr)
+    {
+        ptr = linker::dlsym(handle, "_ZN2gl21supportsImmediateModeEv");
     }
-  }
+    if (!ptr)
+        throw std::runtime_error("Failed to find gl::supportsImmediateMode");
+    unsigned char replace[6] = {0xB8, 0x00, 0x00, 0x00, 0x00, 0xC3};
+    memcpy(ptr, replace, 6);
+
+    enabled = true;
 }
 
-bool GLCorePatch::mustUseDesktopGL() {
+void GLCorePatch::installGL(std::unordered_map<std::string, void *> &overrides, void *(*resolver)(const char *))
+{
+    if (!enabled)
+        return;
+
+    glGenVertexArrays = (void (*)(int, unsigned int *))resolver("glGenVertexArrays");
+    glBindVertexArray = (void (*)(unsigned int))resolver("glBindVertexArray");
+
+    glShaderSource_orig = (void (*)(unsigned int, unsigned int, const char **, int *))resolver("glShaderSource");
+    glLinkProgram_orig = (void (*)(unsigned int))resolver("glLinkProgram");
+    glUseProgram_orig = (void (*)(unsigned int))resolver("glUseProgram");
+    glBindBuffer_orig = (void (*)(int, unsigned int))resolver("glBindBuffer");
+
+    overrides["glShaderSource"] = (void *)glShaderSource;
+    overrides["glLinkProgram"] = (void *)glLinkProgram;
+    overrides["glUseProgram"] = (void *)glUseProgram;
+    overrides["glBindBuffer"] = (void *)glBindBuffer;
+}
+
+void GLCorePatch::glShaderSource(unsigned int shader, unsigned int count, const char **string, int *length)
+{
+    if (*length > 0 && !strcmp(string[0], "#version 300 es\n"))
+    {
+        string[0] = "#version 410\n";
+        length[0] = strlen("#version 410\n");
+    }
+    glShaderSource_orig(shader, count, string, length);
+}
+
+void GLCorePatch::glLinkProgram(unsigned int program)
+{
+    glLinkProgram_orig(program);
+
+    unsigned int vertexArr;
+    glGenVertexArrays(1, &vertexArr);
+    glBindVertexArray(vertexArr);
+    vaoMap[program] = vertexArr;
+}
+
+void GLCorePatch::glUseProgram(unsigned int program)
+{
+    glUseProgram_orig(program);
+
+    if (program != 0)
+    {
+        glBindVertexArray(vaoMap.at(program));
+        for (auto &e : GLCorePatch::buffers) glBindBuffer_orig(e.first, e.second);
+    }
+}
+
+void GLCorePatch::glBindBuffer(int target, unsigned int buffer)
+{
+    glBindBuffer_orig(target, buffer);
+
+    for (auto &e : GLCorePatch::buffers)
+    {
+        if (e.first == target)
+        {
+            e.second = buffer;
+            return;
+        }
+    }
+}
+
+bool GLCorePatch::mustUseDesktopGL()
+{
 #ifdef __APPLE__
-  return true;
+    return true;
 #else
-  return false;
+    return false;
 #endif
 }

--- a/src/gl_core_patch.h
+++ b/src/gl_core_patch.h
@@ -1,37 +1,38 @@
 #pragma once
 
 #include <cstddef>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 class GLCorePatch {
 
 private:
-    static bool enabled;
-    static std::unordered_map<unsigned int, unsigned int> vaoMap;
-    static std::pair<int, unsigned int> buffers[2];
+  static bool enabled;
+  static std::unordered_map<unsigned int, unsigned int> vaoMap;
+  static std::pair<int, unsigned int> buffers[2];
 
-    static void (*glGenVertexArrays)(int n, unsigned int* arrays);
-    static void (*glBindVertexArray)(unsigned int array);
+  static void (*glGenVertexArrays)(int n, unsigned int *arrays);
+  static void (*glBindVertexArray)(unsigned int array);
 
-    static void (*glShaderSource_orig)(unsigned int shader, unsigned int count, const char **string, int *length);
-    static void glShaderSource(unsigned int shader, unsigned int count, const char **string, int *length);
+  static void (*glShaderSource_orig)(unsigned int shader, unsigned int count,
+                                     const char **string, int *length);
+  static void glShaderSource(unsigned int shader, unsigned int count,
+                             const char **string, int *length);
 
-    static void (*glLinkProgram_orig)(unsigned int program);
-    static void glLinkProgram(unsigned int program);
+  static void (*glLinkProgram_orig)(unsigned int program);
+  static void glLinkProgram(unsigned int program);
 
-    static void (*glUseProgram_orig)(unsigned int program);
-    static void glUseProgram(unsigned int program);
+  static void (*glUseProgram_orig)(unsigned int program);
+  static void glUseProgram(unsigned int program);
 
-    static void (*glBindBuffer_orig)(int target, unsigned int buffer);
-    static void glBindBuffer(int target, unsigned int buffer);
+  static void (*glBindBuffer_orig)(int target, unsigned int buffer);
+  static void glBindBuffer(int target, unsigned int buffer);
 
 public:
-    static void install(void* handle);
+  static void install(void *handle);
 
-    static void installGL(std::unordered_map<std::string, void *> &overrides, void *(*resolver)(const char *));
+  static void installGL(std::unordered_map<std::string, void *> &overrides,
+                        void *(*resolver)(const char *));
 
-
-    static bool mustUseDesktopGL();
-
+  static bool mustUseDesktopGL();
 };

--- a/src/gl_core_patch.h
+++ b/src/gl_core_patch.h
@@ -4,35 +4,32 @@
 #include <string>
 #include <unordered_map>
 
-class GLCorePatch {
+class GLCorePatch
+{
+   private:
+    static bool enabled;
+    static std::unordered_map<unsigned int, unsigned int> vaoMap;
+    static std::pair<int, unsigned int> buffers[2];
 
-private:
-  static bool enabled;
-  static std::unordered_map<unsigned int, unsigned int> vaoMap;
-  static std::pair<int, unsigned int> buffers[2];
+    static void (*glGenVertexArrays)(int n, unsigned int *arrays);
+    static void (*glBindVertexArray)(unsigned int array);
 
-  static void (*glGenVertexArrays)(int n, unsigned int *arrays);
-  static void (*glBindVertexArray)(unsigned int array);
+    static void (*glShaderSource_orig)(unsigned int shader, unsigned int count, const char **string, int *length);
+    static void glShaderSource(unsigned int shader, unsigned int count, const char **string, int *length);
 
-  static void (*glShaderSource_orig)(unsigned int shader, unsigned int count,
-                                     const char **string, int *length);
-  static void glShaderSource(unsigned int shader, unsigned int count,
-                             const char **string, int *length);
+    static void (*glLinkProgram_orig)(unsigned int program);
+    static void glLinkProgram(unsigned int program);
 
-  static void (*glLinkProgram_orig)(unsigned int program);
-  static void glLinkProgram(unsigned int program);
+    static void (*glUseProgram_orig)(unsigned int program);
+    static void glUseProgram(unsigned int program);
 
-  static void (*glUseProgram_orig)(unsigned int program);
-  static void glUseProgram(unsigned int program);
+    static void (*glBindBuffer_orig)(int target, unsigned int buffer);
+    static void glBindBuffer(int target, unsigned int buffer);
 
-  static void (*glBindBuffer_orig)(int target, unsigned int buffer);
-  static void glBindBuffer(int target, unsigned int buffer);
+   public:
+    static void install(void *handle);
 
-public:
-  static void install(void *handle);
+    static void installGL(std::unordered_map<std::string, void *> &overrides, void *(*resolver)(const char *));
 
-  static void installGL(std::unordered_map<std::string, void *> &overrides,
-                        void *(*resolver)(const char *));
-
-  static bool mustUseDesktopGL();
+    static bool mustUseDesktopGL();
 };

--- a/src/gl_core_patch.h
+++ b/src/gl_core_patch.h
@@ -4,8 +4,7 @@
 #include <string>
 #include <unordered_map>
 
-class GLCorePatch
-{
+class GLCorePatch {
    private:
     static bool enabled;
     static std::unordered_map<unsigned int, unsigned int> vaoMap;

--- a/src/hbui_patch.cpp
+++ b/src/hbui_patch.cpp
@@ -1,17 +1,19 @@
 #include "hbui_patch.h"
+#include <log.h>
 #include <mcpelauncher/linker.h>
 #include <mcpelauncher/patch_utils.h>
-#include <log.h>
 
 void HbuiPatch::install(void *handle) {
-    void* ptr = linker::dlsym(handle, "_ZN6cohtml17VerifiyLicenseKeyEPKc");
-    if (ptr)
-        PatchUtils::patchCallInstruction(ptr, (void*) returnTrue, true);
-    ptr = linker::dlsym(handle, "_ZN4hbui10LogHandler8WriteLogEN6cohtml7Logging8SeverityEPKcj");
-    if (ptr)
-        PatchUtils::patchCallInstruction(ptr, (void*) writeLog, true);
+  void *ptr = linker::dlsym(handle, "_ZN6cohtml17VerifiyLicenseKeyEPKc");
+  if (ptr)
+    PatchUtils::patchCallInstruction(ptr, (void *)returnTrue, true);
+  ptr = linker::dlsym(
+      handle, "_ZN4hbui10LogHandler8WriteLogEN6cohtml7Logging8SeverityEPKcj");
+  if (ptr)
+    PatchUtils::patchCallInstruction(ptr, (void *)writeLog, true);
 }
 
-void HbuiPatch::writeLog(void* th, int level, const char *what, unsigned int length) {
-    Log::log((LogLevel) level, "Cohtml", "%.*s", length, what);
+void HbuiPatch::writeLog(void *th, int level, const char *what,
+                         unsigned int length) {
+  Log::log((LogLevel)level, "Cohtml", "%.*s", length, what);
 }

--- a/src/hbui_patch.cpp
+++ b/src/hbui_patch.cpp
@@ -3,8 +3,7 @@
 #include <mcpelauncher/linker.h>
 #include <mcpelauncher/patch_utils.h>
 
-void HbuiPatch::install(void *handle)
-{
+void HbuiPatch::install(void *handle) {
     void *ptr = linker::dlsym(handle, "_ZN6cohtml17VerifiyLicenseKeyEPKc");
     if (ptr)
         PatchUtils::patchCallInstruction(ptr, (void *)returnTrue, true);
@@ -13,7 +12,6 @@ void HbuiPatch::install(void *handle)
         PatchUtils::patchCallInstruction(ptr, (void *)writeLog, true);
 }
 
-void HbuiPatch::writeLog(void *th, int level, const char *what, unsigned int length)
-{
+void HbuiPatch::writeLog(void *th, int level, const char *what, unsigned int length) {
     Log::log((LogLevel)level, "Cohtml", "%.*s", length, what);
 }

--- a/src/hbui_patch.cpp
+++ b/src/hbui_patch.cpp
@@ -3,17 +3,17 @@
 #include <mcpelauncher/linker.h>
 #include <mcpelauncher/patch_utils.h>
 
-void HbuiPatch::install(void *handle) {
-  void *ptr = linker::dlsym(handle, "_ZN6cohtml17VerifiyLicenseKeyEPKc");
-  if (ptr)
-    PatchUtils::patchCallInstruction(ptr, (void *)returnTrue, true);
-  ptr = linker::dlsym(
-      handle, "_ZN4hbui10LogHandler8WriteLogEN6cohtml7Logging8SeverityEPKcj");
-  if (ptr)
-    PatchUtils::patchCallInstruction(ptr, (void *)writeLog, true);
+void HbuiPatch::install(void *handle)
+{
+    void *ptr = linker::dlsym(handle, "_ZN6cohtml17VerifiyLicenseKeyEPKc");
+    if (ptr)
+        PatchUtils::patchCallInstruction(ptr, (void *)returnTrue, true);
+    ptr = linker::dlsym(handle, "_ZN4hbui10LogHandler8WriteLogEN6cohtml7Logging8SeverityEPKcj");
+    if (ptr)
+        PatchUtils::patchCallInstruction(ptr, (void *)writeLog, true);
 }
 
-void HbuiPatch::writeLog(void *th, int level, const char *what,
-                         unsigned int length) {
-  Log::log((LogLevel)level, "Cohtml", "%.*s", length, what);
+void HbuiPatch::writeLog(void *th, int level, const char *what, unsigned int length)
+{
+    Log::log((LogLevel)level, "Cohtml", "%.*s", length, what);
 }

--- a/src/hbui_patch.h
+++ b/src/hbui_patch.h
@@ -5,13 +5,11 @@
 class HbuiPatch {
 
 private:
-    static bool returnTrue() {
-        return true;
-    }
+  static bool returnTrue() { return true; }
 
-    static void writeLog(void* th, int level, const char* what, unsigned int length);
+  static void writeLog(void *th, int level, const char *what,
+                       unsigned int length);
 
 public:
-    static void install(void* handle);
-
+  static void install(void *handle);
 };

--- a/src/hbui_patch.h
+++ b/src/hbui_patch.h
@@ -2,8 +2,7 @@
 
 #include <cstddef>
 
-class HbuiPatch
-{
+class HbuiPatch {
    private:
     static bool returnTrue() { return true; }
 

--- a/src/hbui_patch.h
+++ b/src/hbui_patch.h
@@ -2,14 +2,13 @@
 
 #include <cstddef>
 
-class HbuiPatch {
+class HbuiPatch
+{
+   private:
+    static bool returnTrue() { return true; }
 
-private:
-  static bool returnTrue() { return true; }
+    static void writeLog(void *th, int level, const char *what, unsigned int length);
 
-  static void writeLog(void *th, int level, const char *what,
-                       unsigned int length);
-
-public:
-  static void install(void *handle);
+   public:
+    static void install(void *handle);
 };

--- a/src/jni/accounts.cpp
+++ b/src/jni/accounts.cpp
@@ -1,12 +1,14 @@
-#include <log.h>
 #include "accounts.h"
+#include <log.h>
 
 std::shared_ptr<AccountManager> AccountManager::get(std::shared_ptr<Context>) {
-    return std::make_shared<AccountManager>(AccountManager());
+  return std::make_shared<AccountManager>(AccountManager());
 }
 
-std::shared_ptr<FakeJni::JArray<Account>> AccountManager::getAccountsByType(std::shared_ptr<FakeJni::JString> type) {
-    //Log::info("Account", type->asStdString().c_str());
-    //return std::make_shared<FakeJni::JArray<Account>, std::initializer_list<std::shared_ptr<Account>>>({std::make_shared<Account>()});
-    return std::make_shared<FakeJni::JArray<Account>>(0);
+std::shared_ptr<FakeJni::JArray<Account>>
+AccountManager::getAccountsByType(std::shared_ptr<FakeJni::JString> type) {
+  // Log::info("Account", type->asStdString().c_str());
+  // return std::make_shared<FakeJni::JArray<Account>,
+  // std::initializer_list<std::shared_ptr<Account>>>({std::make_shared<Account>()});
+  return std::make_shared<FakeJni::JArray<Account>>(0);
 }

--- a/src/jni/accounts.cpp
+++ b/src/jni/accounts.cpp
@@ -1,13 +1,11 @@
 #include "accounts.h"
 #include <log.h>
 
-std::shared_ptr<AccountManager> AccountManager::get(std::shared_ptr<Context>)
-{
+std::shared_ptr<AccountManager> AccountManager::get(std::shared_ptr<Context>) {
     return std::make_shared<AccountManager>(AccountManager());
 }
 
-std::shared_ptr<FakeJni::JArray<Account>> AccountManager::getAccountsByType(std::shared_ptr<FakeJni::JString> type)
-{
+std::shared_ptr<FakeJni::JArray<Account>> AccountManager::getAccountsByType(std::shared_ptr<FakeJni::JString> type) {
     // Log::info("Account", type->asStdString().c_str());
     // return std::make_shared<FakeJni::JArray<Account>,
     // std::initializer_list<std::shared_ptr<Account>>>({std::make_shared<Account>()});

--- a/src/jni/accounts.cpp
+++ b/src/jni/accounts.cpp
@@ -1,14 +1,15 @@
 #include "accounts.h"
 #include <log.h>
 
-std::shared_ptr<AccountManager> AccountManager::get(std::shared_ptr<Context>) {
-  return std::make_shared<AccountManager>(AccountManager());
+std::shared_ptr<AccountManager> AccountManager::get(std::shared_ptr<Context>)
+{
+    return std::make_shared<AccountManager>(AccountManager());
 }
 
-std::shared_ptr<FakeJni::JArray<Account>>
-AccountManager::getAccountsByType(std::shared_ptr<FakeJni::JString> type) {
-  // Log::info("Account", type->asStdString().c_str());
-  // return std::make_shared<FakeJni::JArray<Account>,
-  // std::initializer_list<std::shared_ptr<Account>>>({std::make_shared<Account>()});
-  return std::make_shared<FakeJni::JArray<Account>>(0);
+std::shared_ptr<FakeJni::JArray<Account>> AccountManager::getAccountsByType(std::shared_ptr<FakeJni::JString> type)
+{
+    // Log::info("Account", type->asStdString().c_str());
+    // return std::make_shared<FakeJni::JArray<Account>,
+    // std::initializer_list<std::shared_ptr<Account>>>({std::make_shared<Account>()});
+    return std::make_shared<FakeJni::JArray<Account>>(0);
 }

--- a/src/jni/accounts.h
+++ b/src/jni/accounts.h
@@ -1,16 +1,17 @@
 #pragma once
 
-#include <fake-jni/jvm.h>
 #include "main_activity.h"
+#include <fake-jni/jvm.h>
 
 class Account : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("android/accounts/Account")
+  DEFINE_CLASS_NAME("android/accounts/Account")
 };
 
 class AccountManager : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("android/accounts/AccountManager")
-    static std::shared_ptr<AccountManager> get(std::shared_ptr<Context>);
-    std::shared_ptr<FakeJni::JArray<Account>> getAccountsByType(std::shared_ptr<FakeJni::JString>);
+  DEFINE_CLASS_NAME("android/accounts/AccountManager")
+  static std::shared_ptr<AccountManager> get(std::shared_ptr<Context>);
+  std::shared_ptr<FakeJni::JArray<Account>>
+      getAccountsByType(std::shared_ptr<FakeJni::JString>);
 };

--- a/src/jni/accounts.h
+++ b/src/jni/accounts.h
@@ -1,17 +1,18 @@
 #pragma once
 
-#include "main_activity.h"
 #include <fake-jni/jvm.h>
+#include "main_activity.h"
 
-class Account : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("android/accounts/Account")
+class Account : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("android/accounts/Account")
 };
 
-class AccountManager : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("android/accounts/AccountManager")
-  static std::shared_ptr<AccountManager> get(std::shared_ptr<Context>);
-  std::shared_ptr<FakeJni::JArray<Account>>
-      getAccountsByType(std::shared_ptr<FakeJni::JString>);
+class AccountManager : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("android/accounts/AccountManager")
+    static std::shared_ptr<AccountManager> get(std::shared_ptr<Context>);
+    std::shared_ptr<FakeJni::JArray<Account>> getAccountsByType(std::shared_ptr<FakeJni::JString>);
 };

--- a/src/jni/accounts.h
+++ b/src/jni/accounts.h
@@ -3,14 +3,12 @@
 #include <fake-jni/jvm.h>
 #include "main_activity.h"
 
-class Account : public FakeJni::JObject
-{
+class Account : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("android/accounts/Account")
 };
 
-class AccountManager : public FakeJni::JObject
-{
+class AccountManager : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("android/accounts/AccountManager")
     static std::shared_ptr<AccountManager> get(std::shared_ptr<Context>);

--- a/src/jni/arrays.cpp
+++ b/src/jni/arrays.cpp
@@ -1,7 +1,8 @@
 #include "arrays.h"
 
-std::shared_ptr<FakeJni::JByteArray> Arrays::copyOfRange(std::shared_ptr<FakeJni::JByteArray> in, int i, int n) {
-    auto ret = std::make_shared<FakeJni::JByteArray>(n - i);
-    memcpy(ret->getArray(), in->getArray() + i, n - i);
-    return ret;
+std::shared_ptr<FakeJni::JByteArray>
+Arrays::copyOfRange(std::shared_ptr<FakeJni::JByteArray> in, int i, int n) {
+  auto ret = std::make_shared<FakeJni::JByteArray>(n - i);
+  memcpy(ret->getArray(), in->getArray() + i, n - i);
+  return ret;
 }

--- a/src/jni/arrays.cpp
+++ b/src/jni/arrays.cpp
@@ -1,7 +1,6 @@
 #include "arrays.h"
 
-std::shared_ptr<FakeJni::JByteArray> Arrays::copyOfRange(std::shared_ptr<FakeJni::JByteArray> in, int i, int n)
-{
+std::shared_ptr<FakeJni::JByteArray> Arrays::copyOfRange(std::shared_ptr<FakeJni::JByteArray> in, int i, int n) {
     auto ret = std::make_shared<FakeJni::JByteArray>(n - i);
     memcpy(ret->getArray(), in->getArray() + i, n - i);
     return ret;

--- a/src/jni/arrays.cpp
+++ b/src/jni/arrays.cpp
@@ -1,8 +1,8 @@
 #include "arrays.h"
 
-std::shared_ptr<FakeJni::JByteArray>
-Arrays::copyOfRange(std::shared_ptr<FakeJni::JByteArray> in, int i, int n) {
-  auto ret = std::make_shared<FakeJni::JByteArray>(n - i);
-  memcpy(ret->getArray(), in->getArray() + i, n - i);
-  return ret;
+std::shared_ptr<FakeJni::JByteArray> Arrays::copyOfRange(std::shared_ptr<FakeJni::JByteArray> in, int i, int n)
+{
+    auto ret = std::make_shared<FakeJni::JByteArray>(n - i);
+    memcpy(ret->getArray(), in->getArray() + i, n - i);
+    return ret;
 }

--- a/src/jni/arrays.h
+++ b/src/jni/arrays.h
@@ -1,11 +1,10 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class Arrays : public FakeJni::JObject {
+class Arrays : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/util/Arrays")
 
-public:
-  DEFINE_CLASS_NAME("java/util/Arrays")
-
-  static std::shared_ptr<FakeJni::JByteArray>
-  copyOfRange(std::shared_ptr<FakeJni::JByteArray>, int i, int n);
+    static std::shared_ptr<FakeJni::JByteArray> copyOfRange(std::shared_ptr<FakeJni::JByteArray>, int i, int n);
 };

--- a/src/jni/arrays.h
+++ b/src/jni/arrays.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class Arrays : public FakeJni::JObject
-{
+class Arrays : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/util/Arrays")
 

--- a/src/jni/arrays.h
+++ b/src/jni/arrays.h
@@ -4,7 +4,8 @@
 class Arrays : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/util/Arrays")
+  DEFINE_CLASS_NAME("java/util/Arrays")
 
-    static std::shared_ptr<FakeJni::JByteArray> copyOfRange(std::shared_ptr<FakeJni::JByteArray>, int i, int n);
+  static std::shared_ptr<FakeJni::JByteArray>
+  copyOfRange(std::shared_ptr<FakeJni::JByteArray>, int i, int n);
 };

--- a/src/jni/cert_manager.cpp
+++ b/src/jni/cert_manager.cpp
@@ -1,31 +1,29 @@
 #include "cert_manager.h"
 
-ByteArrayInputStream::ByteArrayInputStream(
-    std::shared_ptr<FakeJni::JByteArray> bytes) {}
+ByteArrayInputStream::ByteArrayInputStream(std::shared_ptr<FakeJni::JByteArray> bytes) {}
 
-std::shared_ptr<CertificateFactory>
-CertificateFactory::getInstance(std::shared_ptr<FakeJni::JString> s) {
-  return std::make_shared<CertificateFactory>();
+std::shared_ptr<CertificateFactory> CertificateFactory::getInstance(std::shared_ptr<FakeJni::JString> s)
+{
+    return std::make_shared<CertificateFactory>();
 }
 
-std::shared_ptr<Certificate>
-CertificateFactory::generateCertificate(std::shared_ptr<InputStream> s) {
-  return std::make_shared<X509Certificate>();
+std::shared_ptr<Certificate> CertificateFactory::generateCertificate(std::shared_ptr<InputStream> s)
+{
+    return std::make_shared<X509Certificate>();
 }
 
-std::shared_ptr<TrustManagerFactory>
-TrustManagerFactory::getInstance(std::shared_ptr<FakeJni::JString> s) {
-  return std::make_shared<TrustManagerFactory>();
+std::shared_ptr<TrustManagerFactory> TrustManagerFactory::getInstance(std::shared_ptr<FakeJni::JString> s)
+{
+    return std::make_shared<TrustManagerFactory>();
 }
 
-std::shared_ptr<FakeJni::JArray<TrustManager>>
-TrustManagerFactory::getTrustManagers() {
-  auto a = std::make_shared<FakeJni::JArray<TrustManager>>(1);
-  (*a)[0] = std::make_shared<X509TrustManager>();
-  return a;
+std::shared_ptr<FakeJni::JArray<TrustManager>> TrustManagerFactory::getTrustManagers()
+{
+    auto a = std::make_shared<FakeJni::JArray<TrustManager>>(1);
+    (*a)[0] = std::make_shared<X509TrustManager>();
+    return a;
 }
 
 StrictHostnameVerifier::StrictHostnameVerifier() {}
 
-void StrictHostnameVerifier::verify(std::shared_ptr<FakeJni::JString> s,
-                                    std::shared_ptr<X509Certificate> cert) {}
+void StrictHostnameVerifier::verify(std::shared_ptr<FakeJni::JString> s, std::shared_ptr<X509Certificate> cert) {}

--- a/src/jni/cert_manager.cpp
+++ b/src/jni/cert_manager.cpp
@@ -2,23 +2,19 @@
 
 ByteArrayInputStream::ByteArrayInputStream(std::shared_ptr<FakeJni::JByteArray> bytes) {}
 
-std::shared_ptr<CertificateFactory> CertificateFactory::getInstance(std::shared_ptr<FakeJni::JString> s)
-{
+std::shared_ptr<CertificateFactory> CertificateFactory::getInstance(std::shared_ptr<FakeJni::JString> s) {
     return std::make_shared<CertificateFactory>();
 }
 
-std::shared_ptr<Certificate> CertificateFactory::generateCertificate(std::shared_ptr<InputStream> s)
-{
+std::shared_ptr<Certificate> CertificateFactory::generateCertificate(std::shared_ptr<InputStream> s) {
     return std::make_shared<X509Certificate>();
 }
 
-std::shared_ptr<TrustManagerFactory> TrustManagerFactory::getInstance(std::shared_ptr<FakeJni::JString> s)
-{
+std::shared_ptr<TrustManagerFactory> TrustManagerFactory::getInstance(std::shared_ptr<FakeJni::JString> s) {
     return std::make_shared<TrustManagerFactory>();
 }
 
-std::shared_ptr<FakeJni::JArray<TrustManager>> TrustManagerFactory::getTrustManagers()
-{
+std::shared_ptr<FakeJni::JArray<TrustManager>> TrustManagerFactory::getTrustManagers() {
     auto a = std::make_shared<FakeJni::JArray<TrustManager>>(1);
     (*a)[0] = std::make_shared<X509TrustManager>();
     return a;

--- a/src/jni/cert_manager.cpp
+++ b/src/jni/cert_manager.cpp
@@ -1,31 +1,31 @@
 #include "cert_manager.h"
 
-ByteArrayInputStream::ByteArrayInputStream(std::shared_ptr<FakeJni::JByteArray> bytes) {
+ByteArrayInputStream::ByteArrayInputStream(
+    std::shared_ptr<FakeJni::JByteArray> bytes) {}
 
+std::shared_ptr<CertificateFactory>
+CertificateFactory::getInstance(std::shared_ptr<FakeJni::JString> s) {
+  return std::make_shared<CertificateFactory>();
 }
 
-std::shared_ptr<CertificateFactory> CertificateFactory::getInstance(std::shared_ptr<FakeJni::JString> s) {
-    return std::make_shared<CertificateFactory>();
+std::shared_ptr<Certificate>
+CertificateFactory::generateCertificate(std::shared_ptr<InputStream> s) {
+  return std::make_shared<X509Certificate>();
 }
 
-std::shared_ptr<Certificate> CertificateFactory::generateCertificate(std::shared_ptr<InputStream> s) {
-    return std::make_shared<X509Certificate>();
+std::shared_ptr<TrustManagerFactory>
+TrustManagerFactory::getInstance(std::shared_ptr<FakeJni::JString> s) {
+  return std::make_shared<TrustManagerFactory>();
 }
 
-std::shared_ptr<TrustManagerFactory> TrustManagerFactory::getInstance(std::shared_ptr<FakeJni::JString> s) {
-    return std::make_shared<TrustManagerFactory>();
+std::shared_ptr<FakeJni::JArray<TrustManager>>
+TrustManagerFactory::getTrustManagers() {
+  auto a = std::make_shared<FakeJni::JArray<TrustManager>>(1);
+  (*a)[0] = std::make_shared<X509TrustManager>();
+  return a;
 }
 
-std::shared_ptr<FakeJni::JArray<TrustManager>> TrustManagerFactory::getTrustManagers() {
-    auto a = std::make_shared<FakeJni::JArray<TrustManager>>(1);
-    (*a)[0] = std::make_shared<X509TrustManager>();
-    return a;
-}
+StrictHostnameVerifier::StrictHostnameVerifier() {}
 
-StrictHostnameVerifier::StrictHostnameVerifier() {
-
-}
-
-void StrictHostnameVerifier::verify(std::shared_ptr<FakeJni::JString> s, std::shared_ptr<X509Certificate> cert) {
-
-}
+void StrictHostnameVerifier::verify(std::shared_ptr<FakeJni::JString> s,
+                                    std::shared_ptr<X509Certificate> cert) {}

--- a/src/jni/cert_manager.h
+++ b/src/jni/cert_manager.h
@@ -1,67 +1,72 @@
 #pragma once
 
-#include <fake-jni/fake-jni.h>
-#include "java_types.h"
 #include "../text_input_handler.h"
+#include "java_types.h"
+#include <fake-jni/fake-jni.h>
 
 class InputStream : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/io/InputStream")
+  DEFINE_CLASS_NAME("java/io/InputStream")
 };
 
 class ByteArrayInputStream : public InputStream {
 
 public:
-    DEFINE_CLASS_NAME("java/io/ByteArrayInputStream", InputStream)
-    ByteArrayInputStream(std::shared_ptr<FakeJni::JByteArray> bytes);
+  DEFINE_CLASS_NAME("java/io/ByteArrayInputStream", InputStream)
+  ByteArrayInputStream(std::shared_ptr<FakeJni::JByteArray> bytes);
 };
 
 class Certificate : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/security/cert/Certificate")
+  DEFINE_CLASS_NAME("java/security/cert/Certificate")
 };
 
 class X509Certificate : public Certificate {
 
 public:
-    DEFINE_CLASS_NAME("org/apache/http/conn/ssl/java/security/cert/X509Certificate", Certificate)
+  DEFINE_CLASS_NAME(
+      "org/apache/http/conn/ssl/java/security/cert/X509Certificate",
+      Certificate)
 };
-
 
 class CertificateFactory : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/security/cert/CertificateFactory")
-    static std::shared_ptr<CertificateFactory> getInstance(std::shared_ptr<FakeJni::JString> s);
-    std::shared_ptr<Certificate> generateCertificate(std::shared_ptr<InputStream> s);
+  DEFINE_CLASS_NAME("java/security/cert/CertificateFactory")
+  static std::shared_ptr<CertificateFactory>
+  getInstance(std::shared_ptr<FakeJni::JString> s);
+  std::shared_ptr<Certificate>
+  generateCertificate(std::shared_ptr<InputStream> s);
 };
 
 class TrustManager : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("javax/net/ssl/TrustManager")
+  DEFINE_CLASS_NAME("javax/net/ssl/TrustManager")
 };
 
 class X509TrustManager : public TrustManager {
 
 public:
-    DEFINE_CLASS_NAME("javax/net/ssl/X509TrustManager", TrustManager)
+  DEFINE_CLASS_NAME("javax/net/ssl/X509TrustManager", TrustManager)
 };
 
 class TrustManagerFactory : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("javax/net/ssl/TrustManagerFactory")
-    static std::shared_ptr<TrustManagerFactory> getInstance(std::shared_ptr<FakeJni::JString> s);
-    std::shared_ptr<FakeJni::JArray<TrustManager>> getTrustManagers();
+  DEFINE_CLASS_NAME("javax/net/ssl/TrustManagerFactory")
+  static std::shared_ptr<TrustManagerFactory>
+  getInstance(std::shared_ptr<FakeJni::JString> s);
+  std::shared_ptr<FakeJni::JArray<TrustManager>> getTrustManagers();
 };
 
 class StrictHostnameVerifier : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("org/apache/http/conn/ssl/StrictHostnameVerifier")
-    StrictHostnameVerifier();
-    void verify(std::shared_ptr<FakeJni::JString> s, std::shared_ptr<X509Certificate> cert);
+  DEFINE_CLASS_NAME("org/apache/http/conn/ssl/StrictHostnameVerifier")
+  StrictHostnameVerifier();
+  void verify(std::shared_ptr<FakeJni::JString> s,
+              std::shared_ptr<X509Certificate> cert);
 };

--- a/src/jni/cert_manager.h
+++ b/src/jni/cert_manager.h
@@ -1,72 +1,66 @@
 #pragma once
 
+#include <fake-jni/fake-jni.h>
 #include "../text_input_handler.h"
 #include "java_types.h"
-#include <fake-jni/fake-jni.h>
 
-class InputStream : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("java/io/InputStream")
+class InputStream : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/io/InputStream")
 };
 
-class ByteArrayInputStream : public InputStream {
-
-public:
-  DEFINE_CLASS_NAME("java/io/ByteArrayInputStream", InputStream)
-  ByteArrayInputStream(std::shared_ptr<FakeJni::JByteArray> bytes);
+class ByteArrayInputStream : public InputStream
+{
+   public:
+    DEFINE_CLASS_NAME("java/io/ByteArrayInputStream", InputStream)
+    ByteArrayInputStream(std::shared_ptr<FakeJni::JByteArray> bytes);
 };
 
-class Certificate : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("java/security/cert/Certificate")
+class Certificate : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/security/cert/Certificate")
 };
 
-class X509Certificate : public Certificate {
-
-public:
-  DEFINE_CLASS_NAME(
-      "org/apache/http/conn/ssl/java/security/cert/X509Certificate",
-      Certificate)
+class X509Certificate : public Certificate
+{
+   public:
+    DEFINE_CLASS_NAME("org/apache/http/conn/ssl/java/security/cert/X509Certificate", Certificate)
 };
 
-class CertificateFactory : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("java/security/cert/CertificateFactory")
-  static std::shared_ptr<CertificateFactory>
-  getInstance(std::shared_ptr<FakeJni::JString> s);
-  std::shared_ptr<Certificate>
-  generateCertificate(std::shared_ptr<InputStream> s);
+class CertificateFactory : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/security/cert/CertificateFactory")
+    static std::shared_ptr<CertificateFactory> getInstance(std::shared_ptr<FakeJni::JString> s);
+    std::shared_ptr<Certificate> generateCertificate(std::shared_ptr<InputStream> s);
 };
 
-class TrustManager : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("javax/net/ssl/TrustManager")
+class TrustManager : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("javax/net/ssl/TrustManager")
 };
 
-class X509TrustManager : public TrustManager {
-
-public:
-  DEFINE_CLASS_NAME("javax/net/ssl/X509TrustManager", TrustManager)
+class X509TrustManager : public TrustManager
+{
+   public:
+    DEFINE_CLASS_NAME("javax/net/ssl/X509TrustManager", TrustManager)
 };
 
-class TrustManagerFactory : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("javax/net/ssl/TrustManagerFactory")
-  static std::shared_ptr<TrustManagerFactory>
-  getInstance(std::shared_ptr<FakeJni::JString> s);
-  std::shared_ptr<FakeJni::JArray<TrustManager>> getTrustManagers();
+class TrustManagerFactory : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("javax/net/ssl/TrustManagerFactory")
+    static std::shared_ptr<TrustManagerFactory> getInstance(std::shared_ptr<FakeJni::JString> s);
+    std::shared_ptr<FakeJni::JArray<TrustManager>> getTrustManagers();
 };
 
-class StrictHostnameVerifier : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("org/apache/http/conn/ssl/StrictHostnameVerifier")
-  StrictHostnameVerifier();
-  void verify(std::shared_ptr<FakeJni::JString> s,
-              std::shared_ptr<X509Certificate> cert);
+class StrictHostnameVerifier : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("org/apache/http/conn/ssl/StrictHostnameVerifier")
+    StrictHostnameVerifier();
+    void verify(std::shared_ptr<FakeJni::JString> s, std::shared_ptr<X509Certificate> cert);
 };

--- a/src/jni/cert_manager.h
+++ b/src/jni/cert_manager.h
@@ -4,61 +4,52 @@
 #include "../text_input_handler.h"
 #include "java_types.h"
 
-class InputStream : public FakeJni::JObject
-{
+class InputStream : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/io/InputStream")
 };
 
-class ByteArrayInputStream : public InputStream
-{
+class ByteArrayInputStream : public InputStream {
    public:
     DEFINE_CLASS_NAME("java/io/ByteArrayInputStream", InputStream)
     ByteArrayInputStream(std::shared_ptr<FakeJni::JByteArray> bytes);
 };
 
-class Certificate : public FakeJni::JObject
-{
+class Certificate : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/security/cert/Certificate")
 };
 
-class X509Certificate : public Certificate
-{
+class X509Certificate : public Certificate {
    public:
     DEFINE_CLASS_NAME("org/apache/http/conn/ssl/java/security/cert/X509Certificate", Certificate)
 };
 
-class CertificateFactory : public FakeJni::JObject
-{
+class CertificateFactory : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/security/cert/CertificateFactory")
     static std::shared_ptr<CertificateFactory> getInstance(std::shared_ptr<FakeJni::JString> s);
     std::shared_ptr<Certificate> generateCertificate(std::shared_ptr<InputStream> s);
 };
 
-class TrustManager : public FakeJni::JObject
-{
+class TrustManager : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("javax/net/ssl/TrustManager")
 };
 
-class X509TrustManager : public TrustManager
-{
+class X509TrustManager : public TrustManager {
    public:
     DEFINE_CLASS_NAME("javax/net/ssl/X509TrustManager", TrustManager)
 };
 
-class TrustManagerFactory : public FakeJni::JObject
-{
+class TrustManagerFactory : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("javax/net/ssl/TrustManagerFactory")
     static std::shared_ptr<TrustManagerFactory> getInstance(std::shared_ptr<FakeJni::JString> s);
     std::shared_ptr<FakeJni::JArray<TrustManager>> getTrustManagers();
 };
 
-class StrictHostnameVerifier : public FakeJni::JObject
-{
+class StrictHostnameVerifier : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("org/apache/http/conn/ssl/StrictHostnameVerifier")
     StrictHostnameVerifier();

--- a/src/jni/ecdsa.cpp
+++ b/src/jni/ecdsa.cpp
@@ -6,60 +6,48 @@ EC_KEY *Ecdsa::eckey = NULL;
 EC_GROUP *Ecdsa::ecgroup = NULL;
 std::shared_ptr<FakeJni::JString> Ecdsa::unique_id = NULL;
 
-Ecdsa::~Ecdsa()
-{
+Ecdsa::~Ecdsa() {
     EC_KEY_free(eckey);
     EC_GROUP_free(ecgroup);
 }
 
-void Ecdsa::generateKey(std::shared_ptr<FakeJni::JString> unique_id)
-{
+void Ecdsa::generateKey(std::shared_ptr<FakeJni::JString> unique_id) {
     this->unique_id = unique_id;
     ecgroup = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);  // openssl alias of secp256r1
-    if (!ecgroup)
-    {
+    if (!ecgroup) {
         throw std::runtime_error("OpenSSL failed to allocate group prime256v1");
     }
     eckey = EC_KEY_new();
-    if (!eckey)
-    {
+    if (!eckey) {
         throw std::runtime_error("OpenSSL failed to allocate eckey");
     }
-    if (EC_KEY_set_group(eckey, ecgroup) != 1)
-    {
+    if (EC_KEY_set_group(eckey, ecgroup) != 1) {
         throw std::runtime_error("OpenSSL failed to get affine coordinates");
     }
-    if (EC_KEY_generate_key(eckey) != 1)
-    {
+    if (EC_KEY_generate_key(eckey) != 1) {
         throw std::runtime_error("OpenSSL failed to get affine coordinates");
     }
 }
 
-std::shared_ptr<FakeJni::JByteArray> Ecdsa::sign(std::shared_ptr<FakeJni::JByteArray> a)
-{
+std::shared_ptr<FakeJni::JByteArray> Ecdsa::sign(std::shared_ptr<FakeJni::JByteArray> a) {
     ECDSA_SIG *sig = ECDSA_do_sign((const unsigned char *)a->getArray(), a->getSize(), eckey);
-    if (!sig)
-    {
+    if (!sig) {
         throw std::runtime_error("OpenSSL failed to sign bytearray");
     }
     auto n = (EC_GROUP_order_bits(ecgroup) + 7) / 8;
     const BIGNUM *r = ECDSA_SIG_get0_r(sig);
-    if (!r)
-    {
+    if (!r) {
         throw std::runtime_error("OpenSSL failed to get r");
     }
     const BIGNUM *s = ECDSA_SIG_get0_s(sig);
-    if (!s)
-    {
+    if (!s) {
         throw std::runtime_error("OpenSSL failed to get s");
     }
     auto buf = std::make_shared<FakeJni::JByteArray>(2 * n);
-    if (BN_bn2binpad(r, (unsigned char *)buf->getArray(), n) != n)
-    {
+    if (BN_bn2binpad(r, (unsigned char *)buf->getArray(), n) != n) {
         throw std::runtime_error("OpenSSL failed to export bignum");
     }
-    if (BN_bn2binpad(s, (unsigned char *)buf->getArray() + n, n) != n)
-    {
+    if (BN_bn2binpad(s, (unsigned char *)buf->getArray() + n, n) != n) {
         throw std::runtime_error("OpenSSL failed to export bignum");
     }
     ECDSA_SIG_free(sig);
@@ -70,53 +58,43 @@ std::shared_ptr<EcdsaPublicKey> Ecdsa::getPublicKey() { return std::make_shared<
 
 std::shared_ptr<FakeJni::JString> Ecdsa::getUniqueId() { return unique_id; }
 
-std::shared_ptr<Ecdsa> Ecdsa::restoreKeyAndId(std::shared_ptr<Context> ctx)
-{
-    if (eckey == NULL || ecgroup == NULL)
-    {
+std::shared_ptr<Ecdsa> Ecdsa::restoreKeyAndId(std::shared_ptr<Context> ctx) {
+    if (eckey == NULL || ecgroup == NULL) {
         return nullptr;
     }
     return std::make_shared<Ecdsa>();
 }
 
-EcdsaPublicKey::EcdsaPublicKey(EC_KEY *eckey, EC_GROUP *ecgroup)
-{
+EcdsaPublicKey::EcdsaPublicKey(EC_KEY *eckey, EC_GROUP *ecgroup) {
     const EC_POINT *point = EC_KEY_get0_public_key(eckey);
-    if (!point)
-    {
+    if (!point) {
         throw std::runtime_error("OpenSSL failed to get ecdsa public key");
     }
     BIGNUM *x = BN_new(), *y = BN_new();
-    if (!x || !y)
-    {
+    if (!x || !y) {
         throw std::runtime_error("OpenSSL failed to allocate bignum");
     }
-    if (EC_POINT_get_affine_coordinates(ecgroup, point, x, y, NULL) != 1)
-    {
+    if (EC_POINT_get_affine_coordinates(ecgroup, point, x, y, NULL) != 1) {
         throw std::runtime_error("OpenSSL failed to get affine coordinates");
     }
     auto len = BN_num_bytes(x);
     std::string buf(len, '_');
-    if (BN_bn2bin(x, (unsigned char *)buf.data()) != len)
-    {
+    if (BN_bn2bin(x, (unsigned char *)buf.data()) != len) {
         throw std::runtime_error("OpenSSL failed to export bignum");
     }
     xbase64 = Base64::encode(buf);
     len = BN_num_bytes(y);
     buf = std::string(len, '_');
-    if (BN_bn2bin(y, (unsigned char *)buf.data()) != len)
-    {
+    if (BN_bn2bin(y, (unsigned char *)buf.data()) != len) {
         throw std::runtime_error("OpenSSL failed to export bignum");
     }
     ybase64 = Base64::encode(buf);
 }
 
-std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlX()
-{
+std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlX() {
     return std::make_shared<FakeJni::JString>(xbase64);
 }
 
-std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlY()
-{
+std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlY() {
     return std::make_shared<FakeJni::JString>(ybase64);
 }

--- a/src/jni/ecdsa.cpp
+++ b/src/jni/ecdsa.cpp
@@ -6,100 +6,117 @@ EC_KEY *Ecdsa::eckey = NULL;
 EC_GROUP *Ecdsa::ecgroup = NULL;
 std::shared_ptr<FakeJni::JString> Ecdsa::unique_id = NULL;
 
-Ecdsa::~Ecdsa() {
-  EC_KEY_free(eckey);
-  EC_GROUP_free(ecgroup);
+Ecdsa::~Ecdsa()
+{
+    EC_KEY_free(eckey);
+    EC_GROUP_free(ecgroup);
 }
 
-void Ecdsa::generateKey(std::shared_ptr<FakeJni::JString> unique_id) {
-  this->unique_id = unique_id;
-  ecgroup = EC_GROUP_new_by_curve_name(
-      NID_X9_62_prime256v1); // openssl alias of secp256r1
-  if (!ecgroup) {
-    throw std::runtime_error("OpenSSL failed to allocate group prime256v1");
-  }
-  eckey = EC_KEY_new();
-  if (!eckey) {
-    throw std::runtime_error("OpenSSL failed to allocate eckey");
-  }
-  if (EC_KEY_set_group(eckey, ecgroup) != 1) {
-    throw std::runtime_error("OpenSSL failed to get affine coordinates");
-  }
-  if (EC_KEY_generate_key(eckey) != 1) {
-    throw std::runtime_error("OpenSSL failed to get affine coordinates");
-  }
+void Ecdsa::generateKey(std::shared_ptr<FakeJni::JString> unique_id)
+{
+    this->unique_id = unique_id;
+    ecgroup = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);  // openssl alias of secp256r1
+    if (!ecgroup)
+    {
+        throw std::runtime_error("OpenSSL failed to allocate group prime256v1");
+    }
+    eckey = EC_KEY_new();
+    if (!eckey)
+    {
+        throw std::runtime_error("OpenSSL failed to allocate eckey");
+    }
+    if (EC_KEY_set_group(eckey, ecgroup) != 1)
+    {
+        throw std::runtime_error("OpenSSL failed to get affine coordinates");
+    }
+    if (EC_KEY_generate_key(eckey) != 1)
+    {
+        throw std::runtime_error("OpenSSL failed to get affine coordinates");
+    }
 }
 
-std::shared_ptr<FakeJni::JByteArray>
-Ecdsa::sign(std::shared_ptr<FakeJni::JByteArray> a) {
-  ECDSA_SIG *sig =
-      ECDSA_do_sign((const unsigned char *)a->getArray(), a->getSize(), eckey);
-  if (!sig) {
-    throw std::runtime_error("OpenSSL failed to sign bytearray");
-  }
-  auto n = (EC_GROUP_order_bits(ecgroup) + 7) / 8;
-  const BIGNUM *r = ECDSA_SIG_get0_r(sig);
-  if (!r) {
-    throw std::runtime_error("OpenSSL failed to get r");
-  }
-  const BIGNUM *s = ECDSA_SIG_get0_s(sig);
-  if (!s) {
-    throw std::runtime_error("OpenSSL failed to get s");
-  }
-  auto buf = std::make_shared<FakeJni::JByteArray>(2 * n);
-  if (BN_bn2binpad(r, (unsigned char *)buf->getArray(), n) != n) {
-    throw std::runtime_error("OpenSSL failed to export bignum");
-  }
-  if (BN_bn2binpad(s, (unsigned char *)buf->getArray() + n, n) != n) {
-    throw std::runtime_error("OpenSSL failed to export bignum");
-  }
-  ECDSA_SIG_free(sig);
-  return buf;
+std::shared_ptr<FakeJni::JByteArray> Ecdsa::sign(std::shared_ptr<FakeJni::JByteArray> a)
+{
+    ECDSA_SIG *sig = ECDSA_do_sign((const unsigned char *)a->getArray(), a->getSize(), eckey);
+    if (!sig)
+    {
+        throw std::runtime_error("OpenSSL failed to sign bytearray");
+    }
+    auto n = (EC_GROUP_order_bits(ecgroup) + 7) / 8;
+    const BIGNUM *r = ECDSA_SIG_get0_r(sig);
+    if (!r)
+    {
+        throw std::runtime_error("OpenSSL failed to get r");
+    }
+    const BIGNUM *s = ECDSA_SIG_get0_s(sig);
+    if (!s)
+    {
+        throw std::runtime_error("OpenSSL failed to get s");
+    }
+    auto buf = std::make_shared<FakeJni::JByteArray>(2 * n);
+    if (BN_bn2binpad(r, (unsigned char *)buf->getArray(), n) != n)
+    {
+        throw std::runtime_error("OpenSSL failed to export bignum");
+    }
+    if (BN_bn2binpad(s, (unsigned char *)buf->getArray() + n, n) != n)
+    {
+        throw std::runtime_error("OpenSSL failed to export bignum");
+    }
+    ECDSA_SIG_free(sig);
+    return buf;
 }
 
-std::shared_ptr<EcdsaPublicKey> Ecdsa::getPublicKey() {
-  return std::make_shared<EcdsaPublicKey>(eckey, ecgroup);
-}
+std::shared_ptr<EcdsaPublicKey> Ecdsa::getPublicKey() { return std::make_shared<EcdsaPublicKey>(eckey, ecgroup); }
 
 std::shared_ptr<FakeJni::JString> Ecdsa::getUniqueId() { return unique_id; }
 
-std::shared_ptr<Ecdsa> Ecdsa::restoreKeyAndId(std::shared_ptr<Context> ctx) {
-  if (eckey == NULL || ecgroup == NULL) {
-    return nullptr;
-  }
-  return std::make_shared<Ecdsa>();
+std::shared_ptr<Ecdsa> Ecdsa::restoreKeyAndId(std::shared_ptr<Context> ctx)
+{
+    if (eckey == NULL || ecgroup == NULL)
+    {
+        return nullptr;
+    }
+    return std::make_shared<Ecdsa>();
 }
 
-EcdsaPublicKey::EcdsaPublicKey(EC_KEY *eckey, EC_GROUP *ecgroup) {
-  const EC_POINT *point = EC_KEY_get0_public_key(eckey);
-  if (!point) {
-    throw std::runtime_error("OpenSSL failed to get ecdsa public key");
-  }
-  BIGNUM *x = BN_new(), *y = BN_new();
-  if (!x || !y) {
-    throw std::runtime_error("OpenSSL failed to allocate bignum");
-  }
-  if (EC_POINT_get_affine_coordinates(ecgroup, point, x, y, NULL) != 1) {
-    throw std::runtime_error("OpenSSL failed to get affine coordinates");
-  }
-  auto len = BN_num_bytes(x);
-  std::string buf(len, '_');
-  if (BN_bn2bin(x, (unsigned char *)buf.data()) != len) {
-    throw std::runtime_error("OpenSSL failed to export bignum");
-  }
-  xbase64 = Base64::encode(buf);
-  len = BN_num_bytes(y);
-  buf = std::string(len, '_');
-  if (BN_bn2bin(y, (unsigned char *)buf.data()) != len) {
-    throw std::runtime_error("OpenSSL failed to export bignum");
-  }
-  ybase64 = Base64::encode(buf);
+EcdsaPublicKey::EcdsaPublicKey(EC_KEY *eckey, EC_GROUP *ecgroup)
+{
+    const EC_POINT *point = EC_KEY_get0_public_key(eckey);
+    if (!point)
+    {
+        throw std::runtime_error("OpenSSL failed to get ecdsa public key");
+    }
+    BIGNUM *x = BN_new(), *y = BN_new();
+    if (!x || !y)
+    {
+        throw std::runtime_error("OpenSSL failed to allocate bignum");
+    }
+    if (EC_POINT_get_affine_coordinates(ecgroup, point, x, y, NULL) != 1)
+    {
+        throw std::runtime_error("OpenSSL failed to get affine coordinates");
+    }
+    auto len = BN_num_bytes(x);
+    std::string buf(len, '_');
+    if (BN_bn2bin(x, (unsigned char *)buf.data()) != len)
+    {
+        throw std::runtime_error("OpenSSL failed to export bignum");
+    }
+    xbase64 = Base64::encode(buf);
+    len = BN_num_bytes(y);
+    buf = std::string(len, '_');
+    if (BN_bn2bin(y, (unsigned char *)buf.data()) != len)
+    {
+        throw std::runtime_error("OpenSSL failed to export bignum");
+    }
+    ybase64 = Base64::encode(buf);
 }
 
-std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlX() {
-  return std::make_shared<FakeJni::JString>(xbase64);
+std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlX()
+{
+    return std::make_shared<FakeJni::JString>(xbase64);
 }
 
-std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlY() {
-  return std::make_shared<FakeJni::JString>(ybase64);
+std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlY()
+{
+    return std::make_shared<FakeJni::JString>(ybase64);
 }

--- a/src/jni/ecdsa.cpp
+++ b/src/jni/ecdsa.cpp
@@ -7,98 +7,99 @@ EC_GROUP *Ecdsa::ecgroup = NULL;
 std::shared_ptr<FakeJni::JString> Ecdsa::unique_id = NULL;
 
 Ecdsa::~Ecdsa() {
-    EC_KEY_free(eckey);
-    EC_GROUP_free(ecgroup);
+  EC_KEY_free(eckey);
+  EC_GROUP_free(ecgroup);
 }
 
 void Ecdsa::generateKey(std::shared_ptr<FakeJni::JString> unique_id) {
-    this->unique_id = unique_id;
-    ecgroup = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1); //openssl alias of secp256r1
-    if (!ecgroup) {
-        throw std::runtime_error("OpenSSL failed to allocate group prime256v1");
-    }
-    eckey = EC_KEY_new();
-    if (!eckey) {
-        throw std::runtime_error("OpenSSL failed to allocate eckey");
-    }
-    if (EC_KEY_set_group(eckey, ecgroup) != 1) {
-        throw std::runtime_error("OpenSSL failed to get affine coordinates");
-    }
-    if (EC_KEY_generate_key(eckey) != 1) {
-        throw std::runtime_error("OpenSSL failed to get affine coordinates");
-    }
+  this->unique_id = unique_id;
+  ecgroup = EC_GROUP_new_by_curve_name(
+      NID_X9_62_prime256v1); // openssl alias of secp256r1
+  if (!ecgroup) {
+    throw std::runtime_error("OpenSSL failed to allocate group prime256v1");
+  }
+  eckey = EC_KEY_new();
+  if (!eckey) {
+    throw std::runtime_error("OpenSSL failed to allocate eckey");
+  }
+  if (EC_KEY_set_group(eckey, ecgroup) != 1) {
+    throw std::runtime_error("OpenSSL failed to get affine coordinates");
+  }
+  if (EC_KEY_generate_key(eckey) != 1) {
+    throw std::runtime_error("OpenSSL failed to get affine coordinates");
+  }
 }
 
-std::shared_ptr<FakeJni::JByteArray> Ecdsa::sign(std::shared_ptr<FakeJni::JByteArray> a) {
-    ECDSA_SIG * sig = ECDSA_do_sign((const unsigned char*)a->getArray(), a->getSize(), eckey);
-    if (!sig) {
-        throw std::runtime_error("OpenSSL failed to sign bytearray");
-    }
-    auto n = (EC_GROUP_order_bits(ecgroup) + 7) / 8;
-    const BIGNUM* r = ECDSA_SIG_get0_r(sig);
-    if (!r) {
-        throw std::runtime_error("OpenSSL failed to get r");
-    }
-    const BIGNUM* s = ECDSA_SIG_get0_s(sig);
-    if (!s) {
-        throw std::runtime_error("OpenSSL failed to get s");
-    }
-    auto buf = std::make_shared<FakeJni::JByteArray>(2 * n);
-    if (BN_bn2binpad(r, (unsigned char*)buf->getArray(), n) != n) {
-        throw std::runtime_error("OpenSSL failed to export bignum");
-    }
-    if (BN_bn2binpad(s, (unsigned char*)buf->getArray() + n, n) != n) {
-        throw std::runtime_error("OpenSSL failed to export bignum");
-    }
-    ECDSA_SIG_free(sig);
-    return buf;
+std::shared_ptr<FakeJni::JByteArray>
+Ecdsa::sign(std::shared_ptr<FakeJni::JByteArray> a) {
+  ECDSA_SIG *sig =
+      ECDSA_do_sign((const unsigned char *)a->getArray(), a->getSize(), eckey);
+  if (!sig) {
+    throw std::runtime_error("OpenSSL failed to sign bytearray");
+  }
+  auto n = (EC_GROUP_order_bits(ecgroup) + 7) / 8;
+  const BIGNUM *r = ECDSA_SIG_get0_r(sig);
+  if (!r) {
+    throw std::runtime_error("OpenSSL failed to get r");
+  }
+  const BIGNUM *s = ECDSA_SIG_get0_s(sig);
+  if (!s) {
+    throw std::runtime_error("OpenSSL failed to get s");
+  }
+  auto buf = std::make_shared<FakeJni::JByteArray>(2 * n);
+  if (BN_bn2binpad(r, (unsigned char *)buf->getArray(), n) != n) {
+    throw std::runtime_error("OpenSSL failed to export bignum");
+  }
+  if (BN_bn2binpad(s, (unsigned char *)buf->getArray() + n, n) != n) {
+    throw std::runtime_error("OpenSSL failed to export bignum");
+  }
+  ECDSA_SIG_free(sig);
+  return buf;
 }
 
 std::shared_ptr<EcdsaPublicKey> Ecdsa::getPublicKey() {
-    return std::make_shared<EcdsaPublicKey>(eckey, ecgroup);
+  return std::make_shared<EcdsaPublicKey>(eckey, ecgroup);
 }
 
-std::shared_ptr<FakeJni::JString> Ecdsa::getUniqueId() {
-    return unique_id;
-}
+std::shared_ptr<FakeJni::JString> Ecdsa::getUniqueId() { return unique_id; }
 
 std::shared_ptr<Ecdsa> Ecdsa::restoreKeyAndId(std::shared_ptr<Context> ctx) {
-    if(eckey == NULL || ecgroup == NULL) {
-        return nullptr;
-    }
-    return std::make_shared<Ecdsa>();
+  if (eckey == NULL || ecgroup == NULL) {
+    return nullptr;
+  }
+  return std::make_shared<Ecdsa>();
 }
 
 EcdsaPublicKey::EcdsaPublicKey(EC_KEY *eckey, EC_GROUP *ecgroup) {
-    const EC_POINT * point = EC_KEY_get0_public_key(eckey);
-    if (!point) {
-        throw std::runtime_error("OpenSSL failed to get ecdsa public key");
-    }
-    BIGNUM *x = BN_new(), *y = BN_new();
-    if (!x || !y) {
-        throw std::runtime_error("OpenSSL failed to allocate bignum");
-    }
-    if (EC_POINT_get_affine_coordinates(ecgroup, point, x, y, NULL) != 1) {
-        throw std::runtime_error("OpenSSL failed to get affine coordinates");
-    }
-    auto len = BN_num_bytes(x);
-    std::string buf(len, '_');
-    if (BN_bn2bin(x, (unsigned char*)buf.data()) != len) {
-        throw std::runtime_error("OpenSSL failed to export bignum");
-    }
-    xbase64 = Base64::encode(buf);
-    len = BN_num_bytes(y);
-    buf = std::string(len, '_');
-    if (BN_bn2bin(y, (unsigned char*)buf.data()) != len) {
-        throw std::runtime_error("OpenSSL failed to export bignum");
-    }
-    ybase64 = Base64::encode(buf);
+  const EC_POINT *point = EC_KEY_get0_public_key(eckey);
+  if (!point) {
+    throw std::runtime_error("OpenSSL failed to get ecdsa public key");
+  }
+  BIGNUM *x = BN_new(), *y = BN_new();
+  if (!x || !y) {
+    throw std::runtime_error("OpenSSL failed to allocate bignum");
+  }
+  if (EC_POINT_get_affine_coordinates(ecgroup, point, x, y, NULL) != 1) {
+    throw std::runtime_error("OpenSSL failed to get affine coordinates");
+  }
+  auto len = BN_num_bytes(x);
+  std::string buf(len, '_');
+  if (BN_bn2bin(x, (unsigned char *)buf.data()) != len) {
+    throw std::runtime_error("OpenSSL failed to export bignum");
+  }
+  xbase64 = Base64::encode(buf);
+  len = BN_num_bytes(y);
+  buf = std::string(len, '_');
+  if (BN_bn2bin(y, (unsigned char *)buf.data()) != len) {
+    throw std::runtime_error("OpenSSL failed to export bignum");
+  }
+  ybase64 = Base64::encode(buf);
 }
 
 std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlX() {
-    return std::make_shared<FakeJni::JString>(xbase64);
+  return std::make_shared<FakeJni::JString>(xbase64);
 }
 
 std::shared_ptr<FakeJni::JString> EcdsaPublicKey::getBase64UrlY() {
-    return std::make_shared<FakeJni::JString>(ybase64);
+  return std::make_shared<FakeJni::JString>(ybase64);
 }

--- a/src/jni/ecdsa.h
+++ b/src/jni/ecdsa.h
@@ -1,46 +1,47 @@
 #pragma once
+#include "main_activity.h"
+#include <base64.h>
 #include <fake-jni/fake-jni.h>
+#include <openssl/bn.h>
 #include <openssl/ecdsa.h>
 #include <openssl/obj_mac.h>
-#include <openssl/bn.h>
-#include <utility>
-#include <base64.h>
 #include <stdexcept>
 #include <string>
-#include "main_activity.h"
+#include <utility>
 
 class EcdsaPublicKey : public FakeJni::JObject {
-    std::string xbase64;
-    std::string ybase64;
+  std::string xbase64;
+  std::string ybase64;
+
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xal/crypto/EccPubKey")
+  DEFINE_CLASS_NAME("com/microsoft/xal/crypto/EccPubKey")
 
-    EcdsaPublicKey(EC_KEY * eckey, EC_GROUP * ecgroup);
+  EcdsaPublicKey(EC_KEY *eckey, EC_GROUP *ecgroup);
 
-    std::shared_ptr<FakeJni::JString> getBase64UrlX();
+  std::shared_ptr<FakeJni::JString> getBase64UrlX();
 
-    std::shared_ptr<FakeJni::JString> getBase64UrlY();
+  std::shared_ptr<FakeJni::JString> getBase64UrlY();
 };
 
 class Ecdsa : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xal/crypto/Ecdsa")
-    Ecdsa();
+  DEFINE_CLASS_NAME("com/microsoft/xal/crypto/Ecdsa")
+  Ecdsa();
 
-    ~Ecdsa();
+  ~Ecdsa();
 
-    void generateKey(std::shared_ptr<FakeJni::JString> unique_id);
+  void generateKey(std::shared_ptr<FakeJni::JString> unique_id);
 
-    static EC_KEY * eckey;
-    static EC_GROUP * ecgroup;
-    static std::shared_ptr<FakeJni::JString> unique_id;
+  static EC_KEY *eckey;
+  static EC_GROUP *ecgroup;
+  static std::shared_ptr<FakeJni::JString> unique_id;
 
-    std::shared_ptr<FakeJni::JByteArray> sign(std::shared_ptr<FakeJni::JByteArray> a);
+  std::shared_ptr<FakeJni::JByteArray>
+  sign(std::shared_ptr<FakeJni::JByteArray> a);
 
-    std::shared_ptr<EcdsaPublicKey> getPublicKey();
+  std::shared_ptr<EcdsaPublicKey> getPublicKey();
 
-    std::shared_ptr<FakeJni::JString> getUniqueId();
+  std::shared_ptr<FakeJni::JString> getUniqueId();
 
-    static std::shared_ptr<Ecdsa> restoreKeyAndId(std::shared_ptr<Context> ctx);
-    
+  static std::shared_ptr<Ecdsa> restoreKeyAndId(std::shared_ptr<Context> ctx);
 };

--- a/src/jni/ecdsa.h
+++ b/src/jni/ecdsa.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "main_activity.h"
 #include <base64.h>
 #include <fake-jni/fake-jni.h>
 #include <openssl/bn.h>
@@ -8,40 +7,42 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include "main_activity.h"
 
-class EcdsaPublicKey : public FakeJni::JObject {
-  std::string xbase64;
-  std::string ybase64;
+class EcdsaPublicKey : public FakeJni::JObject
+{
+    std::string xbase64;
+    std::string ybase64;
 
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xal/crypto/EccPubKey")
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xal/crypto/EccPubKey")
 
-  EcdsaPublicKey(EC_KEY *eckey, EC_GROUP *ecgroup);
+    EcdsaPublicKey(EC_KEY *eckey, EC_GROUP *ecgroup);
 
-  std::shared_ptr<FakeJni::JString> getBase64UrlX();
+    std::shared_ptr<FakeJni::JString> getBase64UrlX();
 
-  std::shared_ptr<FakeJni::JString> getBase64UrlY();
+    std::shared_ptr<FakeJni::JString> getBase64UrlY();
 };
 
-class Ecdsa : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xal/crypto/Ecdsa")
-  Ecdsa();
+class Ecdsa : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xal/crypto/Ecdsa")
+    Ecdsa();
 
-  ~Ecdsa();
+    ~Ecdsa();
 
-  void generateKey(std::shared_ptr<FakeJni::JString> unique_id);
+    void generateKey(std::shared_ptr<FakeJni::JString> unique_id);
 
-  static EC_KEY *eckey;
-  static EC_GROUP *ecgroup;
-  static std::shared_ptr<FakeJni::JString> unique_id;
+    static EC_KEY *eckey;
+    static EC_GROUP *ecgroup;
+    static std::shared_ptr<FakeJni::JString> unique_id;
 
-  std::shared_ptr<FakeJni::JByteArray>
-  sign(std::shared_ptr<FakeJni::JByteArray> a);
+    std::shared_ptr<FakeJni::JByteArray> sign(std::shared_ptr<FakeJni::JByteArray> a);
 
-  std::shared_ptr<EcdsaPublicKey> getPublicKey();
+    std::shared_ptr<EcdsaPublicKey> getPublicKey();
 
-  std::shared_ptr<FakeJni::JString> getUniqueId();
+    std::shared_ptr<FakeJni::JString> getUniqueId();
 
-  static std::shared_ptr<Ecdsa> restoreKeyAndId(std::shared_ptr<Context> ctx);
+    static std::shared_ptr<Ecdsa> restoreKeyAndId(std::shared_ptr<Context> ctx);
 };

--- a/src/jni/ecdsa.h
+++ b/src/jni/ecdsa.h
@@ -9,8 +9,7 @@
 #include <utility>
 #include "main_activity.h"
 
-class EcdsaPublicKey : public FakeJni::JObject
-{
+class EcdsaPublicKey : public FakeJni::JObject {
     std::string xbase64;
     std::string ybase64;
 
@@ -24,8 +23,7 @@ class EcdsaPublicKey : public FakeJni::JObject
     std::shared_ptr<FakeJni::JString> getBase64UrlY();
 };
 
-class Ecdsa : public FakeJni::JObject
-{
+class Ecdsa : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/microsoft/xal/crypto/Ecdsa")
     Ecdsa();

--- a/src/jni/http_stub.cpp
+++ b/src/jni/http_stub.cpp
@@ -4,14 +4,13 @@
 
 jint HTTPResponse::getStatus() { return 1; }
 
-std::shared_ptr<FakeJni::JString> HTTPResponse::getBody() {
-  return std::make_shared<FakeJni::JString>();
-}
+std::shared_ptr<FakeJni::JString> HTTPResponse::getBody() { return std::make_shared<FakeJni::JString>(); }
 
 jint HTTPResponse::getResponseCode() { return 200; }
 
-std::shared_ptr<FakeJni::JArray<Header>> HTTPResponse::getHeaders() {
-  return std::make_shared<FakeJni::JArray<Header>>();
+std::shared_ptr<FakeJni::JArray<Header>> HTTPResponse::getHeaders()
+{
+    return std::make_shared<FakeJni::JArray<Header>>();
 }
 
 HTTPRequest::HTTPRequest() {}
@@ -24,9 +23,9 @@ void HTTPRequest::setCookieData(std::shared_ptr<FakeJni::JString> arg0) {}
 
 void HTTPRequest::setContentType(std::shared_ptr<FakeJni::JString> arg0) {}
 
-std::shared_ptr<HTTPResponse>
-HTTPRequest::send(std::shared_ptr<FakeJni::JString> arg0) {
-  return std::make_shared<HTTPResponse>();
+std::shared_ptr<HTTPResponse> HTTPRequest::send(std::shared_ptr<FakeJni::JString> arg0)
+{
+    return std::make_shared<HTTPResponse>();
 }
 
 void HTTPRequest::abort() {}

--- a/src/jni/http_stub.cpp
+++ b/src/jni/http_stub.cpp
@@ -2,46 +2,31 @@
 // Never called since Minecraft 1.13
 // Pre 1.13 compatibility
 
-jint HTTPResponse::getStatus() {
-    return 1;
-}
+jint HTTPResponse::getStatus() { return 1; }
 
 std::shared_ptr<FakeJni::JString> HTTPResponse::getBody() {
-    return std::make_shared<FakeJni::JString>();
+  return std::make_shared<FakeJni::JString>();
 }
 
-jint HTTPResponse::getResponseCode() {
-    return 200;
-}
+jint HTTPResponse::getResponseCode() { return 200; }
 
 std::shared_ptr<FakeJni::JArray<Header>> HTTPResponse::getHeaders() {
-    return std::make_shared<FakeJni::JArray<Header>>();
+  return std::make_shared<FakeJni::JArray<Header>>();
 }
 
-HTTPRequest::HTTPRequest() {
-    
+HTTPRequest::HTTPRequest() {}
+
+void HTTPRequest::setURL(std::shared_ptr<FakeJni::JString> arg0) {}
+
+void HTTPRequest::setRequestBody(std::shared_ptr<FakeJni::JString> arg0) {}
+
+void HTTPRequest::setCookieData(std::shared_ptr<FakeJni::JString> arg0) {}
+
+void HTTPRequest::setContentType(std::shared_ptr<FakeJni::JString> arg0) {}
+
+std::shared_ptr<HTTPResponse>
+HTTPRequest::send(std::shared_ptr<FakeJni::JString> arg0) {
+  return std::make_shared<HTTPResponse>();
 }
 
-void HTTPRequest::setURL(std::shared_ptr<FakeJni::JString> arg0) {
-    
-}
-
-void HTTPRequest::setRequestBody(std::shared_ptr<FakeJni::JString> arg0) {
-    
-}
-
-void HTTPRequest::setCookieData(std::shared_ptr<FakeJni::JString> arg0) {
-    
-}
-
-void HTTPRequest::setContentType(std::shared_ptr<FakeJni::JString> arg0) {
-    
-}
-
-std::shared_ptr<HTTPResponse> HTTPRequest::send(std::shared_ptr<FakeJni::JString> arg0) {
-    return std::make_shared<HTTPResponse>();
-}
-
-void HTTPRequest::abort() {
-    
-}
+void HTTPRequest::abort() {}

--- a/src/jni/http_stub.cpp
+++ b/src/jni/http_stub.cpp
@@ -8,8 +8,7 @@ std::shared_ptr<FakeJni::JString> HTTPResponse::getBody() { return std::make_sha
 
 jint HTTPResponse::getResponseCode() { return 200; }
 
-std::shared_ptr<FakeJni::JArray<Header>> HTTPResponse::getHeaders()
-{
+std::shared_ptr<FakeJni::JArray<Header>> HTTPResponse::getHeaders() {
     return std::make_shared<FakeJni::JArray<Header>>();
 }
 
@@ -23,8 +22,7 @@ void HTTPRequest::setCookieData(std::shared_ptr<FakeJni::JString> arg0) {}
 
 void HTTPRequest::setContentType(std::shared_ptr<FakeJni::JString> arg0) {}
 
-std::shared_ptr<HTTPResponse> HTTPRequest::send(std::shared_ptr<FakeJni::JString> arg0)
-{
+std::shared_ptr<HTTPResponse> HTTPRequest::send(std::shared_ptr<FakeJni::JString> arg0) {
     return std::make_shared<HTTPResponse>();
 }
 

--- a/src/jni/http_stub.h
+++ b/src/jni/http_stub.h
@@ -3,14 +3,12 @@
 #include <fake-jni/fake-jni.h>
 #include "java_types.h"
 
-class Header : public FakeJni::JObject
-{
+class Header : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("org/apache/http/Header")
 };
 
-class HTTPResponse : public FakeJni::JObject
-{
+class HTTPResponse : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/android/net/HTTPResponse")
     jint getStatus();
@@ -18,8 +16,7 @@ class HTTPResponse : public FakeJni::JObject
     jint getResponseCode();
     std::shared_ptr<FakeJni::JArray<Header>> getHeaders();
 };
-class HTTPRequest : public FakeJni::JObject
-{
+class HTTPRequest : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/android/net/HTTPRequest")
     HTTPRequest();

--- a/src/jni/http_stub.h
+++ b/src/jni/http_stub.h
@@ -1,30 +1,29 @@
 #pragma once
 
-#include <fake-jni/fake-jni.h>
 #include "java_types.h"
+#include <fake-jni/fake-jni.h>
 
-class Header : public FakeJni::JObject{
+class Header : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("org/apache/http/Header")
-
+  DEFINE_CLASS_NAME("org/apache/http/Header")
 };
 
 class HTTPResponse : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/mojang/android/net/HTTPResponse")
-    jint getStatus();
-    std::shared_ptr<FakeJni::JString> getBody();
-    jint getResponseCode();
-    std::shared_ptr<FakeJni::JArray<Header>> getHeaders();
+  DEFINE_CLASS_NAME("com/mojang/android/net/HTTPResponse")
+  jint getStatus();
+  std::shared_ptr<FakeJni::JString> getBody();
+  jint getResponseCode();
+  std::shared_ptr<FakeJni::JArray<Header>> getHeaders();
 };
 class HTTPRequest : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/mojang/android/net/HTTPRequest")
-    HTTPRequest();
-    void setURL(std::shared_ptr<FakeJni::JString>);
-    void setRequestBody(std::shared_ptr<FakeJni::JString>);
-    void setCookieData(std::shared_ptr<FakeJni::JString>);
-    void setContentType(std::shared_ptr<FakeJni::JString>);
-    std::shared_ptr<HTTPResponse> send(std::shared_ptr<FakeJni::JString>);
-    void abort();
+  DEFINE_CLASS_NAME("com/mojang/android/net/HTTPRequest")
+  HTTPRequest();
+  void setURL(std::shared_ptr<FakeJni::JString>);
+  void setRequestBody(std::shared_ptr<FakeJni::JString>);
+  void setCookieData(std::shared_ptr<FakeJni::JString>);
+  void setContentType(std::shared_ptr<FakeJni::JString>);
+  std::shared_ptr<HTTPResponse> send(std::shared_ptr<FakeJni::JString>);
+  void abort();
 };

--- a/src/jni/http_stub.h
+++ b/src/jni/http_stub.h
@@ -1,29 +1,32 @@
 #pragma once
 
-#include "java_types.h"
 #include <fake-jni/fake-jni.h>
+#include "java_types.h"
 
-class Header : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("org/apache/http/Header")
+class Header : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("org/apache/http/Header")
 };
 
-class HTTPResponse : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/mojang/android/net/HTTPResponse")
-  jint getStatus();
-  std::shared_ptr<FakeJni::JString> getBody();
-  jint getResponseCode();
-  std::shared_ptr<FakeJni::JArray<Header>> getHeaders();
+class HTTPResponse : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/android/net/HTTPResponse")
+    jint getStatus();
+    std::shared_ptr<FakeJni::JString> getBody();
+    jint getResponseCode();
+    std::shared_ptr<FakeJni::JArray<Header>> getHeaders();
 };
-class HTTPRequest : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/mojang/android/net/HTTPRequest")
-  HTTPRequest();
-  void setURL(std::shared_ptr<FakeJni::JString>);
-  void setRequestBody(std::shared_ptr<FakeJni::JString>);
-  void setCookieData(std::shared_ptr<FakeJni::JString>);
-  void setContentType(std::shared_ptr<FakeJni::JString>);
-  std::shared_ptr<HTTPResponse> send(std::shared_ptr<FakeJni::JString>);
-  void abort();
+class HTTPRequest : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/android/net/HTTPRequest")
+    HTTPRequest();
+    void setURL(std::shared_ptr<FakeJni::JString>);
+    void setRequestBody(std::shared_ptr<FakeJni::JString>);
+    void setCookieData(std::shared_ptr<FakeJni::JString>);
+    void setContentType(std::shared_ptr<FakeJni::JString>);
+    std::shared_ptr<HTTPResponse> send(std::shared_ptr<FakeJni::JString>);
+    void abort();
 };

--- a/src/jni/java_types.h
+++ b/src/jni/java_types.h
@@ -2,8 +2,7 @@
 
 #include <fake-jni/fake-jni.h>
 
-class File : public FakeJni::JObject
-{
+class File : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/io/File")
 
@@ -14,19 +13,16 @@ class File : public FakeJni::JObject
     std::shared_ptr<FakeJni::JString> getPath() { return std::make_shared<FakeJni::JString>(path.c_str()); }
 };
 
-class ClassLoader : public FakeJni::JObject
-{
+class ClassLoader : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/lang/ClassLoader")
 
-    static std::shared_ptr<ClassLoader> getInstance()
-    {
+    static std::shared_ptr<ClassLoader> getInstance() {
         static std::shared_ptr<ClassLoader> instance(new ClassLoader);
         return instance;
     }
 
-    std::shared_ptr<FakeJni::JClass> loadClass(std::shared_ptr<FakeJni::JString> str)
-    {
+    std::shared_ptr<FakeJni::JClass> loadClass(std::shared_ptr<FakeJni::JString> str) {
         FakeJni::JniEnvContext context;
         return std::const_pointer_cast<FakeJni::JClass>(
             context.getJniEnv().getVM().findClass(str->asStdString().c_str()));

--- a/src/jni/java_types.h
+++ b/src/jni/java_types.h
@@ -5,33 +5,31 @@
 class File : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/io/File")
+  DEFINE_CLASS_NAME("java/io/File")
 
-    std::string path;
+  std::string path;
 
-    explicit File(std::string path) : path(std::move(path)) {
-    }
+  explicit File(std::string path) : path(std::move(path)) {}
 
-    std::shared_ptr<FakeJni::JString> getPath() {
-        return std::make_shared<FakeJni::JString>(path.c_str());
-    }
-
+  std::shared_ptr<FakeJni::JString> getPath() {
+    return std::make_shared<FakeJni::JString>(path.c_str());
+  }
 };
 
 class ClassLoader : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/lang/ClassLoader")
+  DEFINE_CLASS_NAME("java/lang/ClassLoader")
 
-    static std::shared_ptr<ClassLoader> getInstance() {
-        static std::shared_ptr<ClassLoader> instance (new ClassLoader);
-        return instance;
-    }
+  static std::shared_ptr<ClassLoader> getInstance() {
+    static std::shared_ptr<ClassLoader> instance(new ClassLoader);
+    return instance;
+  }
 
-    std::shared_ptr<FakeJni::JClass> loadClass(std::shared_ptr<FakeJni::JString> str) {
-        FakeJni::JniEnvContext context;
-        return std::const_pointer_cast<FakeJni::JClass>(
-                context.getJniEnv().getVM().findClass(str->asStdString().c_str()));
-    }
-
+  std::shared_ptr<FakeJni::JClass>
+  loadClass(std::shared_ptr<FakeJni::JString> str) {
+    FakeJni::JniEnvContext context;
+    return std::const_pointer_cast<FakeJni::JClass>(
+        context.getJniEnv().getVM().findClass(str->asStdString().c_str()));
+  }
 };

--- a/src/jni/java_types.h
+++ b/src/jni/java_types.h
@@ -2,34 +2,33 @@
 
 #include <fake-jni/fake-jni.h>
 
-class File : public FakeJni::JObject {
+class File : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/io/File")
 
-public:
-  DEFINE_CLASS_NAME("java/io/File")
+    std::string path;
 
-  std::string path;
+    explicit File(std::string path) : path(std::move(path)) {}
 
-  explicit File(std::string path) : path(std::move(path)) {}
-
-  std::shared_ptr<FakeJni::JString> getPath() {
-    return std::make_shared<FakeJni::JString>(path.c_str());
-  }
+    std::shared_ptr<FakeJni::JString> getPath() { return std::make_shared<FakeJni::JString>(path.c_str()); }
 };
 
-class ClassLoader : public FakeJni::JObject {
+class ClassLoader : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/lang/ClassLoader")
 
-public:
-  DEFINE_CLASS_NAME("java/lang/ClassLoader")
+    static std::shared_ptr<ClassLoader> getInstance()
+    {
+        static std::shared_ptr<ClassLoader> instance(new ClassLoader);
+        return instance;
+    }
 
-  static std::shared_ptr<ClassLoader> getInstance() {
-    static std::shared_ptr<ClassLoader> instance(new ClassLoader);
-    return instance;
-  }
-
-  std::shared_ptr<FakeJni::JClass>
-  loadClass(std::shared_ptr<FakeJni::JString> str) {
-    FakeJni::JniEnvContext context;
-    return std::const_pointer_cast<FakeJni::JClass>(
-        context.getJniEnv().getVM().findClass(str->asStdString().c_str()));
-  }
+    std::shared_ptr<FakeJni::JClass> loadClass(std::shared_ptr<FakeJni::JString> str)
+    {
+        FakeJni::JniEnvContext context;
+        return std::const_pointer_cast<FakeJni::JClass>(
+            context.getJniEnv().getVM().findClass(str->asStdString().c_str()));
+    }
 };

--- a/src/jni/jbase64.cpp
+++ b/src/jni/jbase64.cpp
@@ -1,9 +1,10 @@
 #include "jbase64.h"
 #include <base64.h>
 
-std::shared_ptr<FakeJni::JByteArray> JBase64::decode(std::shared_ptr<FakeJni::JString> value, int flags) {
-    auto dec = Base64::decode(value->asStdString());
-    auto ret = std::make_shared<FakeJni::JByteArray>(dec.length());
-    memcpy(ret->getArray(), dec.data(), dec.length());
-    return ret;
+std::shared_ptr<FakeJni::JByteArray>
+JBase64::decode(std::shared_ptr<FakeJni::JString> value, int flags) {
+  auto dec = Base64::decode(value->asStdString());
+  auto ret = std::make_shared<FakeJni::JByteArray>(dec.length());
+  memcpy(ret->getArray(), dec.data(), dec.length());
+  return ret;
 }

--- a/src/jni/jbase64.cpp
+++ b/src/jni/jbase64.cpp
@@ -1,10 +1,10 @@
 #include "jbase64.h"
 #include <base64.h>
 
-std::shared_ptr<FakeJni::JByteArray>
-JBase64::decode(std::shared_ptr<FakeJni::JString> value, int flags) {
-  auto dec = Base64::decode(value->asStdString());
-  auto ret = std::make_shared<FakeJni::JByteArray>(dec.length());
-  memcpy(ret->getArray(), dec.data(), dec.length());
-  return ret;
+std::shared_ptr<FakeJni::JByteArray> JBase64::decode(std::shared_ptr<FakeJni::JString> value, int flags)
+{
+    auto dec = Base64::decode(value->asStdString());
+    auto ret = std::make_shared<FakeJni::JByteArray>(dec.length());
+    memcpy(ret->getArray(), dec.data(), dec.length());
+    return ret;
 }

--- a/src/jni/jbase64.cpp
+++ b/src/jni/jbase64.cpp
@@ -1,8 +1,7 @@
 #include "jbase64.h"
 #include <base64.h>
 
-std::shared_ptr<FakeJni::JByteArray> JBase64::decode(std::shared_ptr<FakeJni::JString> value, int flags)
-{
+std::shared_ptr<FakeJni::JByteArray> JBase64::decode(std::shared_ptr<FakeJni::JString> value, int flags) {
     auto dec = Base64::decode(value->asStdString());
     auto ret = std::make_shared<FakeJni::JByteArray>(dec.length());
     memcpy(ret->getArray(), dec.data(), dec.length());

--- a/src/jni/jbase64.h
+++ b/src/jni/jbase64.h
@@ -1,11 +1,10 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class JBase64 : public FakeJni::JObject {
+class JBase64 : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("android/util/Base64")
 
-public:
-  DEFINE_CLASS_NAME("android/util/Base64")
-
-  static std::shared_ptr<FakeJni::JByteArray>
-  decode(std::shared_ptr<FakeJni::JString>, int flags);
+    static std::shared_ptr<FakeJni::JByteArray> decode(std::shared_ptr<FakeJni::JString>, int flags);
 };

--- a/src/jni/jbase64.h
+++ b/src/jni/jbase64.h
@@ -4,7 +4,8 @@
 class JBase64 : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("android/util/Base64")
+  DEFINE_CLASS_NAME("android/util/Base64")
 
-    static std::shared_ptr<FakeJni::JByteArray> decode(std::shared_ptr<FakeJni::JString>, int flags);
+  static std::shared_ptr<FakeJni::JByteArray>
+  decode(std::shared_ptr<FakeJni::JString>, int flags);
 };

--- a/src/jni/jbase64.h
+++ b/src/jni/jbase64.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class JBase64 : public FakeJni::JObject
-{
+class JBase64 : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("android/util/Base64")
 

--- a/src/jni/jni_descriptors.cpp
+++ b/src/jni/jni_descriptors.cpp
@@ -1,131 +1,135 @@
+#include "cert_manager.h"
+#include "http_stub.h"
+#include "lib_http_client.h"
 #include "main_activity.h"
+#include "package_source.h"
 #include "store.h"
 #include "xbox_live.h"
-#include "lib_http_client.h"
-#include "cert_manager.h"
-#include "package_source.h"
-#include "http_stub.h"
 #ifdef HAVE_PULSEAUDIO
 #include "pulseaudio.h"
 #endif
-#include "java_types.h"
 #include "accounts.h"
-#include "ecdsa.h"
-#include "webview.h"
-#include "jbase64.h"
 #include "arrays.h"
+#include "ecdsa.h"
+#include "java_types.h"
+#include "jbase64.h"
 #include "locale.h"
+#include "securerandom.h"
+#include "shahasher.h"
 #include "signature.h"
 #include "uuid.h"
-#include "shahasher.h"
-#include "securerandom.h"
+#include "webview.h"
 
 using namespace FakeJni;
 
-BEGIN_NATIVE_DESCRIPTOR(BuildVersion)
-{Field<&BuildVersion::SDK_INT> {}, "SDK_INT"},
-{Field<&BuildVersion::RELEASE> {}, "RELEASE"},
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(BuildVersion){Field<&BuildVersion::SDK_INT>{},
+                                      "SDK_INT"},
+    {Field<&BuildVersion::RELEASE>{}, "RELEASE"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(PackageInfo)
-{Field<&PackageInfo::versionName> {}, "versionName"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(PackageInfo){Field<&PackageInfo::versionName>{},
+                                         "versionName"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(PackageManager)
-{Function<&PackageManager::getPackageInfo> {}, "getPackageInfo"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(PackageManager){
+        Function<&PackageManager::getPackageInfo>{}, "getPackageInfo"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(File)
-{Function<&File::getPath> {}, "getPath"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(File){Function<&File::getPath>{}, "getPath"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(ClassLoader)
-{Function<&ClassLoader::loadClass> {}, "loadClass"},
-{Function<&ClassLoader::loadClass> {}, "findClass"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(ClassLoader){Function<&ClassLoader::loadClass>{},
+                                         "loadClass"},
+    {Function<&ClassLoader::loadClass>{}, "findClass"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Locale)
-{Function<&Locale::getDefault> {}, "getDefault"},
-{Function<&Locale::toString> {}, "toString"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(Locale){Function<&Locale::getDefault>{},
+                                    "getDefault"},
+    {Function<&Locale::toString>{}, "toString"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(UUID)
-{Function<&UUID::randomUUID> {}, "randomUUID"},
-{Function<&UUID::toString> {}, "toString"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(UUID){Function<&UUID::randomUUID>{}, "randomUUID"},
+    {Function<&UUID::toString>{}, "toString"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Context)
-{Function<&Context::getFilesDir> {}, "getFilesDir"},
-{Function<&Context::getCacheDir> {}, "getCacheDir"},
-{Function<&Context::getClassLoader> {}, "getClassLoader"},
-{Function<&Context::getApplicationContext> {}, "getApplicationContext"},
-{Function<&Context::getPackageName> {}, "getPackageName"},
-{Function<&Context::getPackageManager> {}, "getPackageManager"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(Context){Function<&Context::getFilesDir>{},
+                                     "getFilesDir"},
+    {Function<&Context::getCacheDir>{}, "getCacheDir"},
+    {Function<&Context::getClassLoader>{}, "getClassLoader"},
+    {Function<&Context::getApplicationContext>{}, "getApplicationContext"},
+    {Function<&Context::getPackageName>{}, "getPackageName"},
+    {Function<&Context::getPackageManager>{}, "getPackageManager"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(ContextWrapper)
-{Function<&ContextWrapper::getFilesDir> {}, "getFilesDir"},
-{Function<&ContextWrapper::getCacheDir> {}, "getCacheDir"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(ContextWrapper){
+        Function<&ContextWrapper::getFilesDir>{}, "getFilesDir"},
+    {Function<&ContextWrapper::getCacheDir>{}, "getCacheDir"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(HardwareInfo)
-{Function<&HardwareInfo::getAndroidVersion> {}, "getAndroidVersion"},
-{Function<&HardwareInfo::getInstallerPackageName> {}, "getInstallerPackageName"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(HardwareInfo){
+        Function<&HardwareInfo::getAndroidVersion>{}, "getAndroidVersion"},
+    {Function<&HardwareInfo::getInstallerPackageName>{},
+     "getInstallerPackageName"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Activity)
+    BEGIN_NATIVE_DESCRIPTOR(Activity)
 END_NATIVE_DESCRIPTOR
 
 BEGIN_NATIVE_DESCRIPTOR(NativeActivity)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(MainActivity)
-{Constructor<MainActivity> {}},
-{Function<&MainActivity::getAndroidVersion> {}, "getAndroidVersion"},
-{Function<&MainActivity::getScreenHeight> {}, "getScreenHeight"},
-{Function<&MainActivity::getScreenWidth> {}, "getScreenWidth"},
-{Function<&MainActivity::getDisplayHeight> {}, "getDisplayHeight"},
-{Function<&MainActivity::getDisplayWidth> {}, "getDisplayWidth"},
-{Function<&MainActivity::isNetworkEnabled> {}, "isNetworkEnabled"},
-{Function<&MainActivity::isChromebook> {}, "isChromebook"},
-{Function<&MainActivity::getLocale> {}, "getLocale"},
-{Function<&MainActivity::getDeviceModel> {}, "getDeviceModel"},
-{Function<&MainActivity::getExternalStoragePath> {}, "getExternalStoragePath"},
-{Function<&MainActivity::getInternalStoragePath> {}, "getInternalStoragePath"},
-{Function<&MainActivity::getLegacyExternalStoragePath>{}, "getLegacyExternalStoragePath"},
-{Function<&MainActivity::hasWriteExternalStoragePermission> {}, "hasWriteExternalStoragePermission"},
-{Function<&MainActivity::getHardwareInfo> {}, "getHardwareInfo"},
-{Function<&MainActivity::createUUID> {}, "createUUID"},
-{Function<&MainActivity::getFileDataBytes> {}, "getFileDataBytes"},
-{Function<&MainActivity::getIPAddresses> {}, "getIPAddresses"},
-{Function<&MainActivity::getBroadcastAddresses> {}, "getBroadcastAddresses"},
-{Function<&MainActivity::showKeyboard> {}, "showKeyboard"},
-{Function<&MainActivity::hideKeyboard> {}, "hideKeyboard"},
-{Function<&MainActivity::updateTextboxText> {}, "updateTextboxText"},
-{Function<&MainActivity::getCursorPosition> {}, "getCursorPosition"},
-{Function<&MainActivity::getUsedMemory> {}, "getUsedMemory"},
-{Function<&MainActivity::getFreeMemory> {}, "getFreeMemory"},
-{Function<&MainActivity::getTotalMemory> {}, "getTotalMemory"},
-{Function<&MainActivity::getMemoryLimit> {}, "getMemoryLimit"},
-{Function<&MainActivity::getAvailableMemory> {}, "getAvailableMemory"},
-{Function<&MainActivity::pickImage> {}, "pickImage"},
-{Function<&MainActivity::initializeXboxLive> {}, "initializeXboxLive"},
-{Function<&MainActivity::initializeXboxLive2> {}, "initializeXboxLive"},
-{Function<&MainActivity::initializeLibHttpClient> {}, "initializeLibHttpClient"},
-// {Function<&MainActivity::getSecureStorageKey> {}, "getSecureStorageKey"},
-{Function<&MainActivity::lockCursor> {}, "lockCursor"},
-{Function<&MainActivity::unlockCursor> {}, "unlockCursor"},
-{Function<&MainActivity::getImageData> {}, "getImageData"},
-{Function<&MainActivity::tick>{}, "tick"},
-{Function<&MainActivity::getPixelsPerMillimeter>{}, "getPixelsPerMillimeter"},
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(MainActivity){Constructor<MainActivity>{}},
+    {Function<&MainActivity::getAndroidVersion>{}, "getAndroidVersion"},
+    {Function<&MainActivity::getScreenHeight>{}, "getScreenHeight"},
+    {Function<&MainActivity::getScreenWidth>{}, "getScreenWidth"},
+    {Function<&MainActivity::getDisplayHeight>{}, "getDisplayHeight"},
+    {Function<&MainActivity::getDisplayWidth>{}, "getDisplayWidth"},
+    {Function<&MainActivity::isNetworkEnabled>{}, "isNetworkEnabled"},
+    {Function<&MainActivity::isChromebook>{}, "isChromebook"},
+    {Function<&MainActivity::getLocale>{}, "getLocale"},
+    {Function<&MainActivity::getDeviceModel>{}, "getDeviceModel"},
+    {Function<&MainActivity::getExternalStoragePath>{},
+     "getExternalStoragePath"},
+    {Function<&MainActivity::getInternalStoragePath>{},
+     "getInternalStoragePath"},
+    {Function<&MainActivity::getLegacyExternalStoragePath>{},
+     "getLegacyExternalStoragePath"},
+    {Function<&MainActivity::hasWriteExternalStoragePermission>{},
+     "hasWriteExternalStoragePermission"},
+    {Function<&MainActivity::getHardwareInfo>{}, "getHardwareInfo"},
+    {Function<&MainActivity::createUUID>{}, "createUUID"},
+    {Function<&MainActivity::getFileDataBytes>{}, "getFileDataBytes"},
+    {Function<&MainActivity::getIPAddresses>{}, "getIPAddresses"},
+    {Function<&MainActivity::getBroadcastAddresses>{}, "getBroadcastAddresses"},
+    {Function<&MainActivity::showKeyboard>{}, "showKeyboard"},
+    {Function<&MainActivity::hideKeyboard>{}, "hideKeyboard"},
+    {Function<&MainActivity::updateTextboxText>{}, "updateTextboxText"},
+    {Function<&MainActivity::getCursorPosition>{}, "getCursorPosition"},
+    {Function<&MainActivity::getUsedMemory>{}, "getUsedMemory"},
+    {Function<&MainActivity::getFreeMemory>{}, "getFreeMemory"},
+    {Function<&MainActivity::getTotalMemory>{}, "getTotalMemory"},
+    {Function<&MainActivity::getMemoryLimit>{}, "getMemoryLimit"},
+    {Function<&MainActivity::getAvailableMemory>{}, "getAvailableMemory"},
+    {Function<&MainActivity::pickImage>{}, "pickImage"},
+    {Function<&MainActivity::initializeXboxLive>{}, "initializeXboxLive"},
+    {Function<&MainActivity::initializeXboxLive2>{}, "initializeXboxLive"},
+    {Function<&MainActivity::initializeLibHttpClient>{},
+     "initializeLibHttpClient"},
+    // {Function<&MainActivity::getSecureStorageKey> {}, "getSecureStorageKey"},
+    {Function<&MainActivity::lockCursor>{}, "lockCursor"},
+    {Function<&MainActivity::unlockCursor>{}, "unlockCursor"},
+    {Function<&MainActivity::getImageData>{}, "getImageData"},
+    {Function<&MainActivity::tick>{}, "tick"},
+    {Function<&MainActivity::getPixelsPerMillimeter>{},
+     "getPixelsPerMillimeter"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(AccountManager)
-{Function<&AccountManager::get> {}, "get"},
-{Function<&AccountManager::getAccountsByType> {}, "getAccountsByType"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(AccountManager){Function<&AccountManager::get>{},
+                                            "get"},
+    {Function<&AccountManager::getAccountsByType>{}, "getAccountsByType"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Account)
+    BEGIN_NATIVE_DESCRIPTOR(Account)
 END_NATIVE_DESCRIPTOR
 
 BEGIN_NATIVE_DESCRIPTOR(JellyBeanDeviceManager)
@@ -134,222 +138,248 @@ END_NATIVE_DESCRIPTOR
 BEGIN_NATIVE_DESCRIPTOR(StoreListener)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(NativeStoreListener)
-{Constructor<NativeStoreListener, JLong> {}},
-// {FakeJni::Function<&NativeStoreListener::onPurchaseFailed>{}, "onPurchaseFailed", FakeJni::JMethodID::PUBLIC },
-// {FakeJni::Function<&NativeStoreListener::onQueryProductsSuccess>{}, "onQueryProductsSuccess", FakeJni::JMethodID::PUBLIC },
-// {FakeJni::Function<&NativeStoreListener::onQueryPurchasesSuccess>{}, "onQueryPurchasesSuccess", FakeJni::JMethodID::PUBLIC },
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(NativeStoreListener){
+    Constructor<NativeStoreListener, JLong>{}},
+    // {FakeJni::Function<&NativeStoreListener::onPurchaseFailed>{},
+    // "onPurchaseFailed", FakeJni::JMethodID::PUBLIC },
+    // {FakeJni::Function<&NativeStoreListener::onQueryProductsSuccess>{},
+    // "onQueryProductsSuccess", FakeJni::JMethodID::PUBLIC },
+    // {FakeJni::Function<&NativeStoreListener::onQueryPurchasesSuccess>{},
+    // "onQueryPurchasesSuccess", FakeJni::JMethodID::PUBLIC },
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Purchase)
-// {FakeJni::Field<&Purchase::mProductId>{}, "mProductId", FakeJni::JFieldID::PUBLIC },
-// {FakeJni::Field<&Purchase::mReceipt>{}, "mReceipt", FakeJni::JFieldID::PUBLIC },
-// {FakeJni::Field<&Purchase::mPurchaseActive>{}, "mPurchaseActive", FakeJni::JFieldID::PUBLIC },
+    BEGIN_NATIVE_DESCRIPTOR(Purchase)
+// {FakeJni::Field<&Purchase::mProductId>{}, "mProductId",
+// FakeJni::JFieldID::PUBLIC }, {FakeJni::Field<&Purchase::mReceipt>{},
+// "mReceipt", FakeJni::JFieldID::PUBLIC },
+// {FakeJni::Field<&Purchase::mPurchaseActive>{}, "mPurchaseActive",
+// FakeJni::JFieldID::PUBLIC },
 END_NATIVE_DESCRIPTOR
 
 BEGIN_NATIVE_DESCRIPTOR(Product)
 // {FakeJni::Field<&Product::mId>{}, "mId", FakeJni::JFieldID::PUBLIC },
 // {FakeJni::Field<&Product::mPrice>{}, "mPrice", FakeJni::JFieldID::PUBLIC },
-// {FakeJni::Field<&Product::mCurrencyCode>{}, "mCurrencyCode", FakeJni::JFieldID::PUBLIC },
-// {FakeJni::Field<&Product::mUnformattedPrice>{}, "mUnformattedPrice", FakeJni::JFieldID::PUBLIC },
+// {FakeJni::Field<&Product::mCurrencyCode>{}, "mCurrencyCode",
+// FakeJni::JFieldID::PUBLIC }, {FakeJni::Field<&Product::mUnformattedPrice>{},
+// "mUnformattedPrice", FakeJni::JFieldID::PUBLIC },
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(NotificationListenerService)
-{FakeJni::Function<&NotificationListenerService::getDeviceRegistrationToken>{}, "getDeviceRegistrationToken", FakeJni::JMethodID::PUBLIC | FakeJni::JMethodID::STATIC},
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(NotificationListenerService){
+    FakeJni::Function<
+        &NotificationListenerService::getDeviceRegistrationToken>{},
+    "getDeviceRegistrationToken",
+    FakeJni::JMethodID::PUBLIC | FakeJni::JMethodID::STATIC},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Store)
-{FakeJni::Function<&Store::receivedLicenseResponse>{}, "receivedLicenseResponse", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::hasVerifiedLicense>{}, "hasVerifiedLicense", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::getStoreId>{}, "getStoreId", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::getProductSkuPrefix>{}, "getProductSkuPrefix", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::getRealmsSkuPrefix>{}, "getRealmsSkuPrefix", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::getExtraLicenseData>{}, "getExtraLicenseData", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::queryProducts>{}, "queryProducts", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::purchase>{}, "purchase", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::acknowledgePurchase>{}, "acknowledgePurchase", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::queryPurchases>{}, "queryPurchases", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&Store::destructor>{}, "destructor", FakeJni::JMethodID::PUBLIC },
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(Store){
+        FakeJni::Function<&Store::receivedLicenseResponse>{},
+        "receivedLicenseResponse", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::hasVerifiedLicense>{}, "hasVerifiedLicense",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::getStoreId>{}, "getStoreId",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::getProductSkuPrefix>{}, "getProductSkuPrefix",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::getRealmsSkuPrefix>{}, "getRealmsSkuPrefix",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::getExtraLicenseData>{}, "getExtraLicenseData",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::queryProducts>{}, "queryProducts",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::purchase>{}, "purchase",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::acknowledgePurchase>{}, "acknowledgePurchase",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::queryPurchases>{}, "queryPurchases",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::destructor>{}, "destructor",
+     FakeJni::JMethodID::PUBLIC},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(ExtraLicenseResponseData)
-{FakeJni::Function<&ExtraLicenseResponseData::getValidationTime>{}, "getValidationTime", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&ExtraLicenseResponseData::getRetryUntilTime>{}, "getRetryUntilTime", FakeJni::JMethodID::PUBLIC },
-{FakeJni::Function<&ExtraLicenseResponseData::getRetryAttempts>{}, "getRetryAttempts", FakeJni::JMethodID::PUBLIC },
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(ExtraLicenseResponseData){
+        FakeJni::Function<&ExtraLicenseResponseData::getValidationTime>{},
+        "getValidationTime", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&ExtraLicenseResponseData::getRetryUntilTime>{},
+     "getRetryUntilTime", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&ExtraLicenseResponseData::getRetryAttempts>{},
+     "getRetryAttempts", FakeJni::JMethodID::PUBLIC},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(StoreFactory)
-{Function<&StoreFactory::createGooglePlayStore> {}, "createGooglePlayStore"},
-{Function<&StoreFactory::createAmazonAppStore> {}, "createAmazonAppStore"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(StoreFactory){
+        Function<&StoreFactory::createGooglePlayStore>{},
+        "createGooglePlayStore"},
+    {Function<&StoreFactory::createAmazonAppStore>{}, "createAmazonAppStore"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(XboxInterop)
-{Function<&XboxInterop::getLocalStoragePath> {}, "GetLocalStoragePath"},
-{Function<&XboxInterop::readConfigFile> {}, "ReadConfigFile"},
-{Function<&XboxInterop::getLocale> {}, "getLocale"},
-{Function<&XboxInterop::invokeMSA> {}, "InvokeMSA"},
-{Function<&XboxInterop::invokeAuthFlow> {}, "InvokeAuthFlow"},
-{Function<&XboxInterop::initCLL> {}, "InitCLL"},
-{Function<&XboxInterop::logCLL> {}, "LogCLL"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(XboxInterop){
+        Function<&XboxInterop::getLocalStoragePath>{}, "GetLocalStoragePath"},
+    {Function<&XboxInterop::readConfigFile>{}, "ReadConfigFile"},
+    {Function<&XboxInterop::getLocale>{}, "getLocale"},
+    {Function<&XboxInterop::invokeMSA>{}, "InvokeMSA"},
+    {Function<&XboxInterop::invokeAuthFlow>{}, "InvokeAuthFlow"},
+    {Function<&XboxInterop::initCLL>{}, "InitCLL"},
+    {Function<&XboxInterop::logCLL>{}, "LogCLL"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(XboxLocalStorage)
-{Function<&XboxLocalStorage::getPath>{}, "getPath" },
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(XboxLocalStorage){
+        Function<&XboxLocalStorage::getPath>{}, "getPath"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Ecdsa)
-{Constructor<Ecdsa> {}},
-{Function<&Ecdsa::sign> {}, "sign"},
-{Function<&Ecdsa::getPublicKey> {}, "getPublicKey"},
-{Function<&Ecdsa::generateKey> {}, "generateKey"},
-{Function<&Ecdsa::restoreKeyAndId> {}, "restoreKeyAndId"},
-{Function<&Ecdsa::getUniqueId> {}, "getUniqueId"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(Ecdsa){Constructor<Ecdsa>{}},
+    {Function<&Ecdsa::sign>{}, "sign"},
+    {Function<&Ecdsa::getPublicKey>{}, "getPublicKey"},
+    {Function<&Ecdsa::generateKey>{}, "generateKey"},
+    {Function<&Ecdsa::restoreKeyAndId>{}, "restoreKeyAndId"},
+    {Function<&Ecdsa::getUniqueId>{}, "getUniqueId"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(EcdsaPublicKey)
-{Function<&EcdsaPublicKey::getBase64UrlX> {}, "getBase64UrlX"},
-{Function<&EcdsaPublicKey::getBase64UrlY> {}, "getBase64UrlY"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(EcdsaPublicKey){
+        Function<&EcdsaPublicKey::getBase64UrlX>{}, "getBase64UrlX"},
+    {Function<&EcdsaPublicKey::getBase64UrlY>{}, "getBase64UrlY"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(HttpClientRequest)
-{Constructor<HttpClientRequest> {}},
-{Function<&HttpClientRequest::isNetworkAvailable> {}, "isNetworkAvailable"},
-{Function<&HttpClientRequest::createClientRequest> {}, "createClientRequest"},
-{Function<&HttpClientRequest::setHttpUrl> {}, "setHttpUrl"},
-{Function<&HttpClientRequest::setHttpMethodAndBody> {}, "setHttpMethodAndBody"},
-{Function<&HttpClientRequest::setHttpMethodAndBody2> {}, "setHttpMethodAndBody"},
-{Function<&HttpClientRequest::setHttpHeader> {}, "setHttpHeader"},
-{Function<&HttpClientRequest::doRequestAsync> {}, "doRequestAsync"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(HttpClientRequest){
+        Constructor<HttpClientRequest>{}},
+    {Function<&HttpClientRequest::isNetworkAvailable>{}, "isNetworkAvailable"},
+    {Function<&HttpClientRequest::createClientRequest>{},
+     "createClientRequest"},
+    {Function<&HttpClientRequest::setHttpUrl>{}, "setHttpUrl"},
+    {Function<&HttpClientRequest::setHttpMethodAndBody>{},
+     "setHttpMethodAndBody"},
+    {Function<&HttpClientRequest::setHttpMethodAndBody2>{},
+     "setHttpMethodAndBody"},
+    {Function<&HttpClientRequest::setHttpHeader>{}, "setHttpHeader"},
+    {Function<&HttpClientRequest::doRequestAsync>{}, "doRequestAsync"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(HttpClientResponse)
-{Function<&HttpClientResponse::getNumHeaders> {}, "getNumHeaders"},
-{Function<&HttpClientResponse::getHeaderNameAtIndex> {}, "getHeaderNameAtIndex"},
-{Function<&HttpClientResponse::getHeaderValueAtIndex> {}, "getHeaderValueAtIndex"},
-{Function<&HttpClientResponse::getResponseBodyBytes> {}, "getResponseBodyBytes"},
-{Function<&HttpClientResponse::getResponseBodyBytes2> {}, "getResponseBodyBytes"},
-{Function<&HttpClientResponse::getResponseCode> {}, "getResponseCode"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(HttpClientResponse){
+        Function<&HttpClientResponse::getNumHeaders>{}, "getNumHeaders"},
+    {Function<&HttpClientResponse::getHeaderNameAtIndex>{},
+     "getHeaderNameAtIndex"},
+    {Function<&HttpClientResponse::getHeaderValueAtIndex>{},
+     "getHeaderValueAtIndex"},
+    {Function<&HttpClientResponse::getResponseBodyBytes>{},
+     "getResponseBodyBytes"},
+    {Function<&HttpClientResponse::getResponseBodyBytes2>{},
+     "getResponseBodyBytes"},
+    {Function<&HttpClientResponse::getResponseCode>{}, "getResponseCode"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(NativeOutputStream)
+    BEGIN_NATIVE_DESCRIPTOR(NativeOutputStream)
 END_NATIVE_DESCRIPTOR
 BEGIN_NATIVE_DESCRIPTOR(NativeInputStream)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(XboxLoginCallback)
-{Function<&XboxLoginCallback::onLogin> {}, "onLogin"},
-{Function<&XboxLoginCallback::onSuccess> {}, "onSuccess"},
-{Function<&XboxLoginCallback::onError> {}, "onError"},
+BEGIN_NATIVE_DESCRIPTOR(XboxLoginCallback){
+    Function<&XboxLoginCallback::onLogin>{}, "onLogin"},
+    {Function<&XboxLoginCallback::onSuccess>{}, "onSuccess"},
+    {Function<&XboxLoginCallback::onError>{}, "onError"},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(InputStream)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(InputStream)
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(ByteArrayInputStream){
+    Constructor<ByteArrayInputStream, std::shared_ptr<FakeJni::JByteArray>>{}},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(ByteArrayInputStream)
-{Constructor<ByteArrayInputStream, std::shared_ptr<FakeJni::JByteArray>> {}},
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(Certificate)
+    BEGIN_NATIVE_DESCRIPTOR(Certificate)
 END_NATIVE_DESCRIPTOR
 
 BEGIN_NATIVE_DESCRIPTOR(X509Certificate)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(CertificateFactory)
-{Function<&CertificateFactory::getInstance> {}, "getInstance"},
-{Function<&CertificateFactory::generateCertificate> {}, "generateCertificate"},
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(CertificateFactory){
+    Function<&CertificateFactory::getInstance>{}, "getInstance"},
+    {Function<&CertificateFactory::generateCertificate>{},
+     "generateCertificate"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(TrustManager)
+    BEGIN_NATIVE_DESCRIPTOR(TrustManager)
 END_NATIVE_DESCRIPTOR
 
 BEGIN_NATIVE_DESCRIPTOR(X509TrustManager)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(TrustManagerFactory)
-{Function<&TrustManagerFactory::getInstance> {}, "getInstance"},
-{Function<&TrustManagerFactory::getTrustManagers> {}, "getTrustManagers"},
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(TrustManagerFactory){
+    Function<&TrustManagerFactory::getInstance>{}, "getInstance"},
+    {Function<&TrustManagerFactory::getTrustManagers>{}, "getTrustManagers"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(StrictHostnameVerifier)
-{Constructor<StrictHostnameVerifier> {}},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(StrictHostnameVerifier){
+        Constructor<StrictHostnameVerifier>{}},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(PackageSource)
+    BEGIN_NATIVE_DESCRIPTOR(PackageSource)
 END_NATIVE_DESCRIPTOR
 
 BEGIN_NATIVE_DESCRIPTOR(PackageSourceListener)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(NativePackageSourceListener)
-{Constructor<NativePackageSourceListener> {}},
+BEGIN_NATIVE_DESCRIPTOR(NativePackageSourceListener){
+    Constructor<NativePackageSourceListener>{}},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(PackageSourceFactory){
+        Function<&PackageSourceFactory::createGooglePlayPackageSource>{},
+        "createGooglePlayPackageSource"},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(Header)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(PackageSourceFactory)
-{Function<&PackageSourceFactory::createGooglePlayPackageSource> {}, "createGooglePlayPackageSource"},
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(HTTPResponse){Function<&HTTPResponse::getStatus>{},
+                                      "getStatus"},
+    {Function<&HTTPResponse::getBody>{}, "getBody"},
+    {Function<&HTTPResponse::getResponseCode>{}, "getResponseCode"},
+    {Function<&HTTPResponse::getHeaders>{}, "getHeaders"},
+    END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Header)
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(HTTPResponse)
-{Function<&HTTPResponse::getStatus> {}, "getStatus"},
-{Function<&HTTPResponse::getBody> {}, "getBody"},
-{Function<&HTTPResponse::getResponseCode> {}, "getResponseCode"},
-{Function<&HTTPResponse::getHeaders> {}, "getHeaders"},
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(HTTPRequest)
-{Function<&HTTPRequest::setURL> {}, "setURL"},
-{Function<&HTTPRequest::setRequestBody> {}, "setRequestBody"},
-{Function<&HTTPRequest::setCookieData> {}, "setCookieData"},
-{Function<&HTTPRequest::setContentType> {}, "setContentType"},
-{Function<&HTTPRequest::send> {}, "send"},
-{Function<&HTTPRequest::abort> {}, "abort"},
-{Constructor<HTTPRequest> {}},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(HTTPRequest){Function<&HTTPRequest::setURL>{},
+                                         "setURL"},
+    {Function<&HTTPRequest::setRequestBody>{}, "setRequestBody"},
+    {Function<&HTTPRequest::setCookieData>{}, "setCookieData"},
+    {Function<&HTTPRequest::setContentType>{}, "setContentType"},
+    {Function<&HTTPRequest::send>{}, "send"},
+    {Function<&HTTPRequest::abort>{}, "abort"}, {Constructor<HTTPRequest>{}},
+    END_NATIVE_DESCRIPTOR
 
 #ifdef HAVE_PULSEAUDIO
-BEGIN_NATIVE_DESCRIPTOR(AudioDevice)
-{Constructor<AudioDevice> {}},
-{Function<&AudioDevice::init> {}, "init"},
-{Function<&AudioDevice::write> {}, "write"},
-{Function<&AudioDevice::close> {}, "close"},
-END_NATIVE_DESCRIPTOR
+    BEGIN_NATIVE_DESCRIPTOR(AudioDevice){Constructor<AudioDevice>{}},
+    {Function<&AudioDevice::init>{}, "init"},
+    {Function<&AudioDevice::write>{}, "write"},
+    {Function<&AudioDevice::close>{}, "close"},
+    END_NATIVE_DESCRIPTOR
 #endif
 
-BEGIN_NATIVE_DESCRIPTOR(ShaHasher)
-{Constructor<ShaHasher> {}},
-{Function<&ShaHasher::AddBytes> {}, "AddBytes"},
-{Function<&ShaHasher::SignHash> {}, "SignHash"},
+    BEGIN_NATIVE_DESCRIPTOR(ShaHasher){Constructor<ShaHasher>{}},
+    {Function<&ShaHasher::AddBytes>{}, "AddBytes"},
+    {Function<&ShaHasher::SignHash>{}, "SignHash"},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(SecureRandom){
+        Function<&SecureRandom::GenerateRandomBytes>{}, "GenerateRandomBytes"},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(WebView){Function<&WebView::showUrl>{}, "showUrl"},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(BrowserLaunchActivity){
+        Function<&BrowserLaunchActivity::showUrl>{}, "showUrl"},
+    {Function<&BrowserLaunchActivity::showUrl2>{}, "showUrl"},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(JBase64){Function<&JBase64::decode>{}, "decode"},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(Arrays){Function<&Arrays::copyOfRange>{},
+                                    "copyOfRange"},
+    END_NATIVE_DESCRIPTOR
+
+    BEGIN_NATIVE_DESCRIPTOR(PublicKey)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(SecureRandom)
-{Function<&SecureRandom::GenerateRandomBytes> {}, "GenerateRandomBytes"},
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(WebView)
-{Function<&WebView::showUrl> {}, "showUrl"},
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(BrowserLaunchActivity)
-{Function<&BrowserLaunchActivity::showUrl> {}, "showUrl"},
-{Function<&BrowserLaunchActivity::showUrl2> {}, "showUrl"},
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(JBase64)
-{Function<&JBase64::decode> {}, "decode"},
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(Arrays)
-{Function<&Arrays::copyOfRange> {}, "copyOfRange"},
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(PublicKey)
-END_NATIVE_DESCRIPTOR
-
-BEGIN_NATIVE_DESCRIPTOR(Signature)
-{Function<&Signature::initVerify> {}, "initVerify"},
-{Function<&Signature::verify> {}, "verify"},
-{Function<&Signature::getInstance> {}, "getInstance"},
-END_NATIVE_DESCRIPTOR
+BEGIN_NATIVE_DESCRIPTOR(Signature){Function<&Signature::initVerify>{},
+                                   "initVerify"},
+    {Function<&Signature::verify>{}, "verify"},
+    {Function<&Signature::getInstance>{}, "getInstance"}, END_NATIVE_DESCRIPTOR

--- a/src/jni/jni_descriptors.cpp
+++ b/src/jni/jni_descriptors.cpp
@@ -22,29 +22,24 @@
 
 using namespace FakeJni;
 
-BEGIN_NATIVE_DESCRIPTOR(BuildVersion){Field<&BuildVersion::SDK_INT>{},
-                                      "SDK_INT"},
+BEGIN_NATIVE_DESCRIPTOR(BuildVersion){Field<&BuildVersion::SDK_INT>{}, "SDK_INT"},
     {Field<&BuildVersion::RELEASE>{}, "RELEASE"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(PackageInfo){Field<&PackageInfo::versionName>{},
-                                         "versionName"},
+    BEGIN_NATIVE_DESCRIPTOR(PackageInfo){Field<&PackageInfo::versionName>{}, "versionName"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(PackageManager){
-        Function<&PackageManager::getPackageInfo>{}, "getPackageInfo"},
+    BEGIN_NATIVE_DESCRIPTOR(PackageManager){Function<&PackageManager::getPackageInfo>{}, "getPackageInfo"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(File){Function<&File::getPath>{}, "getPath"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(ClassLoader){Function<&ClassLoader::loadClass>{},
-                                         "loadClass"},
+    BEGIN_NATIVE_DESCRIPTOR(ClassLoader){Function<&ClassLoader::loadClass>{}, "loadClass"},
     {Function<&ClassLoader::loadClass>{}, "findClass"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(Locale){Function<&Locale::getDefault>{},
-                                    "getDefault"},
+    BEGIN_NATIVE_DESCRIPTOR(Locale){Function<&Locale::getDefault>{}, "getDefault"},
     {Function<&Locale::toString>{}, "toString"},
     END_NATIVE_DESCRIPTOR
 
@@ -52,24 +47,19 @@ BEGIN_NATIVE_DESCRIPTOR(BuildVersion){Field<&BuildVersion::SDK_INT>{},
     {Function<&UUID::toString>{}, "toString"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(Context){Function<&Context::getFilesDir>{},
-                                     "getFilesDir"},
-    {Function<&Context::getCacheDir>{}, "getCacheDir"},
-    {Function<&Context::getClassLoader>{}, "getClassLoader"},
+    BEGIN_NATIVE_DESCRIPTOR(Context){Function<&Context::getFilesDir>{}, "getFilesDir"},
+    {Function<&Context::getCacheDir>{}, "getCacheDir"}, {Function<&Context::getClassLoader>{}, "getClassLoader"},
     {Function<&Context::getApplicationContext>{}, "getApplicationContext"},
     {Function<&Context::getPackageName>{}, "getPackageName"},
     {Function<&Context::getPackageManager>{}, "getPackageManager"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(ContextWrapper){
-        Function<&ContextWrapper::getFilesDir>{}, "getFilesDir"},
+    BEGIN_NATIVE_DESCRIPTOR(ContextWrapper){Function<&ContextWrapper::getFilesDir>{}, "getFilesDir"},
     {Function<&ContextWrapper::getCacheDir>{}, "getCacheDir"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(HardwareInfo){
-        Function<&HardwareInfo::getAndroidVersion>{}, "getAndroidVersion"},
-    {Function<&HardwareInfo::getInstallerPackageName>{},
-     "getInstallerPackageName"},
+    BEGIN_NATIVE_DESCRIPTOR(HardwareInfo){Function<&HardwareInfo::getAndroidVersion>{}, "getAndroidVersion"},
+    {Function<&HardwareInfo::getInstallerPackageName>{}, "getInstallerPackageName"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(Activity)
@@ -85,17 +75,12 @@ BEGIN_NATIVE_DESCRIPTOR(MainActivity){Constructor<MainActivity>{}},
     {Function<&MainActivity::getDisplayHeight>{}, "getDisplayHeight"},
     {Function<&MainActivity::getDisplayWidth>{}, "getDisplayWidth"},
     {Function<&MainActivity::isNetworkEnabled>{}, "isNetworkEnabled"},
-    {Function<&MainActivity::isChromebook>{}, "isChromebook"},
-    {Function<&MainActivity::getLocale>{}, "getLocale"},
+    {Function<&MainActivity::isChromebook>{}, "isChromebook"}, {Function<&MainActivity::getLocale>{}, "getLocale"},
     {Function<&MainActivity::getDeviceModel>{}, "getDeviceModel"},
-    {Function<&MainActivity::getExternalStoragePath>{},
-     "getExternalStoragePath"},
-    {Function<&MainActivity::getInternalStoragePath>{},
-     "getInternalStoragePath"},
-    {Function<&MainActivity::getLegacyExternalStoragePath>{},
-     "getLegacyExternalStoragePath"},
-    {Function<&MainActivity::hasWriteExternalStoragePermission>{},
-     "hasWriteExternalStoragePermission"},
+    {Function<&MainActivity::getExternalStoragePath>{}, "getExternalStoragePath"},
+    {Function<&MainActivity::getInternalStoragePath>{}, "getInternalStoragePath"},
+    {Function<&MainActivity::getLegacyExternalStoragePath>{}, "getLegacyExternalStoragePath"},
+    {Function<&MainActivity::hasWriteExternalStoragePermission>{}, "hasWriteExternalStoragePermission"},
     {Function<&MainActivity::getHardwareInfo>{}, "getHardwareInfo"},
     {Function<&MainActivity::createUUID>{}, "createUUID"},
     {Function<&MainActivity::getFileDataBytes>{}, "getFileDataBytes"},
@@ -113,19 +98,14 @@ BEGIN_NATIVE_DESCRIPTOR(MainActivity){Constructor<MainActivity>{}},
     {Function<&MainActivity::pickImage>{}, "pickImage"},
     {Function<&MainActivity::initializeXboxLive>{}, "initializeXboxLive"},
     {Function<&MainActivity::initializeXboxLive2>{}, "initializeXboxLive"},
-    {Function<&MainActivity::initializeLibHttpClient>{},
-     "initializeLibHttpClient"},
+    {Function<&MainActivity::initializeLibHttpClient>{}, "initializeLibHttpClient"},
     // {Function<&MainActivity::getSecureStorageKey> {}, "getSecureStorageKey"},
-    {Function<&MainActivity::lockCursor>{}, "lockCursor"},
-    {Function<&MainActivity::unlockCursor>{}, "unlockCursor"},
-    {Function<&MainActivity::getImageData>{}, "getImageData"},
-    {Function<&MainActivity::tick>{}, "tick"},
-    {Function<&MainActivity::getPixelsPerMillimeter>{},
-     "getPixelsPerMillimeter"},
+    {Function<&MainActivity::lockCursor>{}, "lockCursor"}, {Function<&MainActivity::unlockCursor>{}, "unlockCursor"},
+    {Function<&MainActivity::getImageData>{}, "getImageData"}, {Function<&MainActivity::tick>{}, "tick"},
+    {Function<&MainActivity::getPixelsPerMillimeter>{}, "getPixelsPerMillimeter"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(AccountManager){Function<&AccountManager::get>{},
-                                            "get"},
+    BEGIN_NATIVE_DESCRIPTOR(AccountManager){Function<&AccountManager::get>{}, "get"},
     {Function<&AccountManager::getAccountsByType>{}, "getAccountsByType"},
     END_NATIVE_DESCRIPTOR
 
@@ -138,8 +118,7 @@ END_NATIVE_DESCRIPTOR
 BEGIN_NATIVE_DESCRIPTOR(StoreListener)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(NativeStoreListener){
-    Constructor<NativeStoreListener, JLong>{}},
+BEGIN_NATIVE_DESCRIPTOR(NativeStoreListener){Constructor<NativeStoreListener, JLong>{}},
     // {FakeJni::Function<&NativeStoreListener::onPurchaseFailed>{},
     // "onPurchaseFailed", FakeJni::JMethodID::PUBLIC },
     // {FakeJni::Function<&NativeStoreListener::onQueryProductsSuccess>{},
@@ -165,103 +144,69 @@ BEGIN_NATIVE_DESCRIPTOR(Product)
 END_NATIVE_DESCRIPTOR
 
 BEGIN_NATIVE_DESCRIPTOR(NotificationListenerService){
-    FakeJni::Function<
-        &NotificationListenerService::getDeviceRegistrationToken>{},
-    "getDeviceRegistrationToken",
+    FakeJni::Function<&NotificationListenerService::getDeviceRegistrationToken>{}, "getDeviceRegistrationToken",
     FakeJni::JMethodID::PUBLIC | FakeJni::JMethodID::STATIC},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(Store){
-        FakeJni::Function<&Store::receivedLicenseResponse>{},
-        "receivedLicenseResponse", FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::hasVerifiedLicense>{}, "hasVerifiedLicense",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::getStoreId>{}, "getStoreId",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::getProductSkuPrefix>{}, "getProductSkuPrefix",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::getRealmsSkuPrefix>{}, "getRealmsSkuPrefix",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::getExtraLicenseData>{}, "getExtraLicenseData",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::queryProducts>{}, "queryProducts",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::purchase>{}, "purchase",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::acknowledgePurchase>{}, "acknowledgePurchase",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::queryPurchases>{}, "queryPurchases",
-     FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&Store::destructor>{}, "destructor",
-     FakeJni::JMethodID::PUBLIC},
+    BEGIN_NATIVE_DESCRIPTOR(Store){FakeJni::Function<&Store::receivedLicenseResponse>{}, "receivedLicenseResponse",
+                                   FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::hasVerifiedLicense>{}, "hasVerifiedLicense", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::getStoreId>{}, "getStoreId", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::getProductSkuPrefix>{}, "getProductSkuPrefix", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::getRealmsSkuPrefix>{}, "getRealmsSkuPrefix", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::getExtraLicenseData>{}, "getExtraLicenseData", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::queryProducts>{}, "queryProducts", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::purchase>{}, "purchase", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::acknowledgePurchase>{}, "acknowledgePurchase", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::queryPurchases>{}, "queryPurchases", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&Store::destructor>{}, "destructor", FakeJni::JMethodID::PUBLIC},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(ExtraLicenseResponseData){
-        FakeJni::Function<&ExtraLicenseResponseData::getValidationTime>{},
-        "getValidationTime", FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&ExtraLicenseResponseData::getRetryUntilTime>{},
-     "getRetryUntilTime", FakeJni::JMethodID::PUBLIC},
-    {FakeJni::Function<&ExtraLicenseResponseData::getRetryAttempts>{},
-     "getRetryAttempts", FakeJni::JMethodID::PUBLIC},
+    BEGIN_NATIVE_DESCRIPTOR(ExtraLicenseResponseData){FakeJni::Function<&ExtraLicenseResponseData::getValidationTime>{},
+                                                      "getValidationTime", FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&ExtraLicenseResponseData::getRetryUntilTime>{}, "getRetryUntilTime",
+     FakeJni::JMethodID::PUBLIC},
+    {FakeJni::Function<&ExtraLicenseResponseData::getRetryAttempts>{}, "getRetryAttempts", FakeJni::JMethodID::PUBLIC},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(StoreFactory){
-        Function<&StoreFactory::createGooglePlayStore>{},
-        "createGooglePlayStore"},
+    BEGIN_NATIVE_DESCRIPTOR(StoreFactory){Function<&StoreFactory::createGooglePlayStore>{}, "createGooglePlayStore"},
     {Function<&StoreFactory::createAmazonAppStore>{}, "createAmazonAppStore"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(XboxInterop){
-        Function<&XboxInterop::getLocalStoragePath>{}, "GetLocalStoragePath"},
-    {Function<&XboxInterop::readConfigFile>{}, "ReadConfigFile"},
-    {Function<&XboxInterop::getLocale>{}, "getLocale"},
-    {Function<&XboxInterop::invokeMSA>{}, "InvokeMSA"},
-    {Function<&XboxInterop::invokeAuthFlow>{}, "InvokeAuthFlow"},
-    {Function<&XboxInterop::initCLL>{}, "InitCLL"},
-    {Function<&XboxInterop::logCLL>{}, "LogCLL"},
+    BEGIN_NATIVE_DESCRIPTOR(XboxInterop){Function<&XboxInterop::getLocalStoragePath>{}, "GetLocalStoragePath"},
+    {Function<&XboxInterop::readConfigFile>{}, "ReadConfigFile"}, {Function<&XboxInterop::getLocale>{}, "getLocale"},
+    {Function<&XboxInterop::invokeMSA>{}, "InvokeMSA"}, {Function<&XboxInterop::invokeAuthFlow>{}, "InvokeAuthFlow"},
+    {Function<&XboxInterop::initCLL>{}, "InitCLL"}, {Function<&XboxInterop::logCLL>{}, "LogCLL"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(XboxLocalStorage){
-        Function<&XboxLocalStorage::getPath>{}, "getPath"},
+    BEGIN_NATIVE_DESCRIPTOR(XboxLocalStorage){Function<&XboxLocalStorage::getPath>{}, "getPath"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(Ecdsa){Constructor<Ecdsa>{}},
-    {Function<&Ecdsa::sign>{}, "sign"},
-    {Function<&Ecdsa::getPublicKey>{}, "getPublicKey"},
-    {Function<&Ecdsa::generateKey>{}, "generateKey"},
-    {Function<&Ecdsa::restoreKeyAndId>{}, "restoreKeyAndId"},
+    {Function<&Ecdsa::sign>{}, "sign"}, {Function<&Ecdsa::getPublicKey>{}, "getPublicKey"},
+    {Function<&Ecdsa::generateKey>{}, "generateKey"}, {Function<&Ecdsa::restoreKeyAndId>{}, "restoreKeyAndId"},
     {Function<&Ecdsa::getUniqueId>{}, "getUniqueId"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(EcdsaPublicKey){
-        Function<&EcdsaPublicKey::getBase64UrlX>{}, "getBase64UrlX"},
+    BEGIN_NATIVE_DESCRIPTOR(EcdsaPublicKey){Function<&EcdsaPublicKey::getBase64UrlX>{}, "getBase64UrlX"},
     {Function<&EcdsaPublicKey::getBase64UrlY>{}, "getBase64UrlY"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(HttpClientRequest){
-        Constructor<HttpClientRequest>{}},
+    BEGIN_NATIVE_DESCRIPTOR(HttpClientRequest){Constructor<HttpClientRequest>{}},
     {Function<&HttpClientRequest::isNetworkAvailable>{}, "isNetworkAvailable"},
-    {Function<&HttpClientRequest::createClientRequest>{},
-     "createClientRequest"},
+    {Function<&HttpClientRequest::createClientRequest>{}, "createClientRequest"},
     {Function<&HttpClientRequest::setHttpUrl>{}, "setHttpUrl"},
-    {Function<&HttpClientRequest::setHttpMethodAndBody>{},
-     "setHttpMethodAndBody"},
-    {Function<&HttpClientRequest::setHttpMethodAndBody2>{},
-     "setHttpMethodAndBody"},
+    {Function<&HttpClientRequest::setHttpMethodAndBody>{}, "setHttpMethodAndBody"},
+    {Function<&HttpClientRequest::setHttpMethodAndBody2>{}, "setHttpMethodAndBody"},
     {Function<&HttpClientRequest::setHttpHeader>{}, "setHttpHeader"},
     {Function<&HttpClientRequest::doRequestAsync>{}, "doRequestAsync"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(HttpClientResponse){
-        Function<&HttpClientResponse::getNumHeaders>{}, "getNumHeaders"},
-    {Function<&HttpClientResponse::getHeaderNameAtIndex>{},
-     "getHeaderNameAtIndex"},
-    {Function<&HttpClientResponse::getHeaderValueAtIndex>{},
-     "getHeaderValueAtIndex"},
-    {Function<&HttpClientResponse::getResponseBodyBytes>{},
-     "getResponseBodyBytes"},
-    {Function<&HttpClientResponse::getResponseBodyBytes2>{},
-     "getResponseBodyBytes"},
+    BEGIN_NATIVE_DESCRIPTOR(HttpClientResponse){Function<&HttpClientResponse::getNumHeaders>{}, "getNumHeaders"},
+    {Function<&HttpClientResponse::getHeaderNameAtIndex>{}, "getHeaderNameAtIndex"},
+    {Function<&HttpClientResponse::getHeaderValueAtIndex>{}, "getHeaderValueAtIndex"},
+    {Function<&HttpClientResponse::getResponseBodyBytes>{}, "getResponseBodyBytes"},
+    {Function<&HttpClientResponse::getResponseBodyBytes2>{}, "getResponseBodyBytes"},
     {Function<&HttpClientResponse::getResponseCode>{}, "getResponseCode"},
     END_NATIVE_DESCRIPTOR
 
@@ -270,10 +215,8 @@ END_NATIVE_DESCRIPTOR
 BEGIN_NATIVE_DESCRIPTOR(NativeInputStream)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(XboxLoginCallback){
-    Function<&XboxLoginCallback::onLogin>{}, "onLogin"},
-    {Function<&XboxLoginCallback::onSuccess>{}, "onSuccess"},
-    {Function<&XboxLoginCallback::onError>{}, "onError"},
+BEGIN_NATIVE_DESCRIPTOR(XboxLoginCallback){Function<&XboxLoginCallback::onLogin>{}, "onLogin"},
+    {Function<&XboxLoginCallback::onSuccess>{}, "onSuccess"}, {Function<&XboxLoginCallback::onError>{}, "onError"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(InputStream)
@@ -289,10 +232,8 @@ END_NATIVE_DESCRIPTOR
 BEGIN_NATIVE_DESCRIPTOR(X509Certificate)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(CertificateFactory){
-    Function<&CertificateFactory::getInstance>{}, "getInstance"},
-    {Function<&CertificateFactory::generateCertificate>{},
-     "generateCertificate"},
+BEGIN_NATIVE_DESCRIPTOR(CertificateFactory){Function<&CertificateFactory::getInstance>{}, "getInstance"},
+    {Function<&CertificateFactory::generateCertificate>{}, "generateCertificate"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(TrustManager)
@@ -301,13 +242,11 @@ END_NATIVE_DESCRIPTOR
 BEGIN_NATIVE_DESCRIPTOR(X509TrustManager)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(TrustManagerFactory){
-    Function<&TrustManagerFactory::getInstance>{}, "getInstance"},
+BEGIN_NATIVE_DESCRIPTOR(TrustManagerFactory){Function<&TrustManagerFactory::getInstance>{}, "getInstance"},
     {Function<&TrustManagerFactory::getTrustManagers>{}, "getTrustManagers"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(StrictHostnameVerifier){
-        Constructor<StrictHostnameVerifier>{}},
+    BEGIN_NATIVE_DESCRIPTOR(StrictHostnameVerifier){Constructor<StrictHostnameVerifier>{}},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(PackageSource)
@@ -316,70 +255,58 @@ END_NATIVE_DESCRIPTOR
 BEGIN_NATIVE_DESCRIPTOR(PackageSourceListener)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(NativePackageSourceListener){
-    Constructor<NativePackageSourceListener>{}},
+BEGIN_NATIVE_DESCRIPTOR(NativePackageSourceListener){Constructor<NativePackageSourceListener>{}},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(PackageSourceFactory){
-        Function<&PackageSourceFactory::createGooglePlayPackageSource>{},
-        "createGooglePlayPackageSource"},
+    BEGIN_NATIVE_DESCRIPTOR(PackageSourceFactory){Function<&PackageSourceFactory::createGooglePlayPackageSource>{},
+                                                  "createGooglePlayPackageSource"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(Header)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(HTTPResponse){Function<&HTTPResponse::getStatus>{},
-                                      "getStatus"},
-    {Function<&HTTPResponse::getBody>{}, "getBody"},
-    {Function<&HTTPResponse::getResponseCode>{}, "getResponseCode"},
+BEGIN_NATIVE_DESCRIPTOR(HTTPResponse){Function<&HTTPResponse::getStatus>{}, "getStatus"},
+    {Function<&HTTPResponse::getBody>{}, "getBody"}, {Function<&HTTPResponse::getResponseCode>{}, "getResponseCode"},
     {Function<&HTTPResponse::getHeaders>{}, "getHeaders"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(HTTPRequest){Function<&HTTPRequest::setURL>{},
-                                         "setURL"},
+    BEGIN_NATIVE_DESCRIPTOR(HTTPRequest){Function<&HTTPRequest::setURL>{}, "setURL"},
     {Function<&HTTPRequest::setRequestBody>{}, "setRequestBody"},
     {Function<&HTTPRequest::setCookieData>{}, "setCookieData"},
-    {Function<&HTTPRequest::setContentType>{}, "setContentType"},
-    {Function<&HTTPRequest::send>{}, "send"},
+    {Function<&HTTPRequest::setContentType>{}, "setContentType"}, {Function<&HTTPRequest::send>{}, "send"},
     {Function<&HTTPRequest::abort>{}, "abort"}, {Constructor<HTTPRequest>{}},
     END_NATIVE_DESCRIPTOR
 
 #ifdef HAVE_PULSEAUDIO
     BEGIN_NATIVE_DESCRIPTOR(AudioDevice){Constructor<AudioDevice>{}},
-    {Function<&AudioDevice::init>{}, "init"},
-    {Function<&AudioDevice::write>{}, "write"},
+    {Function<&AudioDevice::init>{}, "init"}, {Function<&AudioDevice::write>{}, "write"},
     {Function<&AudioDevice::close>{}, "close"},
     END_NATIVE_DESCRIPTOR
 #endif
 
     BEGIN_NATIVE_DESCRIPTOR(ShaHasher){Constructor<ShaHasher>{}},
-    {Function<&ShaHasher::AddBytes>{}, "AddBytes"},
-    {Function<&ShaHasher::SignHash>{}, "SignHash"},
+    {Function<&ShaHasher::AddBytes>{}, "AddBytes"}, {Function<&ShaHasher::SignHash>{}, "SignHash"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(SecureRandom){
-        Function<&SecureRandom::GenerateRandomBytes>{}, "GenerateRandomBytes"},
+    BEGIN_NATIVE_DESCRIPTOR(SecureRandom){Function<&SecureRandom::GenerateRandomBytes>{}, "GenerateRandomBytes"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(WebView){Function<&WebView::showUrl>{}, "showUrl"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(BrowserLaunchActivity){
-        Function<&BrowserLaunchActivity::showUrl>{}, "showUrl"},
+    BEGIN_NATIVE_DESCRIPTOR(BrowserLaunchActivity){Function<&BrowserLaunchActivity::showUrl>{}, "showUrl"},
     {Function<&BrowserLaunchActivity::showUrl2>{}, "showUrl"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(JBase64){Function<&JBase64::decode>{}, "decode"},
     END_NATIVE_DESCRIPTOR
 
-    BEGIN_NATIVE_DESCRIPTOR(Arrays){Function<&Arrays::copyOfRange>{},
-                                    "copyOfRange"},
+    BEGIN_NATIVE_DESCRIPTOR(Arrays){Function<&Arrays::copyOfRange>{}, "copyOfRange"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(PublicKey)
 END_NATIVE_DESCRIPTOR
 
-BEGIN_NATIVE_DESCRIPTOR(Signature){Function<&Signature::initVerify>{},
-                                   "initVerify"},
+BEGIN_NATIVE_DESCRIPTOR(Signature){Function<&Signature::initVerify>{}, "initVerify"},
     {Function<&Signature::verify>{}, "verify"},
     {Function<&Signature::getInstance>{}, "getInstance"}, END_NATIVE_DESCRIPTOR

--- a/src/jni/jni_support.cpp
+++ b/src/jni/jni_support.cpp
@@ -1,13 +1,13 @@
 #include "jni_support.h"
+#include <log.h>
+#include <mcpelauncher/linker.h>
+#include <mcpelauncher/path_helper.h>
 #include "../xbox_live_helper.h"
 #include "cert_manager.h"
 #include "http_stub.h"
 #include "lib_http_client.h"
 #include "package_source.h"
 #include "xbox_live.h"
-#include <log.h>
-#include <mcpelauncher/linker.h>
-#include <mcpelauncher/path_helper.h>
 #ifdef HAVE_PULSEAUDIO
 #include "pulseaudio.h"
 #endif
@@ -22,324 +22,311 @@
 #include "uuid.h"
 #include "webview.h"
 
-void JniSupport::registerJniClasses() {
-  vm.registerClass<File>();
-  vm.registerClass<ClassLoader>();
-  vm.registerClass<Locale>();
-  vm.registerClass<UUID>();
+void JniSupport::registerJniClasses()
+{
+    vm.registerClass<File>();
+    vm.registerClass<ClassLoader>();
+    vm.registerClass<Locale>();
+    vm.registerClass<UUID>();
 
-  vm.registerClass<BuildVersion>();
-  vm.registerClass<PackageInfo>();
-  vm.registerClass<PackageManager>();
-  vm.registerClass<Context>();
-  vm.registerClass<ContextWrapper>();
-  vm.registerClass<HardwareInfo>();
-  vm.registerClass<Activity>();
-  vm.registerClass<NativeActivity>();
-  vm.registerClass<MainActivity>();
-  vm.registerClass<AccountManager>();
-  vm.registerClass<Account>();
+    vm.registerClass<BuildVersion>();
+    vm.registerClass<PackageInfo>();
+    vm.registerClass<PackageManager>();
+    vm.registerClass<Context>();
+    vm.registerClass<ContextWrapper>();
+    vm.registerClass<HardwareInfo>();
+    vm.registerClass<Activity>();
+    vm.registerClass<NativeActivity>();
+    vm.registerClass<MainActivity>();
+    vm.registerClass<AccountManager>();
+    vm.registerClass<Account>();
 
-  vm.registerClass<StoreListener>();
-  vm.registerClass<NativeStoreListener>();
-  vm.registerClass<Store>();
-  vm.registerClass<StoreFactory>();
-  vm.registerClass<ExtraLicenseResponseData>();
+    vm.registerClass<StoreListener>();
+    vm.registerClass<NativeStoreListener>();
+    vm.registerClass<Store>();
+    vm.registerClass<StoreFactory>();
+    vm.registerClass<ExtraLicenseResponseData>();
 
-  vm.registerClass<XboxInterop>();
-  vm.registerClass<XboxLocalStorage>();
-  vm.registerClass<Ecdsa>();
-  vm.registerClass<EcdsaPublicKey>();
-  vm.registerClass<HttpClientRequest>();
-  vm.registerClass<HttpClientResponse>();
+    vm.registerClass<XboxInterop>();
+    vm.registerClass<XboxLocalStorage>();
+    vm.registerClass<Ecdsa>();
+    vm.registerClass<EcdsaPublicKey>();
+    vm.registerClass<HttpClientRequest>();
+    vm.registerClass<HttpClientResponse>();
 
-  vm.registerClass<InputStream>();
-  vm.registerClass<ByteArrayInputStream>();
-  vm.registerClass<Certificate>();
-  vm.registerClass<X509Certificate>();
-  vm.registerClass<CertificateFactory>();
-  vm.registerClass<TrustManager>();
-  vm.registerClass<X509TrustManager>();
-  vm.registerClass<TrustManagerFactory>();
-  vm.registerClass<StrictHostnameVerifier>();
+    vm.registerClass<InputStream>();
+    vm.registerClass<ByteArrayInputStream>();
+    vm.registerClass<Certificate>();
+    vm.registerClass<X509Certificate>();
+    vm.registerClass<CertificateFactory>();
+    vm.registerClass<TrustManager>();
+    vm.registerClass<X509TrustManager>();
+    vm.registerClass<TrustManagerFactory>();
+    vm.registerClass<StrictHostnameVerifier>();
 
-  vm.registerClass<PackageSource>();
-  vm.registerClass<PackageSourceListener>();
-  vm.registerClass<NativePackageSourceListener>();
-  vm.registerClass<PackageSourceFactory>();
+    vm.registerClass<PackageSource>();
+    vm.registerClass<PackageSourceListener>();
+    vm.registerClass<NativePackageSourceListener>();
+    vm.registerClass<PackageSourceFactory>();
 
-  vm.registerClass<Header>();
-  vm.registerClass<HTTPResponse>();
-  vm.registerClass<HTTPRequest>();
+    vm.registerClass<Header>();
+    vm.registerClass<HTTPResponse>();
+    vm.registerClass<HTTPRequest>();
 
-  vm.registerClass<ShaHasher>();
-  vm.registerClass<SecureRandom>();
-  // Minecraft 1.16.20-210
-  vm.registerClass<WebView>();
-  // Minecraft 1.16.220+
-  vm.registerClass<BrowserLaunchActivity>();
+    vm.registerClass<ShaHasher>();
+    vm.registerClass<SecureRandom>();
+    // Minecraft 1.16.20-210
+    vm.registerClass<WebView>();
+    // Minecraft 1.16.220+
+    vm.registerClass<BrowserLaunchActivity>();
 
-  vm.registerClass<JBase64>();
-  vm.registerClass<Arrays>();
-  vm.registerClass<Signature>();
-  vm.registerClass<PublicKey>();
-  vm.registerClass<Product>();
-  vm.registerClass<Purchase>();
-  vm.registerClass<NotificationListenerService>();
+    vm.registerClass<JBase64>();
+    vm.registerClass<Arrays>();
+    vm.registerClass<Signature>();
+    vm.registerClass<PublicKey>();
+    vm.registerClass<Product>();
+    vm.registerClass<Purchase>();
+    vm.registerClass<NotificationListenerService>();
 
 #ifdef HAVE_PULSEAUDIO
-  vm.registerClass<AudioDevice>();
+    vm.registerClass<AudioDevice>();
 #endif
 }
 
-void JniSupport::registerMinecraftNatives(void *(*symResolver)(const char *)) {
-  registerNatives(MainActivity::getDescriptor(),
-                  {{"nativeRegisterThis", "()V"},
-                   {"nativeWaitCrashManagementSetupComplete", "()V"},
-                   {"nativeInitializeWithApplicationContext",
-                    "(Landroid/content/Context;)V"},
-                   {"nativeShutdown", "()V"},
-                   {"nativeUnregisterThis", "()V"},
-                   {"nativeStopThis", "()V"},
-                   {"nativeOnDestroy", "()V"},
-                   {"nativeResize", "(II)V"},
-                   {"nativeSetTextboxText", "(Ljava/lang/String;)V"},
-                   {"nativeReturnKeyPressed", "()V"},
-                   {"nativeOnPickImageSuccess", "(JLjava/lang/String;)V"},
-                   {"nativeOnPickImageCanceled", "(J)V"},
-                   {"nativeInitializeXboxLive", "(JJ)V"},
-                   {"nativeinitializeLibHttpClient", "(J)J"}},
-                  symResolver);
-  registerNatives(NativeStoreListener::getDescriptor(),
-                  {
-                      {"onStoreInitialized", "(JZ)V"},
-                      {"onPurchaseFailed", "(JLjava/lang/String;)V"},
-                      {"onQueryProductsSuccess",
-                       "(J[Lcom/mojang/minecraftpe/store/Product;)V"},
-                      {"onQueryPurchasesSuccess",
-                       "(J[Lcom/mojang/minecraftpe/store/Purchase;)V"},
-                  },
-                  symResolver);
-  registerNatives(JellyBeanDeviceManager::getDescriptor(),
-                  {{"onInputDeviceAddedNative", "(I)V"},
-                   {"onInputDeviceRemovedNative", "(I)V"}},
-                  symResolver);
-  registerNatives(
-      HttpClientRequest::getDescriptor(),
-      {{"OnRequestCompleted", "(JLcom/xbox/httpclient/HttpClientResponse;)V"},
-       {"OnRequestFailed", "(JLjava/lang/String;)V"}},
-      symResolver);
-  registerNatives(WebView::getDescriptor(),
-                  {
-                      {"urlOperationSucceeded",
-                       "(JLjava/lang/String;ZLjava/lang/String;)V"},
-                  },
-                  symResolver);
-  registerNatives(BrowserLaunchActivity::getDescriptor(),
-                  {
-                      {"urlOperationSucceeded",
-                       "(JLjava/lang/String;ZLjava/lang/String;)V"},
-                  },
-                  symResolver);
-  registerNatives(NativeInputStream::getDescriptor(),
-                  {
-                      {"nativeRead", "(JJ[BJJ)I"},
-                  },
-                  symResolver);
-  registerNatives(NativeOutputStream::getDescriptor(),
-                  {
-                      {"nativeWrite", "(J[BII)V"},
-                  },
-                  symResolver);
+void JniSupport::registerMinecraftNatives(void *(*symResolver)(const char *))
+{
+    registerNatives(MainActivity::getDescriptor(),
+                    {{"nativeRegisterThis", "()V"},
+                     {"nativeWaitCrashManagementSetupComplete", "()V"},
+                     {"nativeInitializeWithApplicationContext", "(Landroid/content/Context;)V"},
+                     {"nativeShutdown", "()V"},
+                     {"nativeUnregisterThis", "()V"},
+                     {"nativeStopThis", "()V"},
+                     {"nativeOnDestroy", "()V"},
+                     {"nativeResize", "(II)V"},
+                     {"nativeSetTextboxText", "(Ljava/lang/String;)V"},
+                     {"nativeReturnKeyPressed", "()V"},
+                     {"nativeOnPickImageSuccess", "(JLjava/lang/String;)V"},
+                     {"nativeOnPickImageCanceled", "(J)V"},
+                     {"nativeInitializeXboxLive", "(JJ)V"},
+                     {"nativeinitializeLibHttpClient", "(J)J"}},
+                    symResolver);
+    registerNatives(NativeStoreListener::getDescriptor(),
+                    {
+                        {"onStoreInitialized", "(JZ)V"},
+                        {"onPurchaseFailed", "(JLjava/lang/String;)V"},
+                        {"onQueryProductsSuccess", "(J[Lcom/mojang/minecraftpe/store/Product;)V"},
+                        {"onQueryPurchasesSuccess", "(J[Lcom/mojang/minecraftpe/store/Purchase;)V"},
+                    },
+                    symResolver);
+    registerNatives(JellyBeanDeviceManager::getDescriptor(),
+                    {{"onInputDeviceAddedNative", "(I)V"}, {"onInputDeviceRemovedNative", "(I)V"}}, symResolver);
+    registerNatives(HttpClientRequest::getDescriptor(),
+                    {{"OnRequestCompleted", "(JLcom/xbox/httpclient/HttpClientResponse;)V"},
+                     {"OnRequestFailed", "(JLjava/lang/String;)V"}},
+                    symResolver);
+    registerNatives(WebView::getDescriptor(),
+                    {
+                        {"urlOperationSucceeded", "(JLjava/lang/String;ZLjava/lang/String;)V"},
+                    },
+                    symResolver);
+    registerNatives(BrowserLaunchActivity::getDescriptor(),
+                    {
+                        {"urlOperationSucceeded", "(JLjava/lang/String;ZLjava/lang/String;)V"},
+                    },
+                    symResolver);
+    registerNatives(NativeInputStream::getDescriptor(),
+                    {
+                        {"nativeRead", "(JJ[BJJ)I"},
+                    },
+                    symResolver);
+    registerNatives(NativeOutputStream::getDescriptor(),
+                    {
+                        {"nativeWrite", "(J[BII)V"},
+                    },
+                    symResolver);
 }
 
-JniSupport::JniSupport()
-    : textInput(
-          [this](std::string const &str) { return onSetTextboxText(str); }) {
-  registerJniClasses();
+JniSupport::JniSupport() : textInput([this](std::string const &str) { return onSetTextboxText(str); })
+{
+    registerJniClasses();
 }
 
 void JniSupport::registerNatives(std::shared_ptr<FakeJni::JClass const> clazz,
-                                 std::vector<JniSupport::NativeEntry> entries,
-                                 void *(*symResolver)(const char *)) {
-  FakeJni::LocalFrame frame(vm);
+                                 std::vector<JniSupport::NativeEntry> entries, void *(*symResolver)(const char *))
+{
+    FakeJni::LocalFrame frame(vm);
 
-  std::string cppClassName = clazz->getName();
-  std::replace(cppClassName.begin(), cppClassName.end(), '/', '_');
+    std::string cppClassName = clazz->getName();
+    std::replace(cppClassName.begin(), cppClassName.end(), '/', '_');
 
-  std::vector<JNINativeMethod> javaEntries;
-  for (auto const &ent : entries) {
-    auto cppSymName = std::string("Java_") + cppClassName + "_" + ent.name;
-    auto cppSym = symResolver(cppSymName.c_str());
-    if (cppSym == nullptr) {
-      Log::error("JniSupport", "Missing native symbol: %s", cppSymName.c_str());
-      continue;
+    std::vector<JNINativeMethod> javaEntries;
+    for (auto const &ent : entries)
+    {
+        auto cppSymName = std::string("Java_") + cppClassName + "_" + ent.name;
+        auto cppSym = symResolver(cppSymName.c_str());
+        if (cppSym == nullptr)
+        {
+            Log::error("JniSupport", "Missing native symbol: %s", cppSymName.c_str());
+            continue;
+        }
+
+        javaEntries.push_back({(char *)ent.name, (char *)ent.sig, cppSym});
     }
 
-    javaEntries.push_back({(char *)ent.name, (char *)ent.sig, cppSym});
-  }
-
-  auto jClazz = frame.getJniEnv().createLocalReference(
-      std::const_pointer_cast<FakeJni::JClass>(clazz));
-  if (frame.getJniEnv().RegisterNatives((jclass)jClazz, javaEntries.data(),
-                                        javaEntries.size()) != JNI_OK)
-    throw std::runtime_error("RegisterNatives failed");
+    auto jClazz = frame.getJniEnv().createLocalReference(std::const_pointer_cast<FakeJni::JClass>(clazz));
+    if (frame.getJniEnv().RegisterNatives((jclass)jClazz, javaEntries.data(), javaEntries.size()) != JNI_OK)
+        throw std::runtime_error("RegisterNatives failed");
 }
 
-void JniSupport::startGame(ANativeActivity_createFunc *activityOnCreate,
-                           void *stbiLoadFromMemory, void *stbiImageFree) {
-  FakeJni::LocalFrame frame(vm);
+void JniSupport::startGame(ANativeActivity_createFunc *activityOnCreate, void *stbiLoadFromMemory, void *stbiImageFree)
+{
+    FakeJni::LocalFrame frame(vm);
 
-  vm.attachLibrary("libfmod.so", "",
-                   {linker::dlopen, linker::dlsym, linker::dlclose_unlocked});
-  vm.attachLibrary("libminecraftpe.so", "",
-                   {linker::dlopen, linker::dlsym, linker::dlclose_unlocked});
+    vm.attachLibrary("libfmod.so", "", {linker::dlopen, linker::dlsym, linker::dlclose_unlocked});
+    vm.attachLibrary("libminecraftpe.so", "", {linker::dlopen, linker::dlsym, linker::dlclose_unlocked});
 
-  auto clz = vm.findClass("android/os/Build$VERSION");
-  auto clzRef = (jclass)frame.getJniEnv().createLocalReference(
-      std::const_pointer_cast<FakeJni::JClass>(clz));
-  auto sdkInt = frame.getJniEnv().GetStaticFieldID(clzRef, "SDK_INT", "I");
-  jint test = frame.getJniEnv().GetStaticIntField(clzRef, sdkInt);
-  if (test != 27)
-    abort();
+    auto clz = vm.findClass("android/os/Build$VERSION");
+    auto clzRef = (jclass)frame.getJniEnv().createLocalReference(std::const_pointer_cast<FakeJni::JClass>(clz));
+    auto sdkInt = frame.getJniEnv().GetStaticFieldID(clzRef, "SDK_INT", "I");
+    jint test = frame.getJniEnv().GetStaticIntField(clzRef, sdkInt);
+    if (test != 27)
+        abort();
 
-  activity = std::make_shared<MainActivity>();
-  activityRef = vm.createGlobalReference(activity);
+    activity = std::make_shared<MainActivity>();
+    activityRef = vm.createGlobalReference(activity);
 
-  activity->textInput = &textInput;
-  activity->quitCallback = [this]() { requestExitGame(); };
-  activity->storageDirectory = PathHelper::getPrimaryDataDirectory();
-  activity->stbi_load_from_memory =
-      (decltype(activity->stbi_load_from_memory))stbiLoadFromMemory;
-  activity->stbi_image_free =
-      (decltype(activity->stbi_image_free))stbiImageFree;
+    activity->textInput = &textInput;
+    activity->quitCallback = [this]() { requestExitGame(); };
+    activity->storageDirectory = PathHelper::getPrimaryDataDirectory();
+    activity->stbi_load_from_memory = (decltype(activity->stbi_load_from_memory))stbiLoadFromMemory;
+    activity->stbi_image_free = (decltype(activity->stbi_image_free))stbiImageFree;
 
-  assetManager =
-      std::make_unique<FakeAssetManager>(PathHelper::getGameDir() + "assets");
+    assetManager = std::make_unique<FakeAssetManager>(PathHelper::getGameDir() + "assets");
 
-  XboxLiveHelper::getInstance().setJvm(&vm);
+    XboxLiveHelper::getInstance().setJvm(&vm);
 
-  nativeActivity.callbacks = &nativeActivityCallbacks;
-  nativeActivity.vm = (JavaVM *)&vm;
-  nativeActivity.assetManager = (AAssetManager *)assetManager.get();
-  nativeActivity.env = (JNIEnv *)&frame.getJniEnv();
-  nativeActivity.internalDataPath = "/internal";
-  nativeActivity.externalDataPath = "/external";
-  nativeActivity.clazz = activityRef;
-  nativeActivity.sdkVersion = activity->getAndroidVersion();
+    nativeActivity.callbacks = &nativeActivityCallbacks;
+    nativeActivity.vm = (JavaVM *)&vm;
+    nativeActivity.assetManager = (AAssetManager *)assetManager.get();
+    nativeActivity.env = (JNIEnv *)&frame.getJniEnv();
+    nativeActivity.internalDataPath = "/internal";
+    nativeActivity.externalDataPath = "/external";
+    nativeActivity.clazz = activityRef;
+    nativeActivity.sdkVersion = activity->getAndroidVersion();
 
-  Log::trace("JniSupport", "Invoking nativeRegisterThis\n");
-  auto registerThis =
-      activity->getClass().getMethod("()V", "nativeRegisterThis");
-  if (registerThis)
-    registerThis->invoke(frame.getJniEnv(), activity.get());
+    Log::trace("JniSupport", "Invoking nativeRegisterThis\n");
+    auto registerThis = activity->getClass().getMethod("()V", "nativeRegisterThis");
+    if (registerThis)
+        registerThis->invoke(frame.getJniEnv(), activity.get());
 
-  Log::trace("JniSupport", "Invoking ANativeActivity_onCreate\n");
-  activityOnCreate(&nativeActivity, nullptr, 0);
+    Log::trace("JniSupport", "Invoking ANativeActivity_onCreate\n");
+    activityOnCreate(&nativeActivity, nullptr, 0);
 
-  Log::trace("JniSupport", "Invoking start activity callbacks\n");
-  nativeActivityCallbacks.onInputQueueCreated(&nativeActivity, inputQueue);
-  nativeActivityCallbacks.onNativeWindowCreated(&nativeActivity, window);
-  nativeActivityCallbacks.onStart(&nativeActivity);
-  nativeActivityCallbacks.onResume(&nativeActivity);
+    Log::trace("JniSupport", "Invoking start activity callbacks\n");
+    nativeActivityCallbacks.onInputQueueCreated(&nativeActivity, inputQueue);
+    nativeActivityCallbacks.onNativeWindowCreated(&nativeActivity, window);
+    nativeActivityCallbacks.onStart(&nativeActivity);
+    nativeActivityCallbacks.onResume(&nativeActivity);
 }
 
-void JniSupport::stopGame() {
-  FakeJni::LocalFrame frame(vm);
+void JniSupport::stopGame()
+{
+    FakeJni::LocalFrame frame(vm);
 
-  Log::trace("JniSupport", "Invoking stop activity callbacks\n");
-  auto nativeStopThis = activity->getClass().getMethod("()V", "nativeStopThis");
-  nativeStopThis->invoke(frame.getJniEnv(), activity.get());
-  auto nativeUnregisterThis =
-      activity->getClass().getMethod("()V", "nativeUnregisterThis");
-  if (nativeUnregisterThis)
-    nativeUnregisterThis->invoke(frame.getJniEnv(), activity.get());
-  auto nativeOnDestroy =
-      activity->getClass().getMethod("()V", "nativeOnDestroy");
-  nativeOnDestroy->invoke(frame.getJniEnv(), activity.get());
-  nativeActivityCallbacks.onPause(&nativeActivity);
-  nativeActivityCallbacks.onStop(&nativeActivity);
-  nativeActivityCallbacks.onDestroy(&nativeActivity);
+    Log::trace("JniSupport", "Invoking stop activity callbacks\n");
+    auto nativeStopThis = activity->getClass().getMethod("()V", "nativeStopThis");
+    nativeStopThis->invoke(frame.getJniEnv(), activity.get());
+    auto nativeUnregisterThis = activity->getClass().getMethod("()V", "nativeUnregisterThis");
+    if (nativeUnregisterThis)
+        nativeUnregisterThis->invoke(frame.getJniEnv(), activity.get());
+    auto nativeOnDestroy = activity->getClass().getMethod("()V", "nativeOnDestroy");
+    nativeOnDestroy->invoke(frame.getJniEnv(), activity.get());
+    nativeActivityCallbacks.onPause(&nativeActivity);
+    nativeActivityCallbacks.onStop(&nativeActivity);
+    nativeActivityCallbacks.onDestroy(&nativeActivity);
 
-  Log::trace("JniSupport", "Waiting for looper clean up\n");
-  std::unique_lock<std::mutex> lock(gameExitMutex);
-  gameExitCond.wait(lock, [this] { return !looperRunning; });
-  Log::trace("JniSupport", "exited\n");
+    Log::trace("JniSupport", "Waiting for looper clean up\n");
+    std::unique_lock<std::mutex> lock(gameExitMutex);
+    gameExitCond.wait(lock, [this] { return !looperRunning; });
+    Log::trace("JniSupport", "exited\n");
 }
 
-void JniSupport::waitForGameExit() {
-  std::unique_lock<std::mutex> lock(gameExitMutex);
-  gameExitCond.wait(lock, [this] { return gameExitVal; });
+void JniSupport::waitForGameExit()
+{
+    std::unique_lock<std::mutex> lock(gameExitMutex);
+    gameExitCond.wait(lock, [this] { return gameExitVal; });
 }
 
-void JniSupport::requestExitGame() {
-  std::unique_lock<std::mutex> lock(gameExitMutex);
-  gameExitVal = true;
-  gameExitCond.notify_all();
-  std::thread([this]() { JniSupport::stopGame(); }).detach();
-}
-
-void JniSupport::setLooperRunning(bool running) {
-  std::unique_lock<std::mutex> lock(gameExitMutex);
-  looperRunning = running;
-  if (!running)
+void JniSupport::requestExitGame()
+{
+    std::unique_lock<std::mutex> lock(gameExitMutex);
+    gameExitVal = true;
     gameExitCond.notify_all();
+    std::thread([this]() { JniSupport::stopGame(); }).detach();
 }
 
-void JniSupport::onWindowCreated(ANativeWindow *window,
-                                 AInputQueue *inputQueue) {
-  // Note on thread safety: This code is fine thread-wise because
-  // ANativeActivity_onCreate locks until the thread is initialized; the thread
-  // initialization code runs ALooper_prepare before signaling it's ready.
-  this->window = window;
-  this->inputQueue = inputQueue;
-  activity->window = (GameWindow *)window;
+void JniSupport::setLooperRunning(bool running)
+{
+    std::unique_lock<std::mutex> lock(gameExitMutex);
+    looperRunning = running;
+    if (!running)
+        gameExitCond.notify_all();
 }
 
-void JniSupport::onWindowClosed() {
-  FakeJni::LocalFrame frame(vm);
-  auto shutdown = activity->getClass().getMethod("()V", "nativeShutdown");
-  shutdown->invoke(frame.getJniEnv(), activity.get());
+void JniSupport::onWindowCreated(ANativeWindow *window, AInputQueue *inputQueue)
+{
+    // Note on thread safety: This code is fine thread-wise because
+    // ANativeActivity_onCreate locks until the thread is initialized; the thread
+    // initialization code runs ALooper_prepare before signaling it's ready.
+    this->window = window;
+    this->inputQueue = inputQueue;
+    activity->window = (GameWindow *)window;
 }
 
-void JniSupport::onWindowResized(int newWidth, int newHeight) {
-  FakeJni::LocalFrame frame(vm);
-  auto resize = activity->getClass().getMethod("(II)V", "nativeResize");
-  if (resize)
-    resize->invoke(frame.getJniEnv(), activity.get(), newWidth, newHeight);
+void JniSupport::onWindowClosed()
+{
+    FakeJni::LocalFrame frame(vm);
+    auto shutdown = activity->getClass().getMethod("()V", "nativeShutdown");
+    shutdown->invoke(frame.getJniEnv(), activity.get());
 }
 
-void JniSupport::onSetTextboxText(std::string const &text) {
-  FakeJni::LocalFrame frame(vm);
-  auto setText = activity->getClass().getMethod("(Ljava/lang/String;)V",
-                                                "nativeSetTextboxText");
-  if (setText) {
-    auto str = std::make_shared<FakeJni::JString>(text);
-    setText->invoke(frame.getJniEnv(), activity.get(),
-                    frame.getJniEnv().createLocalReference(str));
-  }
+void JniSupport::onWindowResized(int newWidth, int newHeight)
+{
+    FakeJni::LocalFrame frame(vm);
+    auto resize = activity->getClass().getMethod("(II)V", "nativeResize");
+    if (resize)
+        resize->invoke(frame.getJniEnv(), activity.get(), newWidth, newHeight);
 }
 
-void JniSupport::onReturnKeyPressed() {
-  FakeJni::LocalFrame frame(vm);
-  auto returnPressed =
-      activity->getClass().getMethod("()V", "nativeReturnKeyPressed");
-  if (returnPressed)
-    returnPressed->invoke(frame.getJniEnv(), activity.get());
+void JniSupport::onSetTextboxText(std::string const &text)
+{
+    FakeJni::LocalFrame frame(vm);
+    auto setText = activity->getClass().getMethod("(Ljava/lang/String;)V", "nativeSetTextboxText");
+    if (setText)
+    {
+        auto str = std::make_shared<FakeJni::JString>(text);
+        setText->invoke(frame.getJniEnv(), activity.get(), frame.getJniEnv().createLocalReference(str));
+    }
 }
 
-void JniSupport::setGameControllerConnected(int devId, bool connected) {
-  static auto addedMethod = JellyBeanDeviceManager::getDescriptor()->getMethod(
-      "(I)V", "onInputDeviceAddedNative");
-  static auto removedMethod =
-      JellyBeanDeviceManager::getDescriptor()->getMethod(
-          "(I)V", "onInputDeviceRemovedNative");
+void JniSupport::onReturnKeyPressed()
+{
+    FakeJni::LocalFrame frame(vm);
+    auto returnPressed = activity->getClass().getMethod("()V", "nativeReturnKeyPressed");
+    if (returnPressed)
+        returnPressed->invoke(frame.getJniEnv(), activity.get());
+}
 
-  FakeJni::LocalFrame frame(vm);
-  if (connected && addedMethod)
-    addedMethod->invoke(frame.getJniEnv(),
-                        JellyBeanDeviceManager::getDescriptor().get(), devId);
-  else if (connected && removedMethod)
-    removedMethod->invoke(frame.getJniEnv(),
-                          JellyBeanDeviceManager::getDescriptor().get(), devId);
+void JniSupport::setGameControllerConnected(int devId, bool connected)
+{
+    static auto addedMethod = JellyBeanDeviceManager::getDescriptor()->getMethod("(I)V", "onInputDeviceAddedNative");
+    static auto removedMethod =
+        JellyBeanDeviceManager::getDescriptor()->getMethod("(I)V", "onInputDeviceRemovedNative");
+
+    FakeJni::LocalFrame frame(vm);
+    if (connected && addedMethod)
+        addedMethod->invoke(frame.getJniEnv(), JellyBeanDeviceManager::getDescriptor().get(), devId);
+    else if (connected && removedMethod)
+        removedMethod->invoke(frame.getJniEnv(), JellyBeanDeviceManager::getDescriptor().get(), devId);
 }

--- a/src/jni/jni_support.cpp
+++ b/src/jni/jni_support.cpp
@@ -1,307 +1,345 @@
-#include <log.h>
-#include <mcpelauncher/path_helper.h>
-#include <mcpelauncher/linker.h>
 #include "jni_support.h"
-#include "xbox_live.h"
-#include "lib_http_client.h"
-#include "cert_manager.h"
-#include "package_source.h"
 #include "../xbox_live_helper.h"
+#include "cert_manager.h"
 #include "http_stub.h"
+#include "lib_http_client.h"
+#include "package_source.h"
+#include "xbox_live.h"
+#include <log.h>
+#include <mcpelauncher/linker.h>
+#include <mcpelauncher/path_helper.h>
 #ifdef HAVE_PULSEAUDIO
 #include "pulseaudio.h"
 #endif
 #include "accounts.h"
-#include "ecdsa.h"
-#include "webview.h"
-#include "jbase64.h"
 #include "arrays.h"
+#include "ecdsa.h"
+#include "jbase64.h"
 #include "locale.h"
+#include "securerandom.h"
+#include "shahasher.h"
 #include "signature.h"
 #include "uuid.h"
-#include "shahasher.h"
-#include "securerandom.h"
+#include "webview.h"
 
 void JniSupport::registerJniClasses() {
-    vm.registerClass<File>();
-    vm.registerClass<ClassLoader>();
-    vm.registerClass<Locale>();
-    vm.registerClass<UUID>();
+  vm.registerClass<File>();
+  vm.registerClass<ClassLoader>();
+  vm.registerClass<Locale>();
+  vm.registerClass<UUID>();
 
-    vm.registerClass<BuildVersion>();
-    vm.registerClass<PackageInfo>();
-    vm.registerClass<PackageManager>();
-    vm.registerClass<Context>();
-    vm.registerClass<ContextWrapper>();
-    vm.registerClass<HardwareInfo>();
-    vm.registerClass<Activity>();
-    vm.registerClass<NativeActivity>();
-    vm.registerClass<MainActivity>();
-    vm.registerClass<AccountManager>();
-    vm.registerClass<Account>();
+  vm.registerClass<BuildVersion>();
+  vm.registerClass<PackageInfo>();
+  vm.registerClass<PackageManager>();
+  vm.registerClass<Context>();
+  vm.registerClass<ContextWrapper>();
+  vm.registerClass<HardwareInfo>();
+  vm.registerClass<Activity>();
+  vm.registerClass<NativeActivity>();
+  vm.registerClass<MainActivity>();
+  vm.registerClass<AccountManager>();
+  vm.registerClass<Account>();
 
-    vm.registerClass<StoreListener>();
-    vm.registerClass<NativeStoreListener>();
-    vm.registerClass<Store>();
-    vm.registerClass<StoreFactory>();
-    vm.registerClass<ExtraLicenseResponseData>();
+  vm.registerClass<StoreListener>();
+  vm.registerClass<NativeStoreListener>();
+  vm.registerClass<Store>();
+  vm.registerClass<StoreFactory>();
+  vm.registerClass<ExtraLicenseResponseData>();
 
-    vm.registerClass<XboxInterop>();
-    vm.registerClass<XboxLocalStorage>();
-    vm.registerClass<Ecdsa>();
-    vm.registerClass<EcdsaPublicKey>();
-    vm.registerClass<HttpClientRequest>();
-    vm.registerClass<HttpClientResponse>();
+  vm.registerClass<XboxInterop>();
+  vm.registerClass<XboxLocalStorage>();
+  vm.registerClass<Ecdsa>();
+  vm.registerClass<EcdsaPublicKey>();
+  vm.registerClass<HttpClientRequest>();
+  vm.registerClass<HttpClientResponse>();
 
-    vm.registerClass<InputStream>();
-    vm.registerClass<ByteArrayInputStream>();
-    vm.registerClass<Certificate>();
-    vm.registerClass<X509Certificate>();
-    vm.registerClass<CertificateFactory>();
-    vm.registerClass<TrustManager>();
-    vm.registerClass<X509TrustManager>();
-    vm.registerClass<TrustManagerFactory>();
-    vm.registerClass<StrictHostnameVerifier>();
+  vm.registerClass<InputStream>();
+  vm.registerClass<ByteArrayInputStream>();
+  vm.registerClass<Certificate>();
+  vm.registerClass<X509Certificate>();
+  vm.registerClass<CertificateFactory>();
+  vm.registerClass<TrustManager>();
+  vm.registerClass<X509TrustManager>();
+  vm.registerClass<TrustManagerFactory>();
+  vm.registerClass<StrictHostnameVerifier>();
 
-    vm.registerClass<PackageSource>();
-    vm.registerClass<PackageSourceListener>();
-    vm.registerClass<NativePackageSourceListener>();
-    vm.registerClass<PackageSourceFactory>();
+  vm.registerClass<PackageSource>();
+  vm.registerClass<PackageSourceListener>();
+  vm.registerClass<NativePackageSourceListener>();
+  vm.registerClass<PackageSourceFactory>();
 
-    vm.registerClass<Header>();
-    vm.registerClass<HTTPResponse>();
-    vm.registerClass<HTTPRequest>();
+  vm.registerClass<Header>();
+  vm.registerClass<HTTPResponse>();
+  vm.registerClass<HTTPRequest>();
 
-    vm.registerClass<ShaHasher>();
-    vm.registerClass<SecureRandom>();
-    // Minecraft 1.16.20-210
-    vm.registerClass<WebView>();
-    // Minecraft 1.16.220+
-    vm.registerClass<BrowserLaunchActivity>();
+  vm.registerClass<ShaHasher>();
+  vm.registerClass<SecureRandom>();
+  // Minecraft 1.16.20-210
+  vm.registerClass<WebView>();
+  // Minecraft 1.16.220+
+  vm.registerClass<BrowserLaunchActivity>();
 
-    vm.registerClass<JBase64>();
-    vm.registerClass<Arrays>();
-    vm.registerClass<Signature>();
-    vm.registerClass<PublicKey>();
-    vm.registerClass<Product>();
-    vm.registerClass<Purchase>();
-    vm.registerClass<NotificationListenerService>();
+  vm.registerClass<JBase64>();
+  vm.registerClass<Arrays>();
+  vm.registerClass<Signature>();
+  vm.registerClass<PublicKey>();
+  vm.registerClass<Product>();
+  vm.registerClass<Purchase>();
+  vm.registerClass<NotificationListenerService>();
 
 #ifdef HAVE_PULSEAUDIO
-    vm.registerClass<AudioDevice>();
+  vm.registerClass<AudioDevice>();
 #endif
 }
 
 void JniSupport::registerMinecraftNatives(void *(*symResolver)(const char *)) {
-    registerNatives(MainActivity::getDescriptor(), {
-            {"nativeRegisterThis", "()V"},
-            {"nativeWaitCrashManagementSetupComplete", "()V"},
-            {"nativeInitializeWithApplicationContext", "(Landroid/content/Context;)V"},
-            {"nativeShutdown", "()V"},
-            {"nativeUnregisterThis", "()V"},
-            {"nativeStopThis", "()V"},
-            {"nativeOnDestroy", "()V"},
-            {"nativeResize", "(II)V"},
-            {"nativeSetTextboxText", "(Ljava/lang/String;)V"},
-            {"nativeReturnKeyPressed", "()V"},
-            {"nativeOnPickImageSuccess", "(JLjava/lang/String;)V"},
-            {"nativeOnPickImageCanceled", "(J)V"},
-            {"nativeInitializeXboxLive", "(JJ)V"},
-            {"nativeinitializeLibHttpClient", "(J)J"}
-    }, symResolver);
-    registerNatives(NativeStoreListener::getDescriptor(), {
-            {"onStoreInitialized", "(JZ)V"},
-            {"onPurchaseFailed", "(JLjava/lang/String;)V"},
-            {"onQueryProductsSuccess", "(J[Lcom/mojang/minecraftpe/store/Product;)V"},
-            {"onQueryPurchasesSuccess", "(J[Lcom/mojang/minecraftpe/store/Purchase;)V"},
-    }, symResolver);
-    registerNatives(JellyBeanDeviceManager::getDescriptor(), {
-            {"onInputDeviceAddedNative", "(I)V"},
-            {"onInputDeviceRemovedNative", "(I)V"}
-    }, symResolver);
-    registerNatives(HttpClientRequest::getDescriptor(), {
-            {"OnRequestCompleted", "(JLcom/xbox/httpclient/HttpClientResponse;)V"},
-            {"OnRequestFailed", "(JLjava/lang/String;)V"}
-    }, symResolver);
-    registerNatives(WebView::getDescriptor(), {
-            {"urlOperationSucceeded", "(JLjava/lang/String;ZLjava/lang/String;)V"},
-    }, symResolver);
-    registerNatives(BrowserLaunchActivity::getDescriptor(), {
-            {"urlOperationSucceeded", "(JLjava/lang/String;ZLjava/lang/String;)V"},
-    }, symResolver);
-    registerNatives(NativeInputStream::getDescriptor(), {
-            {"nativeRead", "(JJ[BJJ)I"},
-    }, symResolver);
-    registerNatives(NativeOutputStream::getDescriptor(), {
-            {"nativeWrite", "(J[BII)V"},
-    }, symResolver);
+  registerNatives(MainActivity::getDescriptor(),
+                  {{"nativeRegisterThis", "()V"},
+                   {"nativeWaitCrashManagementSetupComplete", "()V"},
+                   {"nativeInitializeWithApplicationContext",
+                    "(Landroid/content/Context;)V"},
+                   {"nativeShutdown", "()V"},
+                   {"nativeUnregisterThis", "()V"},
+                   {"nativeStopThis", "()V"},
+                   {"nativeOnDestroy", "()V"},
+                   {"nativeResize", "(II)V"},
+                   {"nativeSetTextboxText", "(Ljava/lang/String;)V"},
+                   {"nativeReturnKeyPressed", "()V"},
+                   {"nativeOnPickImageSuccess", "(JLjava/lang/String;)V"},
+                   {"nativeOnPickImageCanceled", "(J)V"},
+                   {"nativeInitializeXboxLive", "(JJ)V"},
+                   {"nativeinitializeLibHttpClient", "(J)J"}},
+                  symResolver);
+  registerNatives(NativeStoreListener::getDescriptor(),
+                  {
+                      {"onStoreInitialized", "(JZ)V"},
+                      {"onPurchaseFailed", "(JLjava/lang/String;)V"},
+                      {"onQueryProductsSuccess",
+                       "(J[Lcom/mojang/minecraftpe/store/Product;)V"},
+                      {"onQueryPurchasesSuccess",
+                       "(J[Lcom/mojang/minecraftpe/store/Purchase;)V"},
+                  },
+                  symResolver);
+  registerNatives(JellyBeanDeviceManager::getDescriptor(),
+                  {{"onInputDeviceAddedNative", "(I)V"},
+                   {"onInputDeviceRemovedNative", "(I)V"}},
+                  symResolver);
+  registerNatives(
+      HttpClientRequest::getDescriptor(),
+      {{"OnRequestCompleted", "(JLcom/xbox/httpclient/HttpClientResponse;)V"},
+       {"OnRequestFailed", "(JLjava/lang/String;)V"}},
+      symResolver);
+  registerNatives(WebView::getDescriptor(),
+                  {
+                      {"urlOperationSucceeded",
+                       "(JLjava/lang/String;ZLjava/lang/String;)V"},
+                  },
+                  symResolver);
+  registerNatives(BrowserLaunchActivity::getDescriptor(),
+                  {
+                      {"urlOperationSucceeded",
+                       "(JLjava/lang/String;ZLjava/lang/String;)V"},
+                  },
+                  symResolver);
+  registerNatives(NativeInputStream::getDescriptor(),
+                  {
+                      {"nativeRead", "(JJ[BJJ)I"},
+                  },
+                  symResolver);
+  registerNatives(NativeOutputStream::getDescriptor(),
+                  {
+                      {"nativeWrite", "(J[BII)V"},
+                  },
+                  symResolver);
 }
 
-JniSupport::JniSupport() : textInput([this](std::string const &str) { return onSetTextboxText(str); }) {
-    registerJniClasses();
+JniSupport::JniSupport()
+    : textInput(
+          [this](std::string const &str) { return onSetTextboxText(str); }) {
+  registerJniClasses();
 }
 
 void JniSupport::registerNatives(std::shared_ptr<FakeJni::JClass const> clazz,
-        std::vector<JniSupport::NativeEntry> entries, void *(*symResolver)(const char *)) {
-    FakeJni::LocalFrame frame (vm);
+                                 std::vector<JniSupport::NativeEntry> entries,
+                                 void *(*symResolver)(const char *)) {
+  FakeJni::LocalFrame frame(vm);
 
-    std::string cppClassName = clazz->getName();
-    std::replace(cppClassName.begin(), cppClassName.end(), '/', '_');
+  std::string cppClassName = clazz->getName();
+  std::replace(cppClassName.begin(), cppClassName.end(), '/', '_');
 
-    std::vector<JNINativeMethod> javaEntries;
-    for (auto const &ent : entries) {
-        auto cppSymName = std::string("Java_") + cppClassName + "_" + ent.name;
-        auto cppSym = symResolver(cppSymName.c_str());
-        if (cppSym == nullptr) {
-            Log::error("JniSupport", "Missing native symbol: %s", cppSymName.c_str());
-            continue;
-        }
-
-        javaEntries.push_back({(char *) ent.name, (char *) ent.sig, cppSym});
+  std::vector<JNINativeMethod> javaEntries;
+  for (auto const &ent : entries) {
+    auto cppSymName = std::string("Java_") + cppClassName + "_" + ent.name;
+    auto cppSym = symResolver(cppSymName.c_str());
+    if (cppSym == nullptr) {
+      Log::error("JniSupport", "Missing native symbol: %s", cppSymName.c_str());
+      continue;
     }
 
-    auto jClazz = frame.getJniEnv().createLocalReference(std::const_pointer_cast<FakeJni::JClass>(clazz));
-    if (frame.getJniEnv().RegisterNatives((jclass) jClazz, javaEntries.data(), javaEntries.size()) != JNI_OK)
-        throw std::runtime_error("RegisterNatives failed");
+    javaEntries.push_back({(char *)ent.name, (char *)ent.sig, cppSym});
+  }
+
+  auto jClazz = frame.getJniEnv().createLocalReference(
+      std::const_pointer_cast<FakeJni::JClass>(clazz));
+  if (frame.getJniEnv().RegisterNatives((jclass)jClazz, javaEntries.data(),
+                                        javaEntries.size()) != JNI_OK)
+    throw std::runtime_error("RegisterNatives failed");
 }
 
 void JniSupport::startGame(ANativeActivity_createFunc *activityOnCreate,
-        void *stbiLoadFromMemory, void *stbiImageFree) {
-    FakeJni::LocalFrame frame (vm);
+                           void *stbiLoadFromMemory, void *stbiImageFree) {
+  FakeJni::LocalFrame frame(vm);
 
-    vm.attachLibrary("libfmod.so", "", {linker::dlopen, linker::dlsym, linker::dlclose_unlocked});
-    vm.attachLibrary("libminecraftpe.so", "", {linker::dlopen, linker::dlsym, linker::dlclose_unlocked});
+  vm.attachLibrary("libfmod.so", "",
+                   {linker::dlopen, linker::dlsym, linker::dlclose_unlocked});
+  vm.attachLibrary("libminecraftpe.so", "",
+                   {linker::dlopen, linker::dlsym, linker::dlclose_unlocked});
 
-    auto clz = vm.findClass("android/os/Build$VERSION");
-    auto clzRef = (jclass) frame.getJniEnv().createLocalReference(std::const_pointer_cast<FakeJni::JClass>(clz));
-    auto sdkInt = frame.getJniEnv().GetStaticFieldID(clzRef, "SDK_INT", "I");
-    jint test = frame.getJniEnv().GetStaticIntField(clzRef, sdkInt);
-    if (test != 27)
-        abort();
+  auto clz = vm.findClass("android/os/Build$VERSION");
+  auto clzRef = (jclass)frame.getJniEnv().createLocalReference(
+      std::const_pointer_cast<FakeJni::JClass>(clz));
+  auto sdkInt = frame.getJniEnv().GetStaticFieldID(clzRef, "SDK_INT", "I");
+  jint test = frame.getJniEnv().GetStaticIntField(clzRef, sdkInt);
+  if (test != 27)
+    abort();
 
-    activity = std::make_shared<MainActivity>();
-    activityRef = vm.createGlobalReference(activity);
+  activity = std::make_shared<MainActivity>();
+  activityRef = vm.createGlobalReference(activity);
 
-    activity->textInput = &textInput;
-    activity->quitCallback = [this]() { requestExitGame(); };
-    activity->storageDirectory = PathHelper::getPrimaryDataDirectory();
-    activity->stbi_load_from_memory = (decltype(activity->stbi_load_from_memory)) stbiLoadFromMemory;
-    activity->stbi_image_free = (decltype(activity->stbi_image_free)) stbiImageFree;
+  activity->textInput = &textInput;
+  activity->quitCallback = [this]() { requestExitGame(); };
+  activity->storageDirectory = PathHelper::getPrimaryDataDirectory();
+  activity->stbi_load_from_memory =
+      (decltype(activity->stbi_load_from_memory))stbiLoadFromMemory;
+  activity->stbi_image_free =
+      (decltype(activity->stbi_image_free))stbiImageFree;
 
-    assetManager = std::make_unique<FakeAssetManager>(PathHelper::getGameDir() + "assets");
+  assetManager =
+      std::make_unique<FakeAssetManager>(PathHelper::getGameDir() + "assets");
 
-    XboxLiveHelper::getInstance().setJvm(&vm);
+  XboxLiveHelper::getInstance().setJvm(&vm);
 
-    nativeActivity.callbacks = &nativeActivityCallbacks;
-    nativeActivity.vm = (JavaVM *) &vm;
-    nativeActivity.assetManager = (AAssetManager *) assetManager.get();
-    nativeActivity.env = (JNIEnv *) &frame.getJniEnv();
-    nativeActivity.internalDataPath = "/internal";
-    nativeActivity.externalDataPath = "/external";
-    nativeActivity.clazz = activityRef;
-    nativeActivity.sdkVersion = activity->getAndroidVersion();
+  nativeActivity.callbacks = &nativeActivityCallbacks;
+  nativeActivity.vm = (JavaVM *)&vm;
+  nativeActivity.assetManager = (AAssetManager *)assetManager.get();
+  nativeActivity.env = (JNIEnv *)&frame.getJniEnv();
+  nativeActivity.internalDataPath = "/internal";
+  nativeActivity.externalDataPath = "/external";
+  nativeActivity.clazz = activityRef;
+  nativeActivity.sdkVersion = activity->getAndroidVersion();
 
-    Log::trace("JniSupport", "Invoking nativeRegisterThis\n");
-    auto registerThis = activity->getClass().getMethod("()V", "nativeRegisterThis");
-    if(registerThis)
-        registerThis->invoke(frame.getJniEnv(), activity.get());
+  Log::trace("JniSupport", "Invoking nativeRegisterThis\n");
+  auto registerThis =
+      activity->getClass().getMethod("()V", "nativeRegisterThis");
+  if (registerThis)
+    registerThis->invoke(frame.getJniEnv(), activity.get());
 
-    Log::trace("JniSupport", "Invoking ANativeActivity_onCreate\n");
-    activityOnCreate(&nativeActivity, nullptr, 0);
+  Log::trace("JniSupport", "Invoking ANativeActivity_onCreate\n");
+  activityOnCreate(&nativeActivity, nullptr, 0);
 
-    Log::trace("JniSupport", "Invoking start activity callbacks\n");
-    nativeActivityCallbacks.onInputQueueCreated(&nativeActivity, inputQueue);
-    nativeActivityCallbacks.onNativeWindowCreated(&nativeActivity, window);
-    nativeActivityCallbacks.onStart(&nativeActivity);
-    nativeActivityCallbacks.onResume(&nativeActivity);
+  Log::trace("JniSupport", "Invoking start activity callbacks\n");
+  nativeActivityCallbacks.onInputQueueCreated(&nativeActivity, inputQueue);
+  nativeActivityCallbacks.onNativeWindowCreated(&nativeActivity, window);
+  nativeActivityCallbacks.onStart(&nativeActivity);
+  nativeActivityCallbacks.onResume(&nativeActivity);
 }
 
 void JniSupport::stopGame() {
-    FakeJni::LocalFrame frame (vm);
+  FakeJni::LocalFrame frame(vm);
 
-    Log::trace("JniSupport", "Invoking stop activity callbacks\n");
-    auto nativeStopThis = activity->getClass().getMethod("()V", "nativeStopThis");
-    nativeStopThis->invoke(frame.getJniEnv(), activity.get());
-    auto nativeUnregisterThis = activity->getClass().getMethod("()V", "nativeUnregisterThis");
-    if (nativeUnregisterThis)
-        nativeUnregisterThis->invoke(frame.getJniEnv(), activity.get());
-    auto nativeOnDestroy = activity->getClass().getMethod("()V", "nativeOnDestroy");
-    nativeOnDestroy->invoke(frame.getJniEnv(), activity.get());
-    nativeActivityCallbacks.onPause(&nativeActivity);
-    nativeActivityCallbacks.onStop(&nativeActivity);
-    nativeActivityCallbacks.onDestroy(&nativeActivity);
+  Log::trace("JniSupport", "Invoking stop activity callbacks\n");
+  auto nativeStopThis = activity->getClass().getMethod("()V", "nativeStopThis");
+  nativeStopThis->invoke(frame.getJniEnv(), activity.get());
+  auto nativeUnregisterThis =
+      activity->getClass().getMethod("()V", "nativeUnregisterThis");
+  if (nativeUnregisterThis)
+    nativeUnregisterThis->invoke(frame.getJniEnv(), activity.get());
+  auto nativeOnDestroy =
+      activity->getClass().getMethod("()V", "nativeOnDestroy");
+  nativeOnDestroy->invoke(frame.getJniEnv(), activity.get());
+  nativeActivityCallbacks.onPause(&nativeActivity);
+  nativeActivityCallbacks.onStop(&nativeActivity);
+  nativeActivityCallbacks.onDestroy(&nativeActivity);
 
-    Log::trace("JniSupport", "Waiting for looper clean up\n");
-    std::unique_lock<std::mutex> lock (gameExitMutex);
-    gameExitCond.wait(lock, [this]{ return !looperRunning; });
-    Log::trace("JniSupport", "exited\n");
+  Log::trace("JniSupport", "Waiting for looper clean up\n");
+  std::unique_lock<std::mutex> lock(gameExitMutex);
+  gameExitCond.wait(lock, [this] { return !looperRunning; });
+  Log::trace("JniSupport", "exited\n");
 }
 
 void JniSupport::waitForGameExit() {
-    std::unique_lock<std::mutex> lock (gameExitMutex);
-    gameExitCond.wait(lock, [this]{ return gameExitVal; });
+  std::unique_lock<std::mutex> lock(gameExitMutex);
+  gameExitCond.wait(lock, [this] { return gameExitVal; });
 }
 
 void JniSupport::requestExitGame() {
-    std::unique_lock<std::mutex> lock (gameExitMutex);
-    gameExitVal = true;
-    gameExitCond.notify_all();
-    std::thread([this]() {
-        JniSupport::stopGame();
-    }).detach();
+  std::unique_lock<std::mutex> lock(gameExitMutex);
+  gameExitVal = true;
+  gameExitCond.notify_all();
+  std::thread([this]() { JniSupport::stopGame(); }).detach();
 }
 
 void JniSupport::setLooperRunning(bool running) {
-    std::unique_lock<std::mutex> lock (gameExitMutex);
-    looperRunning = running;
-    if (!running)
-        gameExitCond.notify_all();
+  std::unique_lock<std::mutex> lock(gameExitMutex);
+  looperRunning = running;
+  if (!running)
+    gameExitCond.notify_all();
 }
 
-void JniSupport::onWindowCreated(ANativeWindow *window, AInputQueue *inputQueue) {
-    // Note on thread safety: This code is fine thread-wise because ANativeActivity_onCreate locks until the thread is
-    // initialized; the thread initialization code runs ALooper_prepare before signaling it's ready.
-    this->window = window;
-    this->inputQueue = inputQueue;
-    activity->window = (GameWindow*)window;
+void JniSupport::onWindowCreated(ANativeWindow *window,
+                                 AInputQueue *inputQueue) {
+  // Note on thread safety: This code is fine thread-wise because
+  // ANativeActivity_onCreate locks until the thread is initialized; the thread
+  // initialization code runs ALooper_prepare before signaling it's ready.
+  this->window = window;
+  this->inputQueue = inputQueue;
+  activity->window = (GameWindow *)window;
 }
 
 void JniSupport::onWindowClosed() {
-    FakeJni::LocalFrame frame (vm);
-    auto shutdown = activity->getClass().getMethod("()V", "nativeShutdown");
-    shutdown->invoke(frame.getJniEnv(), activity.get());
+  FakeJni::LocalFrame frame(vm);
+  auto shutdown = activity->getClass().getMethod("()V", "nativeShutdown");
+  shutdown->invoke(frame.getJniEnv(), activity.get());
 }
 
 void JniSupport::onWindowResized(int newWidth, int newHeight) {
-    FakeJni::LocalFrame frame (vm);
-    auto resize = activity->getClass().getMethod("(II)V", "nativeResize");
-    if (resize)
-        resize->invoke(frame.getJniEnv(), activity.get(), newWidth, newHeight);
+  FakeJni::LocalFrame frame(vm);
+  auto resize = activity->getClass().getMethod("(II)V", "nativeResize");
+  if (resize)
+    resize->invoke(frame.getJniEnv(), activity.get(), newWidth, newHeight);
 }
 
 void JniSupport::onSetTextboxText(std::string const &text) {
-    FakeJni::LocalFrame frame (vm);
-    auto setText = activity->getClass().getMethod("(Ljava/lang/String;)V", "nativeSetTextboxText");
-    if (setText) {
-        auto str = std::make_shared<FakeJni::JString>(text);
-        setText->invoke(frame.getJniEnv(), activity.get(), frame.getJniEnv().createLocalReference(str));
-    }
+  FakeJni::LocalFrame frame(vm);
+  auto setText = activity->getClass().getMethod("(Ljava/lang/String;)V",
+                                                "nativeSetTextboxText");
+  if (setText) {
+    auto str = std::make_shared<FakeJni::JString>(text);
+    setText->invoke(frame.getJniEnv(), activity.get(),
+                    frame.getJniEnv().createLocalReference(str));
+  }
 }
 
 void JniSupport::onReturnKeyPressed() {
-    FakeJni::LocalFrame frame (vm);
-    auto returnPressed = activity->getClass().getMethod("()V", "nativeReturnKeyPressed");
-    if (returnPressed)
-        returnPressed->invoke(frame.getJniEnv(), activity.get());
+  FakeJni::LocalFrame frame(vm);
+  auto returnPressed =
+      activity->getClass().getMethod("()V", "nativeReturnKeyPressed");
+  if (returnPressed)
+    returnPressed->invoke(frame.getJniEnv(), activity.get());
 }
 
 void JniSupport::setGameControllerConnected(int devId, bool connected) {
-    static auto addedMethod = JellyBeanDeviceManager::getDescriptor()->getMethod("(I)V", "onInputDeviceAddedNative");
-    static auto removedMethod = JellyBeanDeviceManager::getDescriptor()->getMethod("(I)V", "onInputDeviceRemovedNative");
+  static auto addedMethod = JellyBeanDeviceManager::getDescriptor()->getMethod(
+      "(I)V", "onInputDeviceAddedNative");
+  static auto removedMethod =
+      JellyBeanDeviceManager::getDescriptor()->getMethod(
+          "(I)V", "onInputDeviceRemovedNative");
 
-    FakeJni::LocalFrame frame (vm);
-    if (connected && addedMethod)
-        addedMethod->invoke(frame.getJniEnv(), JellyBeanDeviceManager::getDescriptor().get(), devId);
-    else if (connected && removedMethod)
-        removedMethod->invoke(frame.getJniEnv(), JellyBeanDeviceManager::getDescriptor().get(), devId);
+  FakeJni::LocalFrame frame(vm);
+  if (connected && addedMethod)
+    addedMethod->invoke(frame.getJniEnv(),
+                        JellyBeanDeviceManager::getDescriptor().get(), devId);
+  else if (connected && removedMethod)
+    removedMethod->invoke(frame.getJniEnv(),
+                          JellyBeanDeviceManager::getDescriptor().get(), devId);
 }

--- a/src/jni/jni_support.h
+++ b/src/jni/jni_support.h
@@ -10,11 +10,9 @@
 #include "main_activity.h"
 #include "store.h"
 
-struct JniSupport
-{
+struct JniSupport {
    private:
-    struct NativeEntry
-    {
+    struct NativeEntry {
         const char *name;
         const char *sig;
     };

--- a/src/jni/jni_support.h
+++ b/src/jni/jni_support.h
@@ -1,69 +1,69 @@
 #pragma once
 
+#include "../fake_assetmanager.h"
+#include "../text_input_handler.h"
 #include "main_activity.h"
 #include "store.h"
-#include "../fake_assetmanager.h"
-#include <baron/baron.h>
 #include <android/native_activity.h>
-#include <game_window.h>
+#include <baron/baron.h>
 #include <condition_variable>
+#include <game_window.h>
 #include <mutex>
-#include "../text_input_handler.h"
 
 struct JniSupport {
 
 private:
-    struct NativeEntry {
-        const char *name;
-        const char *sig;
-    };
+  struct NativeEntry {
+    const char *name;
+    const char *sig;
+  };
 
-    Baron::Jvm vm;
-    ANativeActivityCallbacks nativeActivityCallbacks;
-    ANativeActivity nativeActivity;
-    std::shared_ptr<MainActivity> activity;
-    jobject activityRef;
-    std::unique_ptr<FakeAssetManager> assetManager;
-    ANativeWindow *window;
-    AInputQueue *inputQueue;
-    std::condition_variable gameExitCond;
-    std::mutex gameExitMutex;
-    bool gameExitVal = false, looperRunning = false;
-    TextInputHandler textInput;
+  Baron::Jvm vm;
+  ANativeActivityCallbacks nativeActivityCallbacks;
+  ANativeActivity nativeActivity;
+  std::shared_ptr<MainActivity> activity;
+  jobject activityRef;
+  std::unique_ptr<FakeAssetManager> assetManager;
+  ANativeWindow *window;
+  AInputQueue *inputQueue;
+  std::condition_variable gameExitCond;
+  std::mutex gameExitMutex;
+  bool gameExitVal = false, looperRunning = false;
+  TextInputHandler textInput;
 
-    void registerJniClasses();
+  void registerJniClasses();
 
-    void registerNatives(std::shared_ptr<FakeJni::JClass const> clazz, std::vector<NativeEntry> entries,
-                         void *(*symResolver)(const char *));
+  void registerNatives(std::shared_ptr<FakeJni::JClass const> clazz,
+                       std::vector<NativeEntry> entries,
+                       void *(*symResolver)(const char *));
 
 public:
-    JniSupport();
+  JniSupport();
 
-    void registerMinecraftNatives(void *(*symResolver)(const char *));
+  void registerMinecraftNatives(void *(*symResolver)(const char *));
 
-    void startGame(ANativeActivity_createFunc *activityOnCreate,
-        void *stbiLoadFromMemory, void *stbiImageFree);
+  void startGame(ANativeActivity_createFunc *activityOnCreate,
+                 void *stbiLoadFromMemory, void *stbiImageFree);
 
-    void stopGame();
+  void stopGame();
 
-    void waitForGameExit();
+  void waitForGameExit();
 
-    void requestExitGame();
+  void requestExitGame();
 
-    void setLooperRunning(bool running);
+  void setLooperRunning(bool running);
 
-    void onWindowCreated(ANativeWindow *window, AInputQueue *inputQueue);
+  void onWindowCreated(ANativeWindow *window, AInputQueue *inputQueue);
 
-    void onWindowClosed();
+  void onWindowClosed();
 
-    void onWindowResized(int newWidth, int newHeight);
+  void onWindowResized(int newWidth, int newHeight);
 
-    void onSetTextboxText(std::string const &text);
+  void onSetTextboxText(std::string const &text);
 
-    void onReturnKeyPressed();
+  void onReturnKeyPressed();
 
-    void setGameControllerConnected(int devId, bool connected);
+  void setGameControllerConnected(int devId, bool connected);
 
-    TextInputHandler &getTextInputHandler() { return textInput; }
-
+  TextInputHandler &getTextInputHandler() { return textInput; }
 };

--- a/src/jni/jni_support.h
+++ b/src/jni/jni_support.h
@@ -1,69 +1,68 @@
 #pragma once
 
+#include <android/native_activity.h>
+#include <baron/baron.h>
+#include <game_window.h>
+#include <condition_variable>
+#include <mutex>
 #include "../fake_assetmanager.h"
 #include "../text_input_handler.h"
 #include "main_activity.h"
 #include "store.h"
-#include <android/native_activity.h>
-#include <baron/baron.h>
-#include <condition_variable>
-#include <game_window.h>
-#include <mutex>
 
-struct JniSupport {
+struct JniSupport
+{
+   private:
+    struct NativeEntry
+    {
+        const char *name;
+        const char *sig;
+    };
 
-private:
-  struct NativeEntry {
-    const char *name;
-    const char *sig;
-  };
+    Baron::Jvm vm;
+    ANativeActivityCallbacks nativeActivityCallbacks;
+    ANativeActivity nativeActivity;
+    std::shared_ptr<MainActivity> activity;
+    jobject activityRef;
+    std::unique_ptr<FakeAssetManager> assetManager;
+    ANativeWindow *window;
+    AInputQueue *inputQueue;
+    std::condition_variable gameExitCond;
+    std::mutex gameExitMutex;
+    bool gameExitVal = false, looperRunning = false;
+    TextInputHandler textInput;
 
-  Baron::Jvm vm;
-  ANativeActivityCallbacks nativeActivityCallbacks;
-  ANativeActivity nativeActivity;
-  std::shared_ptr<MainActivity> activity;
-  jobject activityRef;
-  std::unique_ptr<FakeAssetManager> assetManager;
-  ANativeWindow *window;
-  AInputQueue *inputQueue;
-  std::condition_variable gameExitCond;
-  std::mutex gameExitMutex;
-  bool gameExitVal = false, looperRunning = false;
-  TextInputHandler textInput;
+    void registerJniClasses();
 
-  void registerJniClasses();
+    void registerNatives(std::shared_ptr<FakeJni::JClass const> clazz, std::vector<NativeEntry> entries,
+                         void *(*symResolver)(const char *));
 
-  void registerNatives(std::shared_ptr<FakeJni::JClass const> clazz,
-                       std::vector<NativeEntry> entries,
-                       void *(*symResolver)(const char *));
+   public:
+    JniSupport();
 
-public:
-  JniSupport();
+    void registerMinecraftNatives(void *(*symResolver)(const char *));
 
-  void registerMinecraftNatives(void *(*symResolver)(const char *));
+    void startGame(ANativeActivity_createFunc *activityOnCreate, void *stbiLoadFromMemory, void *stbiImageFree);
 
-  void startGame(ANativeActivity_createFunc *activityOnCreate,
-                 void *stbiLoadFromMemory, void *stbiImageFree);
+    void stopGame();
 
-  void stopGame();
+    void waitForGameExit();
 
-  void waitForGameExit();
+    void requestExitGame();
 
-  void requestExitGame();
+    void setLooperRunning(bool running);
 
-  void setLooperRunning(bool running);
+    void onWindowCreated(ANativeWindow *window, AInputQueue *inputQueue);
 
-  void onWindowCreated(ANativeWindow *window, AInputQueue *inputQueue);
+    void onWindowClosed();
 
-  void onWindowClosed();
+    void onWindowResized(int newWidth, int newHeight);
 
-  void onWindowResized(int newWidth, int newHeight);
+    void onSetTextboxText(std::string const &text);
 
-  void onSetTextboxText(std::string const &text);
+    void onReturnKeyPressed();
 
-  void onReturnKeyPressed();
+    void setGameControllerConnected(int devId, bool connected);
 
-  void setGameControllerConnected(int devId, bool connected);
-
-  TextInputHandler &getTextInputHandler() { return textInput; }
+    TextInputHandler &getTextInputHandler() { return textInput; }
 };

--- a/src/jni/lib_http_client.cpp
+++ b/src/jni/lib_http_client.cpp
@@ -1,177 +1,202 @@
 #include "lib_http_client.h"
 #include "../util.h"
-#include <log.h>
 #include <curl/curl.h>
+#include <log.h>
 
 using namespace std::placeholders;
 
 HttpClientRequest::HttpClientRequest() {
-    curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, HttpClientRequest::write_callback_wrapper);
-    curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
-    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, HttpClientRequest::header_callback_wrapper);
+  curl = curl_easy_init();
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION,
+                   HttpClientRequest::write_callback_wrapper);
+  curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
+  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION,
+                   HttpClientRequest::header_callback_wrapper);
 }
 
-HttpClientRequest::~HttpClientRequest() {
-    curl_easy_cleanup(curl);
-}
+HttpClientRequest::~HttpClientRequest() { curl_easy_cleanup(curl); }
 
-FakeJni::JBoolean HttpClientRequest::isNetworkAvailable(std::shared_ptr<Context> context) {
-    return true;
+FakeJni::JBoolean
+HttpClientRequest::isNetworkAvailable(std::shared_ptr<Context> context) {
+  return true;
 }
 
 std::shared_ptr<HttpClientRequest> HttpClientRequest::createClientRequest() {
-    return std::make_shared<HttpClientRequest>();
+  return std::make_shared<HttpClientRequest>();
 }
 
 void HttpClientRequest::setHttpUrl(std::shared_ptr<FakeJni::JString> url) {
-    curl_easy_setopt(curl, CURLOPT_URL, url->asStdString().c_str());
+  curl_easy_setopt(curl, CURLOPT_URL, url->asStdString().c_str());
 }
 
-void HttpClientRequest::setHttpMethodAndBody(std::shared_ptr<FakeJni::JString> method,
-                                             std::shared_ptr<FakeJni::JString> contentType,
-                                             std::shared_ptr<FakeJni::JByteArray> body) {
-    this->method = method->asStdString();
-    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
-    this->body = body ? std::vector<char>((char*)body->getArray(), (char*)body->getArray() + body->getSize()) : std::vector<char>{};
-    if(this->body.size()) {
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
-    }
-    auto conttype = contentType->asStdString();
-    if(conttype.length()) {
-        header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
-        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
-    }
-}
-
-static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
-{
-    auto stream = (NativeInputStream*)userdata;
-    return stream->Read(ptr, size * nmemb);
-}
-
-void HttpClientRequest::setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString> method, FakeJni::JLong callHandle, std::shared_ptr<FakeJni::JString> contentType, FakeJni::JLong contentLength) {
-    this->method = method->asStdString();
-    // if(this->method == "POST") {
-    //     curl_easy_setopt(curl, CURLOPT_HTTPPOST, 1);        
-    // } else {
-        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
-    // }
-    if(contentLength > 0) {
-        // static auto ___callback = (void*)+[](char *ptr, size_t size, size_t nmemb, void *userdata) -> size_t {
-        //     auto stream = (NativeInputStream*)userdata;
-        //     return stream->Read(ptr, size * nmemb);
-        // };
-        // this->inputStream = std::make_shared<NativeInputStream>(callHandle);
-        // curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
-        // curl_easy_setopt(curl, CURLOPT_READDATA, this->inputStream.get());
-        // curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) contentLength);
-        this->body.resize(contentLength);
-        auto stream = std::make_shared<NativeInputStream>(callHandle);
-        auto read = stream->Read(this->body.data(), this->body.size());
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
-    }
-    auto conttype = contentType->asStdString();
-    if(conttype.length()) {
-        header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
-        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
-    }
-}
-
-void HttpClientRequest::setHttpHeader(std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> value) {
-    header = curl_slist_append(header, (name->asStdString() + ": " + value->asStdString()).c_str());
+void HttpClientRequest::setHttpMethodAndBody(
+    std::shared_ptr<FakeJni::JString> method,
+    std::shared_ptr<FakeJni::JString> contentType,
+    std::shared_ptr<FakeJni::JByteArray> body) {
+  this->method = method->asStdString();
+  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
+  this->body =
+      body ? std::vector<char>((char *)body->getArray(),
+                               (char *)body->getArray() + body->getSize())
+           : std::vector<char>{};
+  if (this->body.size()) {
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
+  }
+  auto conttype = contentType->asStdString();
+  if (conttype.length()) {
+    header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
+  }
+}
+
+static size_t read_callback(char *ptr, size_t size, size_t nmemb,
+                            void *userdata) {
+  auto stream = (NativeInputStream *)userdata;
+  return stream->Read(ptr, size * nmemb);
+}
+
+void HttpClientRequest::setHttpMethodAndBody2(
+    std::shared_ptr<FakeJni::JString> method, FakeJni::JLong callHandle,
+    std::shared_ptr<FakeJni::JString> contentType,
+    FakeJni::JLong contentLength) {
+  this->method = method->asStdString();
+  // if(this->method == "POST") {
+  //     curl_easy_setopt(curl, CURLOPT_HTTPPOST, 1);
+  // } else {
+  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
+  // }
+  if (contentLength > 0) {
+    // static auto ___callback = (void*)+[](char *ptr, size_t size, size_t
+    // nmemb, void *userdata) -> size_t {
+    //     auto stream = (NativeInputStream*)userdata;
+    //     return stream->Read(ptr, size * nmemb);
+    // };
+    // this->inputStream = std::make_shared<NativeInputStream>(callHandle);
+    // curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+    // curl_easy_setopt(curl, CURLOPT_READDATA, this->inputStream.get());
+    // curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)
+    // contentLength);
+    this->body.resize(contentLength);
+    auto stream = std::make_shared<NativeInputStream>(callHandle);
+    auto read = stream->Read(this->body.data(), this->body.size());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
+  }
+  auto conttype = contentType->asStdString();
+  if (conttype.length()) {
+    header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
+  }
+}
+
+void HttpClientRequest::setHttpHeader(std::shared_ptr<FakeJni::JString> name,
+                                      std::shared_ptr<FakeJni::JString> value) {
+  header = curl_slist_append(
+      header, (name->asStdString() + ": " + value->asStdString()).c_str());
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
 }
 
 void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall) {
-    auto ret = curl_easy_perform(curl);
-    long response_code;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-    FakeJni::LocalFrame frame;
-    if (ret == CURLE_OK) {
-        auto method = getClass().getMethod("(JLcom/xbox/httpclient/HttpClientResponse;)V", "OnRequestCompleted");
-        method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<HttpClientResponse>(sourceCall, response_code, response, headers)));
-    }
-    else {
-        auto method = getClass().getMethod("(JLjava/lang/String;)V", "OnRequestFailed");
-        method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
-    }
+  auto ret = curl_easy_perform(curl);
+  long response_code;
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+  FakeJni::LocalFrame frame;
+  if (ret == CURLE_OK) {
+    auto method = getClass().getMethod(
+        "(JLcom/xbox/httpclient/HttpClientResponse;)V", "OnRequestCompleted");
+    method->invoke(frame.getJniEnv(), this, sourceCall,
+                   frame.getJniEnv().createLocalReference(
+                       std::make_shared<HttpClientResponse>(
+                           sourceCall, response_code, response, headers)));
+  } else {
+    auto method =
+        getClass().getMethod("(JLjava/lang/String;)V", "OnRequestFailed");
+    method->invoke(frame.getJniEnv(), this, sourceCall,
+                   frame.getJniEnv().createLocalReference(
+                       std::make_shared<FakeJni::JString>("Error")));
+  }
 }
 
-FakeJni::JInt HttpClientResponse::getNumHeaders() {
-    return headers.size();
+FakeJni::JInt HttpClientResponse::getNumHeaders() { return headers.size(); }
+
+std::shared_ptr<FakeJni::JString>
+HttpClientResponse::getHeaderNameAtIndex(FakeJni::JInt index) {
+  return std::make_shared<FakeJni::JString>(headers[index].name);
 }
 
-std::shared_ptr<FakeJni::JString> HttpClientResponse::getHeaderNameAtIndex(FakeJni::JInt index) {
-    return std::make_shared<FakeJni::JString>(headers[index].name);
+std::shared_ptr<FakeJni::JString>
+HttpClientResponse::getHeaderValueAtIndex(FakeJni::JInt index) {
+  return std::make_shared<FakeJni::JString>(headers[index].value);
 }
 
-std::shared_ptr<FakeJni::JString> HttpClientResponse::getHeaderValueAtIndex(FakeJni::JInt index) {
-    return std::make_shared<FakeJni::JString>(headers[index].value);
-}
-
-std::shared_ptr<FakeJni::JByteArray> HttpClientResponse::getResponseBodyBytes() {
-    return std::make_shared<FakeJni::JByteArray>(body);
+std::shared_ptr<FakeJni::JByteArray>
+HttpClientResponse::getResponseBodyBytes() {
+  return std::make_shared<FakeJni::JByteArray>(body);
 }
 
 void HttpClientResponse::getResponseBodyBytes2() {
-    std::make_shared<NativeOutputStream>(call_handle)->WriteAll(getResponseBodyBytes());
+  std::make_shared<NativeOutputStream>(call_handle)
+      ->WriteAll(getResponseBodyBytes());
 }
 
-FakeJni::JInt HttpClientResponse::getResponseCode() {
-    return response_code;
-}
+FakeJni::JInt HttpClientResponse::getResponseCode() { return response_code; }
 
-HttpClientResponse::HttpClientResponse(FakeJni::JLong call_handle, int response_code, std::vector<signed char> body, std::vector<ResponseHeader> headers) :
-    response_code(response_code),
-    body(body),
-    headers(headers),
-    call_handle(call_handle)
-{}
+HttpClientResponse::HttpClientResponse(FakeJni::JLong call_handle,
+                                       int response_code,
+                                       std::vector<signed char> body,
+                                       std::vector<ResponseHeader> headers)
+    : response_code(response_code), body(body), headers(headers),
+      call_handle(call_handle) {}
 
 size_t HttpClientRequest::write_callback(char *ptr, size_t size, size_t nmemb) {
-    response.insert(response.end(), ptr, ptr + nmemb);
-    return size * nmemb;
+  response.insert(response.end(), ptr, ptr + nmemb);
+  return size * nmemb;
 }
 
-size_t HttpClientRequest::header_callback(char *buffer, size_t size, size_t nitems) {
-    auto string = std::string(buffer, nitems);
-    auto location = string.find(": ");
-    if (location != std::string::npos) {
-        auto name = string.substr(0, location);
-        auto value = string.substr(location+1, string.length());
-        trim(name);
-        trim(value);
-        headers.emplace_back(name, value);
-    }
-    return size * nitems;
+size_t HttpClientRequest::header_callback(char *buffer, size_t size,
+                                          size_t nitems) {
+  auto string = std::string(buffer, nitems);
+  auto location = string.find(": ");
+  if (location != std::string::npos) {
+    auto name = string.substr(0, location);
+    auto value = string.substr(location + 1, string.length());
+    trim(name);
+    trim(value);
+    headers.emplace_back(name, value);
+  }
+  return size * nitems;
 }
 
-NativeInputStream::NativeInputStream(FakeJni::JLong call_handle) : call_handle(call_handle) {
-
-}
+NativeInputStream::NativeInputStream(FakeJni::JLong call_handle)
+    : call_handle(call_handle) {}
 
 size_t NativeInputStream::Read(void *buffer, size_t size) {
-    FakeJni::LocalFrame frame;
-    auto method = getClass().getMethod("(JJ[BJJ)I", "nativeRead");
-    auto buf = std::make_shared<FakeJni::JByteArray>((size_t)std::numeric_limits<jsize>::max() < size ? std::numeric_limits<jsize>::max() : (jsize)size);
-    jvalue ret = method->invoke(frame.getJniEnv(), this, call_handle, offset, frame.getJniEnv().createLocalReference(buf), (FakeJni::JLong)0, (FakeJni::JLong)buf->getSize());
-    if(ret.i != -1) { 
-        memcpy(buffer, buf->getArray(), ret.i);
-        offset += ret.i;
-    }
-    return ret.i;
+  FakeJni::LocalFrame frame;
+  auto method = getClass().getMethod("(JJ[BJJ)I", "nativeRead");
+  auto buf = std::make_shared<FakeJni::JByteArray>(
+      (size_t)std::numeric_limits<jsize>::max() < size
+          ? std::numeric_limits<jsize>::max()
+          : (jsize)size);
+  jvalue ret =
+      method->invoke(frame.getJniEnv(), this, call_handle, offset,
+                     frame.getJniEnv().createLocalReference(buf),
+                     (FakeJni::JLong)0, (FakeJni::JLong)buf->getSize());
+  if (ret.i != -1) {
+    memcpy(buffer, buf->getArray(), ret.i);
+    offset += ret.i;
+  }
+  return ret.i;
 }
 
-NativeOutputStream::NativeOutputStream(FakeJni::JLong call_handle) : call_handle(call_handle) {
-
-}
+NativeOutputStream::NativeOutputStream(FakeJni::JLong call_handle)
+    : call_handle(call_handle) {}
 
 void NativeOutputStream::WriteAll(std::shared_ptr<FakeJni::JByteArray> data) {
-    FakeJni::LocalFrame frame;
-    auto method = getClass().getMethod("(J[BII)V", "nativeWrite");
-    method->invoke(frame.getJniEnv(), this, call_handle, frame.getJniEnv().createLocalReference(data), (FakeJni::JInt)0, (FakeJni::JInt)data->getSize());
+  FakeJni::LocalFrame frame;
+  auto method = getClass().getMethod("(J[BII)V", "nativeWrite");
+  method->invoke(frame.getJniEnv(), this, call_handle,
+                 frame.getJniEnv().createLocalReference(data), (FakeJni::JInt)0,
+                 (FakeJni::JInt)data->getSize());
 }

--- a/src/jni/lib_http_client.cpp
+++ b/src/jni/lib_http_client.cpp
@@ -1,202 +1,199 @@
 #include "lib_http_client.h"
-#include "../util.h"
 #include <curl/curl.h>
 #include <log.h>
+#include "../util.h"
 
 using namespace std::placeholders;
 
-HttpClientRequest::HttpClientRequest() {
-  curl = curl_easy_init();
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION,
-                   HttpClientRequest::write_callback_wrapper);
-  curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
-  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION,
-                   HttpClientRequest::header_callback_wrapper);
+HttpClientRequest::HttpClientRequest()
+{
+    curl = curl_easy_init();
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, HttpClientRequest::write_callback_wrapper);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, HttpClientRequest::header_callback_wrapper);
 }
 
 HttpClientRequest::~HttpClientRequest() { curl_easy_cleanup(curl); }
 
-FakeJni::JBoolean
-HttpClientRequest::isNetworkAvailable(std::shared_ptr<Context> context) {
-  return true;
+FakeJni::JBoolean HttpClientRequest::isNetworkAvailable(std::shared_ptr<Context> context) { return true; }
+
+std::shared_ptr<HttpClientRequest> HttpClientRequest::createClientRequest()
+{
+    return std::make_shared<HttpClientRequest>();
 }
 
-std::shared_ptr<HttpClientRequest> HttpClientRequest::createClientRequest() {
-  return std::make_shared<HttpClientRequest>();
+void HttpClientRequest::setHttpUrl(std::shared_ptr<FakeJni::JString> url)
+{
+    curl_easy_setopt(curl, CURLOPT_URL, url->asStdString().c_str());
 }
 
-void HttpClientRequest::setHttpUrl(std::shared_ptr<FakeJni::JString> url) {
-  curl_easy_setopt(curl, CURLOPT_URL, url->asStdString().c_str());
+void HttpClientRequest::setHttpMethodAndBody(std::shared_ptr<FakeJni::JString> method,
+                                             std::shared_ptr<FakeJni::JString> contentType,
+                                             std::shared_ptr<FakeJni::JByteArray> body)
+{
+    this->method = method->asStdString();
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
+    this->body = body ? std::vector<char>((char *)body->getArray(), (char *)body->getArray() + body->getSize())
+                      : std::vector<char>{};
+    if (this->body.size())
+    {
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
+    }
+    auto conttype = contentType->asStdString();
+    if (conttype.length())
+    {
+        header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
+    }
 }
 
-void HttpClientRequest::setHttpMethodAndBody(
-    std::shared_ptr<FakeJni::JString> method,
-    std::shared_ptr<FakeJni::JString> contentType,
-    std::shared_ptr<FakeJni::JByteArray> body) {
-  this->method = method->asStdString();
-  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
-  this->body =
-      body ? std::vector<char>((char *)body->getArray(),
-                               (char *)body->getArray() + body->getSize())
-           : std::vector<char>{};
-  if (this->body.size()) {
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
-  }
-  auto conttype = contentType->asStdString();
-  if (conttype.length()) {
-    header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+    auto stream = (NativeInputStream *)userdata;
+    return stream->Read(ptr, size * nmemb);
+}
+
+void HttpClientRequest::setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString> method, FakeJni::JLong callHandle,
+                                              std::shared_ptr<FakeJni::JString> contentType,
+                                              FakeJni::JLong contentLength)
+{
+    this->method = method->asStdString();
+    // if(this->method == "POST") {
+    //     curl_easy_setopt(curl, CURLOPT_HTTPPOST, 1);
+    // } else {
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
+    // }
+    if (contentLength > 0)
+    {
+        // static auto ___callback = (void*)+[](char *ptr, size_t size, size_t
+        // nmemb, void *userdata) -> size_t {
+        //     auto stream = (NativeInputStream*)userdata;
+        //     return stream->Read(ptr, size * nmemb);
+        // };
+        // this->inputStream = std::make_shared<NativeInputStream>(callHandle);
+        // curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+        // curl_easy_setopt(curl, CURLOPT_READDATA, this->inputStream.get());
+        // curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)
+        // contentLength);
+        this->body.resize(contentLength);
+        auto stream = std::make_shared<NativeInputStream>(callHandle);
+        auto read = stream->Read(this->body.data(), this->body.size());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
+    }
+    auto conttype = contentType->asStdString();
+    if (conttype.length())
+    {
+        header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
+    }
+}
+
+void HttpClientRequest::setHttpHeader(std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> value)
+{
+    header = curl_slist_append(header, (name->asStdString() + ": " + value->asStdString()).c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
-  }
 }
 
-static size_t read_callback(char *ptr, size_t size, size_t nmemb,
-                            void *userdata) {
-  auto stream = (NativeInputStream *)userdata;
-  return stream->Read(ptr, size * nmemb);
-}
-
-void HttpClientRequest::setHttpMethodAndBody2(
-    std::shared_ptr<FakeJni::JString> method, FakeJni::JLong callHandle,
-    std::shared_ptr<FakeJni::JString> contentType,
-    FakeJni::JLong contentLength) {
-  this->method = method->asStdString();
-  // if(this->method == "POST") {
-  //     curl_easy_setopt(curl, CURLOPT_HTTPPOST, 1);
-  // } else {
-  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
-  // }
-  if (contentLength > 0) {
-    // static auto ___callback = (void*)+[](char *ptr, size_t size, size_t
-    // nmemb, void *userdata) -> size_t {
-    //     auto stream = (NativeInputStream*)userdata;
-    //     return stream->Read(ptr, size * nmemb);
-    // };
-    // this->inputStream = std::make_shared<NativeInputStream>(callHandle);
-    // curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
-    // curl_easy_setopt(curl, CURLOPT_READDATA, this->inputStream.get());
-    // curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)
-    // contentLength);
-    this->body.resize(contentLength);
-    auto stream = std::make_shared<NativeInputStream>(callHandle);
-    auto read = stream->Read(this->body.data(), this->body.size());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
-  }
-  auto conttype = contentType->asStdString();
-  if (conttype.length()) {
-    header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
-  }
-}
-
-void HttpClientRequest::setHttpHeader(std::shared_ptr<FakeJni::JString> name,
-                                      std::shared_ptr<FakeJni::JString> value) {
-  header = curl_slist_append(
-      header, (name->asStdString() + ": " + value->asStdString()).c_str());
-  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
-}
-
-void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall) {
-  auto ret = curl_easy_perform(curl);
-  long response_code;
-  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-  FakeJni::LocalFrame frame;
-  if (ret == CURLE_OK) {
-    auto method = getClass().getMethod(
-        "(JLcom/xbox/httpclient/HttpClientResponse;)V", "OnRequestCompleted");
-    method->invoke(frame.getJniEnv(), this, sourceCall,
-                   frame.getJniEnv().createLocalReference(
-                       std::make_shared<HttpClientResponse>(
-                           sourceCall, response_code, response, headers)));
-  } else {
-    auto method =
-        getClass().getMethod("(JLjava/lang/String;)V", "OnRequestFailed");
-    method->invoke(frame.getJniEnv(), this, sourceCall,
-                   frame.getJniEnv().createLocalReference(
-                       std::make_shared<FakeJni::JString>("Error")));
-  }
+void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall)
+{
+    auto ret = curl_easy_perform(curl);
+    long response_code;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+    FakeJni::LocalFrame frame;
+    if (ret == CURLE_OK)
+    {
+        auto method = getClass().getMethod("(JLcom/xbox/httpclient/HttpClientResponse;)V", "OnRequestCompleted");
+        method->invoke(frame.getJniEnv(), this, sourceCall,
+                       frame.getJniEnv().createLocalReference(
+                           std::make_shared<HttpClientResponse>(sourceCall, response_code, response, headers)));
+    }
+    else
+    {
+        auto method = getClass().getMethod("(JLjava/lang/String;)V", "OnRequestFailed");
+        method->invoke(frame.getJniEnv(), this, sourceCall,
+                       frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
+    }
 }
 
 FakeJni::JInt HttpClientResponse::getNumHeaders() { return headers.size(); }
 
-std::shared_ptr<FakeJni::JString>
-HttpClientResponse::getHeaderNameAtIndex(FakeJni::JInt index) {
-  return std::make_shared<FakeJni::JString>(headers[index].name);
+std::shared_ptr<FakeJni::JString> HttpClientResponse::getHeaderNameAtIndex(FakeJni::JInt index)
+{
+    return std::make_shared<FakeJni::JString>(headers[index].name);
 }
 
-std::shared_ptr<FakeJni::JString>
-HttpClientResponse::getHeaderValueAtIndex(FakeJni::JInt index) {
-  return std::make_shared<FakeJni::JString>(headers[index].value);
+std::shared_ptr<FakeJni::JString> HttpClientResponse::getHeaderValueAtIndex(FakeJni::JInt index)
+{
+    return std::make_shared<FakeJni::JString>(headers[index].value);
 }
 
-std::shared_ptr<FakeJni::JByteArray>
-HttpClientResponse::getResponseBodyBytes() {
-  return std::make_shared<FakeJni::JByteArray>(body);
+std::shared_ptr<FakeJni::JByteArray> HttpClientResponse::getResponseBodyBytes()
+{
+    return std::make_shared<FakeJni::JByteArray>(body);
 }
 
-void HttpClientResponse::getResponseBodyBytes2() {
-  std::make_shared<NativeOutputStream>(call_handle)
-      ->WriteAll(getResponseBodyBytes());
+void HttpClientResponse::getResponseBodyBytes2()
+{
+    std::make_shared<NativeOutputStream>(call_handle)->WriteAll(getResponseBodyBytes());
 }
 
 FakeJni::JInt HttpClientResponse::getResponseCode() { return response_code; }
 
-HttpClientResponse::HttpClientResponse(FakeJni::JLong call_handle,
-                                       int response_code,
-                                       std::vector<signed char> body,
+HttpClientResponse::HttpClientResponse(FakeJni::JLong call_handle, int response_code, std::vector<signed char> body,
                                        std::vector<ResponseHeader> headers)
-    : response_code(response_code), body(body), headers(headers),
-      call_handle(call_handle) {}
-
-size_t HttpClientRequest::write_callback(char *ptr, size_t size, size_t nmemb) {
-  response.insert(response.end(), ptr, ptr + nmemb);
-  return size * nmemb;
+    : response_code(response_code), body(body), headers(headers), call_handle(call_handle)
+{
 }
 
-size_t HttpClientRequest::header_callback(char *buffer, size_t size,
-                                          size_t nitems) {
-  auto string = std::string(buffer, nitems);
-  auto location = string.find(": ");
-  if (location != std::string::npos) {
-    auto name = string.substr(0, location);
-    auto value = string.substr(location + 1, string.length());
-    trim(name);
-    trim(value);
-    headers.emplace_back(name, value);
-  }
-  return size * nitems;
+size_t HttpClientRequest::write_callback(char *ptr, size_t size, size_t nmemb)
+{
+    response.insert(response.end(), ptr, ptr + nmemb);
+    return size * nmemb;
 }
 
-NativeInputStream::NativeInputStream(FakeJni::JLong call_handle)
-    : call_handle(call_handle) {}
-
-size_t NativeInputStream::Read(void *buffer, size_t size) {
-  FakeJni::LocalFrame frame;
-  auto method = getClass().getMethod("(JJ[BJJ)I", "nativeRead");
-  auto buf = std::make_shared<FakeJni::JByteArray>(
-      (size_t)std::numeric_limits<jsize>::max() < size
-          ? std::numeric_limits<jsize>::max()
-          : (jsize)size);
-  jvalue ret =
-      method->invoke(frame.getJniEnv(), this, call_handle, offset,
-                     frame.getJniEnv().createLocalReference(buf),
-                     (FakeJni::JLong)0, (FakeJni::JLong)buf->getSize());
-  if (ret.i != -1) {
-    memcpy(buffer, buf->getArray(), ret.i);
-    offset += ret.i;
-  }
-  return ret.i;
+size_t HttpClientRequest::header_callback(char *buffer, size_t size, size_t nitems)
+{
+    auto string = std::string(buffer, nitems);
+    auto location = string.find(": ");
+    if (location != std::string::npos)
+    {
+        auto name = string.substr(0, location);
+        auto value = string.substr(location + 1, string.length());
+        trim(name);
+        trim(value);
+        headers.emplace_back(name, value);
+    }
+    return size * nitems;
 }
 
-NativeOutputStream::NativeOutputStream(FakeJni::JLong call_handle)
-    : call_handle(call_handle) {}
+NativeInputStream::NativeInputStream(FakeJni::JLong call_handle) : call_handle(call_handle) {}
 
-void NativeOutputStream::WriteAll(std::shared_ptr<FakeJni::JByteArray> data) {
-  FakeJni::LocalFrame frame;
-  auto method = getClass().getMethod("(J[BII)V", "nativeWrite");
-  method->invoke(frame.getJniEnv(), this, call_handle,
-                 frame.getJniEnv().createLocalReference(data), (FakeJni::JInt)0,
-                 (FakeJni::JInt)data->getSize());
+size_t NativeInputStream::Read(void *buffer, size_t size)
+{
+    FakeJni::LocalFrame frame;
+    auto method = getClass().getMethod("(JJ[BJJ)I", "nativeRead");
+    auto buf = std::make_shared<FakeJni::JByteArray>(
+        (size_t)std::numeric_limits<jsize>::max() < size ? std::numeric_limits<jsize>::max() : (jsize)size);
+    jvalue ret =
+        method->invoke(frame.getJniEnv(), this, call_handle, offset, frame.getJniEnv().createLocalReference(buf),
+                       (FakeJni::JLong)0, (FakeJni::JLong)buf->getSize());
+    if (ret.i != -1)
+    {
+        memcpy(buffer, buf->getArray(), ret.i);
+        offset += ret.i;
+    }
+    return ret.i;
+}
+
+NativeOutputStream::NativeOutputStream(FakeJni::JLong call_handle) : call_handle(call_handle) {}
+
+void NativeOutputStream::WriteAll(std::shared_ptr<FakeJni::JByteArray> data)
+{
+    FakeJni::LocalFrame frame;
+    auto method = getClass().getMethod("(J[BII)V", "nativeWrite");
+    method->invoke(frame.getJniEnv(), this, call_handle, frame.getJniEnv().createLocalReference(data), (FakeJni::JInt)0,
+                   (FakeJni::JInt)data->getSize());
 }

--- a/src/jni/lib_http_client.cpp
+++ b/src/jni/lib_http_client.cpp
@@ -5,8 +5,7 @@
 
 using namespace std::placeholders;
 
-HttpClientRequest::HttpClientRequest()
-{
+HttpClientRequest::HttpClientRequest() {
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, HttpClientRequest::write_callback_wrapper);
@@ -18,55 +17,47 @@ HttpClientRequest::~HttpClientRequest() { curl_easy_cleanup(curl); }
 
 FakeJni::JBoolean HttpClientRequest::isNetworkAvailable(std::shared_ptr<Context> context) { return true; }
 
-std::shared_ptr<HttpClientRequest> HttpClientRequest::createClientRequest()
-{
+std::shared_ptr<HttpClientRequest> HttpClientRequest::createClientRequest() {
     return std::make_shared<HttpClientRequest>();
 }
 
-void HttpClientRequest::setHttpUrl(std::shared_ptr<FakeJni::JString> url)
-{
+void HttpClientRequest::setHttpUrl(std::shared_ptr<FakeJni::JString> url) {
     curl_easy_setopt(curl, CURLOPT_URL, url->asStdString().c_str());
 }
 
 void HttpClientRequest::setHttpMethodAndBody(std::shared_ptr<FakeJni::JString> method,
                                              std::shared_ptr<FakeJni::JString> contentType,
-                                             std::shared_ptr<FakeJni::JByteArray> body)
-{
+                                             std::shared_ptr<FakeJni::JByteArray> body) {
     this->method = method->asStdString();
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
     this->body = body ? std::vector<char>((char *)body->getArray(), (char *)body->getArray() + body->getSize())
                       : std::vector<char>{};
-    if (this->body.size())
-    {
+    if (this->body.size()) {
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, this->body.data());
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
     }
     auto conttype = contentType->asStdString();
-    if (conttype.length())
-    {
+    if (conttype.length()) {
         header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
     }
 }
 
-static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
-{
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userdata) {
     auto stream = (NativeInputStream *)userdata;
     return stream->Read(ptr, size * nmemb);
 }
 
 void HttpClientRequest::setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString> method, FakeJni::JLong callHandle,
                                               std::shared_ptr<FakeJni::JString> contentType,
-                                              FakeJni::JLong contentLength)
-{
+                                              FakeJni::JLong contentLength) {
     this->method = method->asStdString();
     // if(this->method == "POST") {
     //     curl_easy_setopt(curl, CURLOPT_HTTPPOST, 1);
     // } else {
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
     // }
-    if (contentLength > 0)
-    {
+    if (contentLength > 0) {
         // static auto ___callback = (void*)+[](char *ptr, size_t size, size_t
         // nmemb, void *userdata) -> size_t {
         //     auto stream = (NativeInputStream*)userdata;
@@ -84,34 +75,28 @@ void HttpClientRequest::setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString> 
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, this->body.size());
     }
     auto conttype = contentType->asStdString();
-    if (conttype.length())
-    {
+    if (conttype.length()) {
         header = curl_slist_append(header, ("Content-Type: " + conttype).c_str());
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
     }
 }
 
-void HttpClientRequest::setHttpHeader(std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> value)
-{
+void HttpClientRequest::setHttpHeader(std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> value) {
     header = curl_slist_append(header, (name->asStdString() + ": " + value->asStdString()).c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header);
 }
 
-void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall)
-{
+void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall) {
     auto ret = curl_easy_perform(curl);
     long response_code;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
     FakeJni::LocalFrame frame;
-    if (ret == CURLE_OK)
-    {
+    if (ret == CURLE_OK) {
         auto method = getClass().getMethod("(JLcom/xbox/httpclient/HttpClientResponse;)V", "OnRequestCompleted");
         method->invoke(frame.getJniEnv(), this, sourceCall,
                        frame.getJniEnv().createLocalReference(
                            std::make_shared<HttpClientResponse>(sourceCall, response_code, response, headers)));
-    }
-    else
-    {
+    } else {
         auto method = getClass().getMethod("(JLjava/lang/String;)V", "OnRequestFailed");
         method->invoke(frame.getJniEnv(), this, sourceCall,
                        frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
@@ -120,23 +105,19 @@ void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall)
 
 FakeJni::JInt HttpClientResponse::getNumHeaders() { return headers.size(); }
 
-std::shared_ptr<FakeJni::JString> HttpClientResponse::getHeaderNameAtIndex(FakeJni::JInt index)
-{
+std::shared_ptr<FakeJni::JString> HttpClientResponse::getHeaderNameAtIndex(FakeJni::JInt index) {
     return std::make_shared<FakeJni::JString>(headers[index].name);
 }
 
-std::shared_ptr<FakeJni::JString> HttpClientResponse::getHeaderValueAtIndex(FakeJni::JInt index)
-{
+std::shared_ptr<FakeJni::JString> HttpClientResponse::getHeaderValueAtIndex(FakeJni::JInt index) {
     return std::make_shared<FakeJni::JString>(headers[index].value);
 }
 
-std::shared_ptr<FakeJni::JByteArray> HttpClientResponse::getResponseBodyBytes()
-{
+std::shared_ptr<FakeJni::JByteArray> HttpClientResponse::getResponseBodyBytes() {
     return std::make_shared<FakeJni::JByteArray>(body);
 }
 
-void HttpClientResponse::getResponseBodyBytes2()
-{
+void HttpClientResponse::getResponseBodyBytes2() {
     std::make_shared<NativeOutputStream>(call_handle)->WriteAll(getResponseBodyBytes());
 }
 
@@ -144,22 +125,17 @@ FakeJni::JInt HttpClientResponse::getResponseCode() { return response_code; }
 
 HttpClientResponse::HttpClientResponse(FakeJni::JLong call_handle, int response_code, std::vector<signed char> body,
                                        std::vector<ResponseHeader> headers)
-    : response_code(response_code), body(body), headers(headers), call_handle(call_handle)
-{
-}
+    : response_code(response_code), body(body), headers(headers), call_handle(call_handle) {}
 
-size_t HttpClientRequest::write_callback(char *ptr, size_t size, size_t nmemb)
-{
+size_t HttpClientRequest::write_callback(char *ptr, size_t size, size_t nmemb) {
     response.insert(response.end(), ptr, ptr + nmemb);
     return size * nmemb;
 }
 
-size_t HttpClientRequest::header_callback(char *buffer, size_t size, size_t nitems)
-{
+size_t HttpClientRequest::header_callback(char *buffer, size_t size, size_t nitems) {
     auto string = std::string(buffer, nitems);
     auto location = string.find(": ");
-    if (location != std::string::npos)
-    {
+    if (location != std::string::npos) {
         auto name = string.substr(0, location);
         auto value = string.substr(location + 1, string.length());
         trim(name);
@@ -171,8 +147,7 @@ size_t HttpClientRequest::header_callback(char *buffer, size_t size, size_t nite
 
 NativeInputStream::NativeInputStream(FakeJni::JLong call_handle) : call_handle(call_handle) {}
 
-size_t NativeInputStream::Read(void *buffer, size_t size)
-{
+size_t NativeInputStream::Read(void *buffer, size_t size) {
     FakeJni::LocalFrame frame;
     auto method = getClass().getMethod("(JJ[BJJ)I", "nativeRead");
     auto buf = std::make_shared<FakeJni::JByteArray>(
@@ -180,8 +155,7 @@ size_t NativeInputStream::Read(void *buffer, size_t size)
     jvalue ret =
         method->invoke(frame.getJniEnv(), this, call_handle, offset, frame.getJniEnv().createLocalReference(buf),
                        (FakeJni::JLong)0, (FakeJni::JLong)buf->getSize());
-    if (ret.i != -1)
-    {
+    if (ret.i != -1) {
         memcpy(buffer, buf->getArray(), ret.i);
         offset += ret.i;
     }
@@ -190,8 +164,7 @@ size_t NativeInputStream::Read(void *buffer, size_t size)
 
 NativeOutputStream::NativeOutputStream(FakeJni::JLong call_handle) : call_handle(call_handle) {}
 
-void NativeOutputStream::WriteAll(std::shared_ptr<FakeJni::JByteArray> data)
-{
+void NativeOutputStream::WriteAll(std::shared_ptr<FakeJni::JByteArray> data) {
     FakeJni::LocalFrame frame;
     auto method = getClass().getMethod("(J[BII)V", "nativeWrite");
     method->invoke(frame.getJniEnv(), this, call_handle, frame.getJniEnv().createLocalReference(data), (FakeJni::JInt)0,

--- a/src/jni/lib_http_client.h
+++ b/src/jni/lib_http_client.h
@@ -1,86 +1,101 @@
 #pragma once
 
-#include <fake-jni/fake-jni.h>
 #include "main_activity.h"
+#include <fake-jni/fake-jni.h>
 #include <log.h>
 
 #include <utility>
 
 class ResponseHeader {
 public:
-    ResponseHeader(std::string name, std::string value) : name(std::move(name)), value(std::move(value)) {}
-    std::string name;
-    std::string value;
+  ResponseHeader(std::string name, std::string value)
+      : name(std::move(name)), value(std::move(value)) {}
+  std::string name;
+  std::string value;
 };
 
 class NativeInputStream : public FakeJni::JObject {
-    FakeJni::JLong call_handle;
-    FakeJni::JLong offset = 0;
+  FakeJni::JLong call_handle;
+  FakeJni::JLong offset = 0;
+
 public:
-    DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientRequestBody/00024NativeInputStream")
-    NativeInputStream(FakeJni::JLong call_handle);
-    size_t Read(void* buffer, size_t size);
+  DEFINE_CLASS_NAME(
+      "com/xbox/httpclient/HttpClientRequestBody/00024NativeInputStream")
+  NativeInputStream(FakeJni::JLong call_handle);
+  size_t Read(void *buffer, size_t size);
 };
 
 class HttpClientRequest : public FakeJni::JObject {
-    std::shared_ptr<NativeInputStream> inputStream;
+  std::shared_ptr<NativeInputStream> inputStream;
+
 public:
-    DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientRequest")
-    HttpClientRequest();
-    ~HttpClientRequest();
+  DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientRequest")
+  HttpClientRequest();
+  ~HttpClientRequest();
 
-    static FakeJni::JBoolean isNetworkAvailable(std::shared_ptr<Context> context);
-    static std::shared_ptr<HttpClientRequest> createClientRequest();
+  static FakeJni::JBoolean isNetworkAvailable(std::shared_ptr<Context> context);
+  static std::shared_ptr<HttpClientRequest> createClientRequest();
 
-    void setHttpUrl(std::shared_ptr<FakeJni::JString> url);
-    void setHttpMethodAndBody(std::shared_ptr<FakeJni::JString> method, std::shared_ptr<FakeJni::JString> contentType, std::shared_ptr<FakeJni::JByteArray> body);
-    void setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString>, FakeJni::JLong, std::shared_ptr<FakeJni::JString>, FakeJni::JLong);
-    void setHttpHeader(std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> value);
-    void doRequestAsync(FakeJni::JLong sourceCall);
-    static size_t write_callback_wrapper(char *ptr, size_t size, size_t nmemb, void *userdata) {
-        auto *self = static_cast<HttpClientRequest*>(userdata);
-        return self->write_callback(ptr, size, nmemb);
-    }
-    static size_t header_callback_wrapper(char *ptr, size_t size, size_t nmemb, void *userdata) {
-        auto *self = static_cast<HttpClientRequest*>(userdata);
-        return self->header_callback(ptr, size, nmemb);
-    }
+  void setHttpUrl(std::shared_ptr<FakeJni::JString> url);
+  void setHttpMethodAndBody(std::shared_ptr<FakeJni::JString> method,
+                            std::shared_ptr<FakeJni::JString> contentType,
+                            std::shared_ptr<FakeJni::JByteArray> body);
+  void setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString>, FakeJni::JLong,
+                             std::shared_ptr<FakeJni::JString>, FakeJni::JLong);
+  void setHttpHeader(std::shared_ptr<FakeJni::JString> name,
+                     std::shared_ptr<FakeJni::JString> value);
+  void doRequestAsync(FakeJni::JLong sourceCall);
+  static size_t write_callback_wrapper(char *ptr, size_t size, size_t nmemb,
+                                       void *userdata) {
+    auto *self = static_cast<HttpClientRequest *>(userdata);
+    return self->write_callback(ptr, size, nmemb);
+  }
+  static size_t header_callback_wrapper(char *ptr, size_t size, size_t nmemb,
+                                        void *userdata) {
+    auto *self = static_cast<HttpClientRequest *>(userdata);
+    return self->header_callback(ptr, size, nmemb);
+  }
 
 private:
-    void *curl;
-    struct curl_slist * header = nullptr;
-    std::vector<signed char> response;
-    std::vector<ResponseHeader> headers;
-    std::vector<char> body;
-    std::string method;
+  void *curl;
+  struct curl_slist *header = nullptr;
+  std::vector<signed char> response;
+  std::vector<ResponseHeader> headers;
+  std::vector<char> body;
+  std::string method;
 
-    size_t write_callback(char *ptr, size_t size, size_t nmemb);
-    size_t header_callback(char *buffer,   size_t size,   size_t nitems);
+  size_t write_callback(char *ptr, size_t size, size_t nmemb);
+  size_t header_callback(char *buffer, size_t size, size_t nitems);
 };
 
 class HttpClientResponse : public FakeJni::JObject {
-    FakeJni::JLong call_handle;
-public:
-    DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientResponse")
+  FakeJni::JLong call_handle;
 
-    HttpClientResponse(FakeJni::JLong call_handle, int response_code, std::vector<signed char> body, std::vector<ResponseHeader> headers);
-    FakeJni::JInt getNumHeaders();
-    std::shared_ptr<FakeJni::JString> getHeaderNameAtIndex(FakeJni::JInt index);
-    std::shared_ptr<FakeJni::JString> getHeaderValueAtIndex(FakeJni::JInt index);
-    std::shared_ptr<FakeJni::JByteArray> getResponseBodyBytes();
-    void getResponseBodyBytes2();
-    FakeJni::JInt getResponseCode();
+public:
+  DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientResponse")
+
+  HttpClientResponse(FakeJni::JLong call_handle, int response_code,
+                     std::vector<signed char> body,
+                     std::vector<ResponseHeader> headers);
+  FakeJni::JInt getNumHeaders();
+  std::shared_ptr<FakeJni::JString> getHeaderNameAtIndex(FakeJni::JInt index);
+  std::shared_ptr<FakeJni::JString> getHeaderValueAtIndex(FakeJni::JInt index);
+  std::shared_ptr<FakeJni::JByteArray> getResponseBodyBytes();
+  void getResponseBodyBytes2();
+  FakeJni::JInt getResponseCode();
 
 private:
-    int response_code;
-    std::vector<signed char> body;
-    std::vector<ResponseHeader> headers;
+  int response_code;
+  std::vector<signed char> body;
+  std::vector<ResponseHeader> headers;
 };
 
 class NativeOutputStream : public FakeJni::JObject {
-    FakeJni::JLong call_handle;
+  FakeJni::JLong call_handle;
+
 public:
-    DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientResponse/00024NativeOutputStream")
-    NativeOutputStream(FakeJni::JLong call_handle);
-    void WriteAll(std::shared_ptr<FakeJni::JByteArray> data);
+  DEFINE_CLASS_NAME(
+      "com/xbox/httpclient/HttpClientResponse/00024NativeOutputStream")
+  NativeOutputStream(FakeJni::JLong call_handle);
+  void WriteAll(std::shared_ptr<FakeJni::JByteArray> data);
 };

--- a/src/jni/lib_http_client.h
+++ b/src/jni/lib_http_client.h
@@ -1,101 +1,100 @@
 #pragma once
 
-#include "main_activity.h"
 #include <fake-jni/fake-jni.h>
 #include <log.h>
+#include "main_activity.h"
 
 #include <utility>
 
-class ResponseHeader {
-public:
-  ResponseHeader(std::string name, std::string value)
-      : name(std::move(name)), value(std::move(value)) {}
-  std::string name;
-  std::string value;
+class ResponseHeader
+{
+   public:
+    ResponseHeader(std::string name, std::string value) : name(std::move(name)), value(std::move(value)) {}
+    std::string name;
+    std::string value;
 };
 
-class NativeInputStream : public FakeJni::JObject {
-  FakeJni::JLong call_handle;
-  FakeJni::JLong offset = 0;
+class NativeInputStream : public FakeJni::JObject
+{
+    FakeJni::JLong call_handle;
+    FakeJni::JLong offset = 0;
 
-public:
-  DEFINE_CLASS_NAME(
-      "com/xbox/httpclient/HttpClientRequestBody/00024NativeInputStream")
-  NativeInputStream(FakeJni::JLong call_handle);
-  size_t Read(void *buffer, size_t size);
+   public:
+    DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientRequestBody/00024NativeInputStream")
+    NativeInputStream(FakeJni::JLong call_handle);
+    size_t Read(void *buffer, size_t size);
 };
 
-class HttpClientRequest : public FakeJni::JObject {
-  std::shared_ptr<NativeInputStream> inputStream;
+class HttpClientRequest : public FakeJni::JObject
+{
+    std::shared_ptr<NativeInputStream> inputStream;
 
-public:
-  DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientRequest")
-  HttpClientRequest();
-  ~HttpClientRequest();
+   public:
+    DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientRequest")
+    HttpClientRequest();
+    ~HttpClientRequest();
 
-  static FakeJni::JBoolean isNetworkAvailable(std::shared_ptr<Context> context);
-  static std::shared_ptr<HttpClientRequest> createClientRequest();
+    static FakeJni::JBoolean isNetworkAvailable(std::shared_ptr<Context> context);
+    static std::shared_ptr<HttpClientRequest> createClientRequest();
 
-  void setHttpUrl(std::shared_ptr<FakeJni::JString> url);
-  void setHttpMethodAndBody(std::shared_ptr<FakeJni::JString> method,
-                            std::shared_ptr<FakeJni::JString> contentType,
-                            std::shared_ptr<FakeJni::JByteArray> body);
-  void setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString>, FakeJni::JLong,
-                             std::shared_ptr<FakeJni::JString>, FakeJni::JLong);
-  void setHttpHeader(std::shared_ptr<FakeJni::JString> name,
-                     std::shared_ptr<FakeJni::JString> value);
-  void doRequestAsync(FakeJni::JLong sourceCall);
-  static size_t write_callback_wrapper(char *ptr, size_t size, size_t nmemb,
-                                       void *userdata) {
-    auto *self = static_cast<HttpClientRequest *>(userdata);
-    return self->write_callback(ptr, size, nmemb);
-  }
-  static size_t header_callback_wrapper(char *ptr, size_t size, size_t nmemb,
-                                        void *userdata) {
-    auto *self = static_cast<HttpClientRequest *>(userdata);
-    return self->header_callback(ptr, size, nmemb);
-  }
+    void setHttpUrl(std::shared_ptr<FakeJni::JString> url);
+    void setHttpMethodAndBody(std::shared_ptr<FakeJni::JString> method, std::shared_ptr<FakeJni::JString> contentType,
+                              std::shared_ptr<FakeJni::JByteArray> body);
+    void setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString>, FakeJni::JLong, std::shared_ptr<FakeJni::JString>,
+                               FakeJni::JLong);
+    void setHttpHeader(std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> value);
+    void doRequestAsync(FakeJni::JLong sourceCall);
+    static size_t write_callback_wrapper(char *ptr, size_t size, size_t nmemb, void *userdata)
+    {
+        auto *self = static_cast<HttpClientRequest *>(userdata);
+        return self->write_callback(ptr, size, nmemb);
+    }
+    static size_t header_callback_wrapper(char *ptr, size_t size, size_t nmemb, void *userdata)
+    {
+        auto *self = static_cast<HttpClientRequest *>(userdata);
+        return self->header_callback(ptr, size, nmemb);
+    }
 
-private:
-  void *curl;
-  struct curl_slist *header = nullptr;
-  std::vector<signed char> response;
-  std::vector<ResponseHeader> headers;
-  std::vector<char> body;
-  std::string method;
+   private:
+    void *curl;
+    struct curl_slist *header = nullptr;
+    std::vector<signed char> response;
+    std::vector<ResponseHeader> headers;
+    std::vector<char> body;
+    std::string method;
 
-  size_t write_callback(char *ptr, size_t size, size_t nmemb);
-  size_t header_callback(char *buffer, size_t size, size_t nitems);
+    size_t write_callback(char *ptr, size_t size, size_t nmemb);
+    size_t header_callback(char *buffer, size_t size, size_t nitems);
 };
 
-class HttpClientResponse : public FakeJni::JObject {
-  FakeJni::JLong call_handle;
+class HttpClientResponse : public FakeJni::JObject
+{
+    FakeJni::JLong call_handle;
 
-public:
-  DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientResponse")
+   public:
+    DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientResponse")
 
-  HttpClientResponse(FakeJni::JLong call_handle, int response_code,
-                     std::vector<signed char> body,
-                     std::vector<ResponseHeader> headers);
-  FakeJni::JInt getNumHeaders();
-  std::shared_ptr<FakeJni::JString> getHeaderNameAtIndex(FakeJni::JInt index);
-  std::shared_ptr<FakeJni::JString> getHeaderValueAtIndex(FakeJni::JInt index);
-  std::shared_ptr<FakeJni::JByteArray> getResponseBodyBytes();
-  void getResponseBodyBytes2();
-  FakeJni::JInt getResponseCode();
+    HttpClientResponse(FakeJni::JLong call_handle, int response_code, std::vector<signed char> body,
+                       std::vector<ResponseHeader> headers);
+    FakeJni::JInt getNumHeaders();
+    std::shared_ptr<FakeJni::JString> getHeaderNameAtIndex(FakeJni::JInt index);
+    std::shared_ptr<FakeJni::JString> getHeaderValueAtIndex(FakeJni::JInt index);
+    std::shared_ptr<FakeJni::JByteArray> getResponseBodyBytes();
+    void getResponseBodyBytes2();
+    FakeJni::JInt getResponseCode();
 
-private:
-  int response_code;
-  std::vector<signed char> body;
-  std::vector<ResponseHeader> headers;
+   private:
+    int response_code;
+    std::vector<signed char> body;
+    std::vector<ResponseHeader> headers;
 };
 
-class NativeOutputStream : public FakeJni::JObject {
-  FakeJni::JLong call_handle;
+class NativeOutputStream : public FakeJni::JObject
+{
+    FakeJni::JLong call_handle;
 
-public:
-  DEFINE_CLASS_NAME(
-      "com/xbox/httpclient/HttpClientResponse/00024NativeOutputStream")
-  NativeOutputStream(FakeJni::JLong call_handle);
-  void WriteAll(std::shared_ptr<FakeJni::JByteArray> data);
+   public:
+    DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientResponse/00024NativeOutputStream")
+    NativeOutputStream(FakeJni::JLong call_handle);
+    void WriteAll(std::shared_ptr<FakeJni::JByteArray> data);
 };

--- a/src/jni/lib_http_client.h
+++ b/src/jni/lib_http_client.h
@@ -6,16 +6,14 @@
 
 #include <utility>
 
-class ResponseHeader
-{
+class ResponseHeader {
    public:
     ResponseHeader(std::string name, std::string value) : name(std::move(name)), value(std::move(value)) {}
     std::string name;
     std::string value;
 };
 
-class NativeInputStream : public FakeJni::JObject
-{
+class NativeInputStream : public FakeJni::JObject {
     FakeJni::JLong call_handle;
     FakeJni::JLong offset = 0;
 
@@ -25,8 +23,7 @@ class NativeInputStream : public FakeJni::JObject
     size_t Read(void *buffer, size_t size);
 };
 
-class HttpClientRequest : public FakeJni::JObject
-{
+class HttpClientRequest : public FakeJni::JObject {
     std::shared_ptr<NativeInputStream> inputStream;
 
    public:
@@ -44,13 +41,11 @@ class HttpClientRequest : public FakeJni::JObject
                                FakeJni::JLong);
     void setHttpHeader(std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> value);
     void doRequestAsync(FakeJni::JLong sourceCall);
-    static size_t write_callback_wrapper(char *ptr, size_t size, size_t nmemb, void *userdata)
-    {
+    static size_t write_callback_wrapper(char *ptr, size_t size, size_t nmemb, void *userdata) {
         auto *self = static_cast<HttpClientRequest *>(userdata);
         return self->write_callback(ptr, size, nmemb);
     }
-    static size_t header_callback_wrapper(char *ptr, size_t size, size_t nmemb, void *userdata)
-    {
+    static size_t header_callback_wrapper(char *ptr, size_t size, size_t nmemb, void *userdata) {
         auto *self = static_cast<HttpClientRequest *>(userdata);
         return self->header_callback(ptr, size, nmemb);
     }
@@ -67,8 +62,7 @@ class HttpClientRequest : public FakeJni::JObject
     size_t header_callback(char *buffer, size_t size, size_t nitems);
 };
 
-class HttpClientResponse : public FakeJni::JObject
-{
+class HttpClientResponse : public FakeJni::JObject {
     FakeJni::JLong call_handle;
 
    public:
@@ -89,8 +83,7 @@ class HttpClientResponse : public FakeJni::JObject
     std::vector<ResponseHeader> headers;
 };
 
-class NativeOutputStream : public FakeJni::JObject
-{
+class NativeOutputStream : public FakeJni::JObject {
     FakeJni::JLong call_handle;
 
    public:

--- a/src/jni/locale.cpp
+++ b/src/jni/locale.cpp
@@ -1,13 +1,12 @@
 #include "locale.h"
 #include <locale>
 
-Locale::Locale(std::locale locale) : l(locale) {
-}
+Locale::Locale(std::locale locale) : l(locale) {}
 
 std::shared_ptr<Locale> Locale::getDefault() {
-    return std::make_shared<Locale>(Locale(std::locale()));
+  return std::make_shared<Locale>(Locale(std::locale()));
 }
 
 std::shared_ptr<FakeJni::JString> Locale::toString() {
-    return std::make_shared<FakeJni::JString>(l.name());
+  return std::make_shared<FakeJni::JString>(l.name());
 }

--- a/src/jni/locale.cpp
+++ b/src/jni/locale.cpp
@@ -3,10 +3,6 @@
 
 Locale::Locale(std::locale locale) : l(locale) {}
 
-std::shared_ptr<Locale> Locale::getDefault() {
-  return std::make_shared<Locale>(Locale(std::locale()));
-}
+std::shared_ptr<Locale> Locale::getDefault() { return std::make_shared<Locale>(Locale(std::locale())); }
 
-std::shared_ptr<FakeJni::JString> Locale::toString() {
-  return std::make_shared<FakeJni::JString>(l.name());
-}
+std::shared_ptr<FakeJni::JString> Locale::toString() { return std::make_shared<FakeJni::JString>(l.name()); }

--- a/src/jni/locale.h
+++ b/src/jni/locale.h
@@ -5,13 +5,12 @@
 class Locale : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/util/Locale")
+  DEFINE_CLASS_NAME("java/util/Locale")
 
-    Locale(std::locale locale);
-    static std::shared_ptr<Locale> getDefault();
-    std::shared_ptr<FakeJni::JString> toString();
+  Locale(std::locale locale);
+  static std::shared_ptr<Locale> getDefault();
+  std::shared_ptr<FakeJni::JString> toString();
 
 private:
-    std::locale l;
-
+  std::locale l;
 };

--- a/src/jni/locale.h
+++ b/src/jni/locale.h
@@ -2,8 +2,7 @@
 #include <fake-jni/fake-jni.h>
 #include <locale>
 
-class Locale : public FakeJni::JObject
-{
+class Locale : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/util/Locale")
 

--- a/src/jni/locale.h
+++ b/src/jni/locale.h
@@ -2,15 +2,15 @@
 #include <fake-jni/fake-jni.h>
 #include <locale>
 
-class Locale : public FakeJni::JObject {
+class Locale : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/util/Locale")
 
-public:
-  DEFINE_CLASS_NAME("java/util/Locale")
+    Locale(std::locale locale);
+    static std::shared_ptr<Locale> getDefault();
+    std::shared_ptr<FakeJni::JString> toString();
 
-  Locale(std::locale locale);
-  static std::shared_ptr<Locale> getDefault();
-  std::shared_ptr<FakeJni::JString> toString();
-
-private:
-  std::locale l;
+   private:
+    std::locale l;
 };

--- a/src/jni/main_activity.cpp
+++ b/src/jni/main_activity.cpp
@@ -4,155 +4,169 @@
 #ifndef __APPLE__
 #include <sys/sysinfo.h>
 #else
-#include <sys/sysctl.h>
 #include <mach/mach.h>
+#include <sys/sysctl.h>
 #endif
-#include <file_picker_factory.h>
-#include <game_window_manager.h>
 #include "uuid.h"
 #include <climits>
+#include <file_picker_factory.h>
+#include <game_window_manager.h>
 #include <sstream>
 
 #include <log.h>
 
 FakeJni::JInt BuildVersion::SDK_INT = 27;
-std::shared_ptr<FakeJni::JString> BuildVersion::RELEASE = std::make_shared<FakeJni::JString>("AndroidX");
+std::shared_ptr<FakeJni::JString> BuildVersion::RELEASE =
+    std::make_shared<FakeJni::JString>("AndroidX");
 
 std::shared_ptr<FakeJni::JString> MainActivity::createUUID() {
-    return UUID::randomUUID()->toString();
+  return UUID::randomUUID()->toString();
 }
 
 FakeJni::JLong MainActivity::getUsedMemory() {
 #ifdef __APPLE__
-    uint64_t page_size;
-    size_t len = sizeof(page_size);
-    sysctlbyname("hw.pagesize", &page_size, &len, NULL, 0);
+  uint64_t page_size;
+  size_t len = sizeof(page_size);
+  sysctlbyname("hw.pagesize", &page_size, &len, NULL, 0);
 
-    struct vm_statistics64 stat;
-    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
-    host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t) &stat, &count);
+  struct vm_statistics64 stat;
+  mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+  host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&stat,
+                    &count);
 
-    double page_K = page_size / (double) 1024;
-    return (stat.active_count + stat.wire_count) * page_K * 1000;
+  double page_K = page_size / (double)1024;
+  return (stat.active_count + stat.wire_count) * page_K * 1000;
 #else
-    FILE* file = fopen("/proc/self/statm", "r");
-    if (file == nullptr)
-        return 0L;
-    int pageSize = getpagesize();
-    long long pageCount = 0L;
-    fscanf(file, "%lld", &pageCount);
-    fclose(file);
-    return pageCount * pageSize;
+  FILE *file = fopen("/proc/self/statm", "r");
+  if (file == nullptr)
+    return 0L;
+  int pageSize = getpagesize();
+  long long pageCount = 0L;
+  fscanf(file, "%lld", &pageCount);
+  fclose(file);
+  return pageCount * pageSize;
 #endif
 }
 
 FakeJni::JLong MainActivity::getFreeMemory() {
 #ifdef __APPLE__
-    uint64_t page_size;
-    size_t len = sizeof(page_size);
-    sysctlbyname("hw.pagesize", &page_size, &len, NULL, 0);
+  uint64_t page_size;
+  size_t len = sizeof(page_size);
+  sysctlbyname("hw.pagesize", &page_size, &len, NULL, 0);
 
-    struct vm_statistics64 stat;
-    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
-    host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t) &stat, &count);
+  struct vm_statistics64 stat;
+  mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+  host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&stat,
+                    &count);
 
-    double page_K = page_size / (double) 1024;
-    return stat.free_count * page_K * 1000;
+  double page_K = page_size / (double)1024;
+  return stat.free_count * page_K * 1000;
 #else
-    struct sysinfo memInfo;
-    sysinfo (&memInfo);
-    long long total = memInfo.freeram;
-    total *= memInfo.mem_unit;
-    return total;
+  struct sysinfo memInfo;
+  sysinfo(&memInfo);
+  long long total = memInfo.freeram;
+  total *= memInfo.mem_unit;
+  return total;
 #endif
 }
 
 FakeJni::JLong MainActivity::getTotalMemory() {
 #ifdef __APPLE__
-    uint64_t memsize;
-    size_t len = sizeof(memsize);
-    sysctlbyname("hw.memsize", &memsize, &len, NULL, 0);
-    return memsize;
+  uint64_t memsize;
+  size_t len = sizeof(memsize);
+  sysctlbyname("hw.memsize", &memsize, &len, NULL, 0);
+  return memsize;
 #else
-    struct sysinfo memInfo;
-    sysinfo (&memInfo);
-    long long total = memInfo.totalram;
-    total *= memInfo.mem_unit;
-    return total;
+  struct sysinfo memInfo;
+  sysinfo(&memInfo);
+  long long total = memInfo.totalram;
+  total *= memInfo.mem_unit;
+  return total;
 #endif
 }
 
-FakeJni::JLong MainActivity::getMemoryLimit() {
-    return getTotalMemory();
-}
+FakeJni::JLong MainActivity::getMemoryLimit() { return getTotalMemory(); }
 
-FakeJni::JLong MainActivity::getAvailableMemory() {
-    return getTotalMemory();
-}
+FakeJni::JLong MainActivity::getAvailableMemory() { return getTotalMemory(); }
 
 void MainActivity::pickImage(FakeJni::JLong callback) {
-    try {
-        auto picker = FilePickerFactory::createFilePicker();
-        picker->setTitle("Select image");
-        picker->setFileNameFilters({ "*.png" });
-        if (picker->show()) {
-            auto method = getClass().getMethod("(JLjava/lang/String;)V", "nativeOnPickImageSuccess");
-            FakeJni::LocalFrame frame;
-            method->invoke(frame.getJniEnv(), this, callback, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(picker->getPickedFile())));
-        } else {
-            auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
-            FakeJni::LocalFrame frame;
-            method->invoke(frame.getJniEnv(), this, callback);
-        }
-    } catch(const std::exception& e) {
-        GameWindowManager::getManager()->getErrorHandler()->onError("FilePickerFactory", std::string("Failed to open the file-picker details: ") + e.what());
-        auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
-        FakeJni::LocalFrame frame;
-        method->invoke(frame.getJniEnv(), this, callback);
+  try {
+    auto picker = FilePickerFactory::createFilePicker();
+    picker->setTitle("Select image");
+    picker->setFileNameFilters({"*.png"});
+    if (picker->show()) {
+      auto method = getClass().getMethod("(JLjava/lang/String;)V",
+                                         "nativeOnPickImageSuccess");
+      FakeJni::LocalFrame frame;
+      method->invoke(
+          frame.getJniEnv(), this, callback,
+          frame.getJniEnv().createLocalReference(
+              std::make_shared<FakeJni::JString>(picker->getPickedFile())));
+    } else {
+      auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
+      FakeJni::LocalFrame frame;
+      method->invoke(frame.getJniEnv(), this, callback);
     }
+  } catch (const std::exception &e) {
+    GameWindowManager::getManager()->getErrorHandler()->onError(
+        "FilePickerFactory",
+        std::string("Failed to open the file-picker details: ") + e.what());
+    auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
+    FakeJni::LocalFrame frame;
+    method->invoke(frame.getJniEnv(), this, callback);
+  }
 }
 
-void MainActivity::initializeXboxLive(FakeJni::JLong xalinit, FakeJni::JLong xblinit) {
-    auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
-    FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
+void MainActivity::initializeXboxLive(FakeJni::JLong xalinit,
+                                      FakeJni::JLong xblinit) {
+  auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
+  FakeJni::LocalFrame frame;
+  method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
 }
 
-FakeJni::JLong MainActivity::initializeXboxLive2(FakeJni::JLong xalinit, FakeJni::JLong xblinit) {
-    auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
-    FakeJni::LocalFrame frame;
-    auto ret = method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
-    return ret.j;
+FakeJni::JLong MainActivity::initializeXboxLive2(FakeJni::JLong xalinit,
+                                                 FakeJni::JLong xblinit) {
+  auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
+  FakeJni::LocalFrame frame;
+  auto ret = method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
+  return ret.j;
 }
 
 FakeJni::JLong MainActivity::initializeLibHttpClient(FakeJni::JLong init) {
-    auto method = getClass().getMethod("(J)J", "nativeinitializeLibHttpClient");
-    FakeJni::LocalFrame frame;
-    auto ret = method->invoke(frame.getJniEnv(), this, init);
-    return ret.j;
+  auto method = getClass().getMethod("(J)J", "nativeinitializeLibHttpClient");
+  FakeJni::LocalFrame frame;
+  auto ret = method->invoke(frame.getJniEnv(), this, init);
+  return ret.j;
 }
 
-std::shared_ptr<FakeJni::JIntArray> MainActivity::getImageData(std::shared_ptr<FakeJni::JString> filename) {
-    if(!stbi_load_from_memory || !stbi_image_free) return 0;
-    int width, height, channels;
-    std::ifstream f(filename->asStdString().data());
-    if(!f.is_open()) return 0;
-    std::stringstream s;
-    s << f.rdbuf();
-    auto buf = s.str();
-    auto image = stbi_load_from_memory((unsigned char*)buf.data(), buf.length(), &width, &height, &channels, 4);
-    if(!image) return 0;
-    auto ret = std::make_shared<FakeJni::JIntArray>(2 + width * height);
-    (*ret)[0] = width;
-    (*ret)[1] = height;
+std::shared_ptr<FakeJni::JIntArray>
+MainActivity::getImageData(std::shared_ptr<FakeJni::JString> filename) {
+  if (!stbi_load_from_memory || !stbi_image_free)
+    return 0;
+  int width, height, channels;
+  std::ifstream f(filename->asStdString().data());
+  if (!f.is_open())
+    return 0;
+  std::stringstream s;
+  s << f.rdbuf();
+  auto buf = s.str();
+  auto image = stbi_load_from_memory((unsigned char *)buf.data(), buf.length(),
+                                     &width, &height, &channels, 4);
+  if (!image)
+    return 0;
+  auto ret = std::make_shared<FakeJni::JIntArray>(2 + width * height);
+  (*ret)[0] = width;
+  (*ret)[1] = height;
 
-    for(int x = 0; x < width * height; x++) {
-        (*ret)[2 + x] = (image[x * 4 + 2]) | (image[x * 4 + 1] << 8) | (image[x * 4 + 0] << 16) | (image[x * 4 + 3] << 24);
-    }
-    stbi_image_free(image);
-    return ret;
+  for (int x = 0; x < width * height; x++) {
+    (*ret)[2 + x] = (image[x * 4 + 2]) | (image[x * 4 + 1] << 8) |
+                    (image[x * 4 + 0] << 16) | (image[x * 4 + 3] << 24);
+  }
+  stbi_image_free(image);
+  return ret;
 }
 
-std::shared_ptr<FakeJni::JByteArray> MainActivity::getFileDataBytes(std::shared_ptr<FakeJni::JString> path) {
-    return std::make_shared<FakeJni::JByteArray>();
+std::shared_ptr<FakeJni::JByteArray>
+MainActivity::getFileDataBytes(std::shared_ptr<FakeJni::JString> path) {
+  return std::make_shared<FakeJni::JByteArray>();
 }

--- a/src/jni/main_activity.cpp
+++ b/src/jni/main_activity.cpp
@@ -7,81 +7,79 @@
 #include <mach/mach.h>
 #include <sys/sysctl.h>
 #endif
-#include "uuid.h"
-#include <climits>
 #include <file_picker_factory.h>
 #include <game_window_manager.h>
+#include <climits>
 #include <sstream>
+#include "uuid.h"
 
 #include <log.h>
 
 FakeJni::JInt BuildVersion::SDK_INT = 27;
-std::shared_ptr<FakeJni::JString> BuildVersion::RELEASE =
-    std::make_shared<FakeJni::JString>("AndroidX");
+std::shared_ptr<FakeJni::JString> BuildVersion::RELEASE = std::make_shared<FakeJni::JString>("AndroidX");
 
-std::shared_ptr<FakeJni::JString> MainActivity::createUUID() {
-  return UUID::randomUUID()->toString();
-}
+std::shared_ptr<FakeJni::JString> MainActivity::createUUID() { return UUID::randomUUID()->toString(); }
 
-FakeJni::JLong MainActivity::getUsedMemory() {
+FakeJni::JLong MainActivity::getUsedMemory()
+{
 #ifdef __APPLE__
-  uint64_t page_size;
-  size_t len = sizeof(page_size);
-  sysctlbyname("hw.pagesize", &page_size, &len, NULL, 0);
+    uint64_t page_size;
+    size_t len = sizeof(page_size);
+    sysctlbyname("hw.pagesize", &page_size, &len, NULL, 0);
 
-  struct vm_statistics64 stat;
-  mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
-  host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&stat,
-                    &count);
+    struct vm_statistics64 stat;
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&stat, &count);
 
-  double page_K = page_size / (double)1024;
-  return (stat.active_count + stat.wire_count) * page_K * 1000;
+    double page_K = page_size / (double)1024;
+    return (stat.active_count + stat.wire_count) * page_K * 1000;
 #else
-  FILE *file = fopen("/proc/self/statm", "r");
-  if (file == nullptr)
-    return 0L;
-  int pageSize = getpagesize();
-  long long pageCount = 0L;
-  fscanf(file, "%lld", &pageCount);
-  fclose(file);
-  return pageCount * pageSize;
+    FILE *file = fopen("/proc/self/statm", "r");
+    if (file == nullptr)
+        return 0L;
+    int pageSize = getpagesize();
+    long long pageCount = 0L;
+    fscanf(file, "%lld", &pageCount);
+    fclose(file);
+    return pageCount * pageSize;
 #endif
 }
 
-FakeJni::JLong MainActivity::getFreeMemory() {
+FakeJni::JLong MainActivity::getFreeMemory()
+{
 #ifdef __APPLE__
-  uint64_t page_size;
-  size_t len = sizeof(page_size);
-  sysctlbyname("hw.pagesize", &page_size, &len, NULL, 0);
+    uint64_t page_size;
+    size_t len = sizeof(page_size);
+    sysctlbyname("hw.pagesize", &page_size, &len, NULL, 0);
 
-  struct vm_statistics64 stat;
-  mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
-  host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&stat,
-                    &count);
+    struct vm_statistics64 stat;
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&stat, &count);
 
-  double page_K = page_size / (double)1024;
-  return stat.free_count * page_K * 1000;
+    double page_K = page_size / (double)1024;
+    return stat.free_count * page_K * 1000;
 #else
-  struct sysinfo memInfo;
-  sysinfo(&memInfo);
-  long long total = memInfo.freeram;
-  total *= memInfo.mem_unit;
-  return total;
+    struct sysinfo memInfo;
+    sysinfo(&memInfo);
+    long long total = memInfo.freeram;
+    total *= memInfo.mem_unit;
+    return total;
 #endif
 }
 
-FakeJni::JLong MainActivity::getTotalMemory() {
+FakeJni::JLong MainActivity::getTotalMemory()
+{
 #ifdef __APPLE__
-  uint64_t memsize;
-  size_t len = sizeof(memsize);
-  sysctlbyname("hw.memsize", &memsize, &len, NULL, 0);
-  return memsize;
+    uint64_t memsize;
+    size_t len = sizeof(memsize);
+    sysctlbyname("hw.memsize", &memsize, &len, NULL, 0);
+    return memsize;
 #else
-  struct sysinfo memInfo;
-  sysinfo(&memInfo);
-  long long total = memInfo.totalram;
-  total *= memInfo.mem_unit;
-  return total;
+    struct sysinfo memInfo;
+    sysinfo(&memInfo);
+    long long total = memInfo.totalram;
+    total *= memInfo.mem_unit;
+    return total;
 #endif
 }
 
@@ -89,84 +87,89 @@ FakeJni::JLong MainActivity::getMemoryLimit() { return getTotalMemory(); }
 
 FakeJni::JLong MainActivity::getAvailableMemory() { return getTotalMemory(); }
 
-void MainActivity::pickImage(FakeJni::JLong callback) {
-  try {
-    auto picker = FilePickerFactory::createFilePicker();
-    picker->setTitle("Select image");
-    picker->setFileNameFilters({"*.png"});
-    if (picker->show()) {
-      auto method = getClass().getMethod("(JLjava/lang/String;)V",
-                                         "nativeOnPickImageSuccess");
-      FakeJni::LocalFrame frame;
-      method->invoke(
-          frame.getJniEnv(), this, callback,
-          frame.getJniEnv().createLocalReference(
-              std::make_shared<FakeJni::JString>(picker->getPickedFile())));
-    } else {
-      auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
-      FakeJni::LocalFrame frame;
-      method->invoke(frame.getJniEnv(), this, callback);
+void MainActivity::pickImage(FakeJni::JLong callback)
+{
+    try
+    {
+        auto picker = FilePickerFactory::createFilePicker();
+        picker->setTitle("Select image");
+        picker->setFileNameFilters({"*.png"});
+        if (picker->show())
+        {
+            auto method = getClass().getMethod("(JLjava/lang/String;)V", "nativeOnPickImageSuccess");
+            FakeJni::LocalFrame frame;
+            method->invoke(
+                frame.getJniEnv(), this, callback,
+                frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(picker->getPickedFile())));
+        }
+        else
+        {
+            auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
+            FakeJni::LocalFrame frame;
+            method->invoke(frame.getJniEnv(), this, callback);
+        }
     }
-  } catch (const std::exception &e) {
-    GameWindowManager::getManager()->getErrorHandler()->onError(
-        "FilePickerFactory",
-        std::string("Failed to open the file-picker details: ") + e.what());
-    auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
+    catch (const std::exception &e)
+    {
+        GameWindowManager::getManager()->getErrorHandler()->onError(
+            "FilePickerFactory", std::string("Failed to open the file-picker details: ") + e.what());
+        auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
+        FakeJni::LocalFrame frame;
+        method->invoke(frame.getJniEnv(), this, callback);
+    }
+}
+
+void MainActivity::initializeXboxLive(FakeJni::JLong xalinit, FakeJni::JLong xblinit)
+{
+    auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
     FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), this, callback);
-  }
+    method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
 }
 
-void MainActivity::initializeXboxLive(FakeJni::JLong xalinit,
-                                      FakeJni::JLong xblinit) {
-  auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
-  FakeJni::LocalFrame frame;
-  method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
+FakeJni::JLong MainActivity::initializeXboxLive2(FakeJni::JLong xalinit, FakeJni::JLong xblinit)
+{
+    auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
+    FakeJni::LocalFrame frame;
+    auto ret = method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
+    return ret.j;
 }
 
-FakeJni::JLong MainActivity::initializeXboxLive2(FakeJni::JLong xalinit,
-                                                 FakeJni::JLong xblinit) {
-  auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
-  FakeJni::LocalFrame frame;
-  auto ret = method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
-  return ret.j;
+FakeJni::JLong MainActivity::initializeLibHttpClient(FakeJni::JLong init)
+{
+    auto method = getClass().getMethod("(J)J", "nativeinitializeLibHttpClient");
+    FakeJni::LocalFrame frame;
+    auto ret = method->invoke(frame.getJniEnv(), this, init);
+    return ret.j;
 }
 
-FakeJni::JLong MainActivity::initializeLibHttpClient(FakeJni::JLong init) {
-  auto method = getClass().getMethod("(J)J", "nativeinitializeLibHttpClient");
-  FakeJni::LocalFrame frame;
-  auto ret = method->invoke(frame.getJniEnv(), this, init);
-  return ret.j;
+std::shared_ptr<FakeJni::JIntArray> MainActivity::getImageData(std::shared_ptr<FakeJni::JString> filename)
+{
+    if (!stbi_load_from_memory || !stbi_image_free)
+        return 0;
+    int width, height, channels;
+    std::ifstream f(filename->asStdString().data());
+    if (!f.is_open())
+        return 0;
+    std::stringstream s;
+    s << f.rdbuf();
+    auto buf = s.str();
+    auto image = stbi_load_from_memory((unsigned char *)buf.data(), buf.length(), &width, &height, &channels, 4);
+    if (!image)
+        return 0;
+    auto ret = std::make_shared<FakeJni::JIntArray>(2 + width * height);
+    (*ret)[0] = width;
+    (*ret)[1] = height;
+
+    for (int x = 0; x < width * height; x++)
+    {
+        (*ret)[2 + x] =
+            (image[x * 4 + 2]) | (image[x * 4 + 1] << 8) | (image[x * 4 + 0] << 16) | (image[x * 4 + 3] << 24);
+    }
+    stbi_image_free(image);
+    return ret;
 }
 
-std::shared_ptr<FakeJni::JIntArray>
-MainActivity::getImageData(std::shared_ptr<FakeJni::JString> filename) {
-  if (!stbi_load_from_memory || !stbi_image_free)
-    return 0;
-  int width, height, channels;
-  std::ifstream f(filename->asStdString().data());
-  if (!f.is_open())
-    return 0;
-  std::stringstream s;
-  s << f.rdbuf();
-  auto buf = s.str();
-  auto image = stbi_load_from_memory((unsigned char *)buf.data(), buf.length(),
-                                     &width, &height, &channels, 4);
-  if (!image)
-    return 0;
-  auto ret = std::make_shared<FakeJni::JIntArray>(2 + width * height);
-  (*ret)[0] = width;
-  (*ret)[1] = height;
-
-  for (int x = 0; x < width * height; x++) {
-    (*ret)[2 + x] = (image[x * 4 + 2]) | (image[x * 4 + 1] << 8) |
-                    (image[x * 4 + 0] << 16) | (image[x * 4 + 3] << 24);
-  }
-  stbi_image_free(image);
-  return ret;
-}
-
-std::shared_ptr<FakeJni::JByteArray>
-MainActivity::getFileDataBytes(std::shared_ptr<FakeJni::JString> path) {
-  return std::make_shared<FakeJni::JByteArray>();
+std::shared_ptr<FakeJni::JByteArray> MainActivity::getFileDataBytes(std::shared_ptr<FakeJni::JString> path)
+{
+    return std::make_shared<FakeJni::JByteArray>();
 }

--- a/src/jni/main_activity.cpp
+++ b/src/jni/main_activity.cpp
@@ -20,8 +20,7 @@ std::shared_ptr<FakeJni::JString> BuildVersion::RELEASE = std::make_shared<FakeJ
 
 std::shared_ptr<FakeJni::JString> MainActivity::createUUID() { return UUID::randomUUID()->toString(); }
 
-FakeJni::JLong MainActivity::getUsedMemory()
-{
+FakeJni::JLong MainActivity::getUsedMemory() {
 #ifdef __APPLE__
     uint64_t page_size;
     size_t len = sizeof(page_size);
@@ -45,8 +44,7 @@ FakeJni::JLong MainActivity::getUsedMemory()
 #endif
 }
 
-FakeJni::JLong MainActivity::getFreeMemory()
-{
+FakeJni::JLong MainActivity::getFreeMemory() {
 #ifdef __APPLE__
     uint64_t page_size;
     size_t len = sizeof(page_size);
@@ -67,8 +65,7 @@ FakeJni::JLong MainActivity::getFreeMemory()
 #endif
 }
 
-FakeJni::JLong MainActivity::getTotalMemory()
-{
+FakeJni::JLong MainActivity::getTotalMemory() {
 #ifdef __APPLE__
     uint64_t memsize;
     size_t len = sizeof(memsize);
@@ -87,30 +84,23 @@ FakeJni::JLong MainActivity::getMemoryLimit() { return getTotalMemory(); }
 
 FakeJni::JLong MainActivity::getAvailableMemory() { return getTotalMemory(); }
 
-void MainActivity::pickImage(FakeJni::JLong callback)
-{
-    try
-    {
+void MainActivity::pickImage(FakeJni::JLong callback) {
+    try {
         auto picker = FilePickerFactory::createFilePicker();
         picker->setTitle("Select image");
         picker->setFileNameFilters({"*.png"});
-        if (picker->show())
-        {
+        if (picker->show()) {
             auto method = getClass().getMethod("(JLjava/lang/String;)V", "nativeOnPickImageSuccess");
             FakeJni::LocalFrame frame;
             method->invoke(
                 frame.getJniEnv(), this, callback,
                 frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(picker->getPickedFile())));
-        }
-        else
-        {
+        } else {
             auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
             FakeJni::LocalFrame frame;
             method->invoke(frame.getJniEnv(), this, callback);
         }
-    }
-    catch (const std::exception &e)
-    {
+    } catch (const std::exception &e) {
         GameWindowManager::getManager()->getErrorHandler()->onError(
             "FilePickerFactory", std::string("Failed to open the file-picker details: ") + e.what());
         auto method = getClass().getMethod("(J)V", "nativeOnPickImageCanceled");
@@ -119,31 +109,27 @@ void MainActivity::pickImage(FakeJni::JLong callback)
     }
 }
 
-void MainActivity::initializeXboxLive(FakeJni::JLong xalinit, FakeJni::JLong xblinit)
-{
+void MainActivity::initializeXboxLive(FakeJni::JLong xalinit, FakeJni::JLong xblinit) {
     auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
     FakeJni::LocalFrame frame;
     method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
 }
 
-FakeJni::JLong MainActivity::initializeXboxLive2(FakeJni::JLong xalinit, FakeJni::JLong xblinit)
-{
+FakeJni::JLong MainActivity::initializeXboxLive2(FakeJni::JLong xalinit, FakeJni::JLong xblinit) {
     auto method = getClass().getMethod("(JJ)V", "nativeInitializeXboxLive");
     FakeJni::LocalFrame frame;
     auto ret = method->invoke(frame.getJniEnv(), this, xalinit, xblinit);
     return ret.j;
 }
 
-FakeJni::JLong MainActivity::initializeLibHttpClient(FakeJni::JLong init)
-{
+FakeJni::JLong MainActivity::initializeLibHttpClient(FakeJni::JLong init) {
     auto method = getClass().getMethod("(J)J", "nativeinitializeLibHttpClient");
     FakeJni::LocalFrame frame;
     auto ret = method->invoke(frame.getJniEnv(), this, init);
     return ret.j;
 }
 
-std::shared_ptr<FakeJni::JIntArray> MainActivity::getImageData(std::shared_ptr<FakeJni::JString> filename)
-{
+std::shared_ptr<FakeJni::JIntArray> MainActivity::getImageData(std::shared_ptr<FakeJni::JString> filename) {
     if (!stbi_load_from_memory || !stbi_image_free)
         return 0;
     int width, height, channels;
@@ -160,8 +146,7 @@ std::shared_ptr<FakeJni::JIntArray> MainActivity::getImageData(std::shared_ptr<F
     (*ret)[0] = width;
     (*ret)[1] = height;
 
-    for (int x = 0; x < width * height; x++)
-    {
+    for (int x = 0; x < width * height; x++) {
         (*ret)[2 + x] =
             (image[x * 4 + 2]) | (image[x * 4 + 1] << 8) | (image[x * 4 + 0] << 16) | (image[x * 4 + 3] << 24);
     }
@@ -169,7 +154,6 @@ std::shared_ptr<FakeJni::JIntArray> MainActivity::getImageData(std::shared_ptr<F
     return ret;
 }
 
-std::shared_ptr<FakeJni::JByteArray> MainActivity::getFileDataBytes(std::shared_ptr<FakeJni::JString> path)
-{
+std::shared_ptr<FakeJni::JByteArray> MainActivity::getFileDataBytes(std::shared_ptr<FakeJni::JString> path) {
     return std::make_shared<FakeJni::JByteArray>();
 }

--- a/src/jni/main_activity.h
+++ b/src/jni/main_activity.h
@@ -1,259 +1,248 @@
 #pragma once
 
+#include <fake-jni/fake-jni.h>
 #include "../text_input_handler.h"
 #include "java_types.h"
-#include <fake-jni/fake-jni.h>
 
-class BuildVersion : public FakeJni::JObject {
+class BuildVersion : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("android/os/Build$VERSION")
 
-public:
-  DEFINE_CLASS_NAME("android/os/Build$VERSION")
-
-  static FakeJni::JInt SDK_INT;
-  static std::shared_ptr<FakeJni::JString> RELEASE;
+    static FakeJni::JInt SDK_INT;
+    static std::shared_ptr<FakeJni::JString> RELEASE;
 };
 
-class PackageInfo : public FakeJni::JObject {
+class PackageInfo : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("android/content/pm/PackageInfo")
 
-public:
-  DEFINE_CLASS_NAME("android/content/pm/PackageInfo")
-
-  PackageInfo() { versionName = std::make_shared<FakeJni::JString>("TODO"); }
-  std::shared_ptr<FakeJni::JString> versionName;
+    PackageInfo() { versionName = std::make_shared<FakeJni::JString>("TODO"); }
+    std::shared_ptr<FakeJni::JString> versionName;
 };
 
-class PackageManager : public FakeJni::JObject {
+class PackageManager : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("android/content/pm/PackageManager")
 
-public:
-  DEFINE_CLASS_NAME("android/content/pm/PackageManager")
-
-  std::shared_ptr<PackageInfo>
-  getPackageInfo(std::shared_ptr<FakeJni::JString> packageName,
-                 FakeJni::JInt flags) {
-    return std::make_shared<PackageInfo>(PackageInfo());
-  }
+    std::shared_ptr<PackageInfo> getPackageInfo(std::shared_ptr<FakeJni::JString> packageName, FakeJni::JInt flags)
+    {
+        return std::make_shared<PackageInfo>(PackageInfo());
+    }
 };
 
-class Context : public FakeJni::JObject {
+class Context : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("android/content/Context")
 
-public:
-  DEFINE_CLASS_NAME("android/content/Context")
+    virtual std::shared_ptr<File> getFilesDir() = 0;
 
-  virtual std::shared_ptr<File> getFilesDir() = 0;
+    virtual std::shared_ptr<File> getCacheDir() = 0;
 
-  virtual std::shared_ptr<File> getCacheDir() = 0;
+    std::shared_ptr<ClassLoader> getClassLoader() { return ClassLoader::getInstance(); }
 
-  std::shared_ptr<ClassLoader> getClassLoader() {
-    return ClassLoader::getInstance();
-  }
+    std::shared_ptr<Context> getApplicationContext() { return std::static_pointer_cast<Context>(shared_from_this()); }
 
-  std::shared_ptr<Context> getApplicationContext() {
-    return std::static_pointer_cast<Context>(shared_from_this());
-  }
+    std::shared_ptr<FakeJni::JString> getPackageName()
+    {
+        return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
+    }
 
-  std::shared_ptr<FakeJni::JString> getPackageName() {
-    return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
-  }
-
-  std::shared_ptr<PackageManager> getPackageManager() {
-    return std::make_shared<PackageManager>(PackageManager());
-  }
+    std::shared_ptr<PackageManager> getPackageManager() { return std::make_shared<PackageManager>(PackageManager()); }
 };
 
-class ContextWrapper : public Context {
-
-public:
-  DEFINE_CLASS_NAME("android/content/ContextWrapper", Context)
+class ContextWrapper : public Context
+{
+   public:
+    DEFINE_CLASS_NAME("android/content/ContextWrapper", Context)
 };
 
-class Activity : public ContextWrapper {
-
-public:
-  DEFINE_CLASS_NAME("android/app/Activity", ContextWrapper)
+class Activity : public ContextWrapper
+{
+   public:
+    DEFINE_CLASS_NAME("android/app/Activity", ContextWrapper)
 };
 
-class NativeActivity : public Activity {
-
-public:
-  DEFINE_CLASS_NAME("android/app/NativeActivity", Activity)
+class NativeActivity : public Activity
+{
+   public:
+    DEFINE_CLASS_NAME("android/app/NativeActivity", Activity)
 };
 
-class HardwareInfo : public FakeJni::JObject {
+class HardwareInfo : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/HardwareInformation")
 
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/HardwareInformation")
+    static std::shared_ptr<FakeJni::JString> getAndroidVersion() { return std::make_shared<FakeJni::JString>("Linux"); }
 
-  static std::shared_ptr<FakeJni::JString> getAndroidVersion() {
-    return std::make_shared<FakeJni::JString>("Linux");
-  }
-
-  std::shared_ptr<FakeJni::JString> getInstallerPackageName() {
-    return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
-  }
+    std::shared_ptr<FakeJni::JString> getInstallerPackageName()
+    {
+        return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
+    }
 };
 #include <fstream>
-class MainActivity : public NativeActivity {
+class MainActivity : public NativeActivity
+{
+   private:
+    bool ignoreNextHideKeyboard = false;
 
-private:
-  bool ignoreNextHideKeyboard = false;
+   public:
+    unsigned char *(*stbi_load_from_memory)(unsigned char const *buffer, int len, int *x, int *y, int *channels_in_file,
+                                            int desired_channels);
+    void (*stbi_image_free)(void *retval_from_stbi_load);
 
-public:
-  unsigned char *(*stbi_load_from_memory)(unsigned char const *buffer, int len,
-                                          int *x, int *y, int *channels_in_file,
-                                          int desired_channels);
-  void (*stbi_image_free)(void *retval_from_stbi_load);
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/MainActivity", NativeActivity)
 
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/MainActivity", NativeActivity)
+    std::string storageDirectory;
+    TextInputHandler *textInput = nullptr;
+    std::function<void()> quitCallback;
+    GameWindow *window;
 
-  std::string storageDirectory;
-  TextInputHandler *textInput = nullptr;
-  std::function<void()> quitCallback;
-  GameWindow *window;
+    int getAndroidVersion() { return 27; }
 
-  int getAndroidVersion() { return 27; }
-
-  int getScreenWidth() {
-    int width, height;
-    window->getWindowSize(width, height);
-    return width;
-  }
-
-  int getScreenHeight() {
-    int width, height;
-    window->getWindowSize(width, height);
-    return height;
-  }
-
-  int getDisplayWidth() {
-    int width, height;
-    window->getWindowSize(width, height);
-    return width;
-  }
-
-  int getDisplayHeight() {
-    int width, height;
-    window->getWindowSize(width, height);
-    return height;
-  }
-
-  void tick() {}
-
-  FakeJni::JBoolean isNetworkEnabled(FakeJni::JBoolean wifi) { return true; }
-
-  FakeJni::JBoolean isChromebook() { return false; }
-
-  std::shared_ptr<FakeJni::JString> getLocale() {
-    return std::make_shared<FakeJni::JString>("en");
-  }
-
-  std::shared_ptr<FakeJni::JString> getDeviceModel() {
-    return std::make_shared<FakeJni::JString>("Linux");
-  }
-
-  std::shared_ptr<File> getFilesDir() override {
-    return std::make_shared<File>(storageDirectory);
-  }
-
-  std::shared_ptr<File> getCacheDir() override {
-    return std::make_shared<File>(storageDirectory);
-  }
-
-  std::shared_ptr<FakeJni::JString> getExternalStoragePath() {
-    return std::make_shared<FakeJni::JString>(storageDirectory);
-  }
-
-  std::shared_ptr<FakeJni::JString> getInternalStoragePath() {
-    return getExternalStoragePath();
-  }
-
-  std::shared_ptr<FakeJni::JString>
-  getLegacyExternalStoragePath(std::shared_ptr<FakeJni::JString> gameFolder) {
-    return std::make_shared<FakeJni::JString>("");
-  }
-
-  FakeJni::JBoolean hasWriteExternalStoragePermission() { return true; }
-
-  std::shared_ptr<HardwareInfo> getHardwareInfo() {
-    return std::make_shared<HardwareInfo>();
-  }
-
-  FakeJni::JFloat getPixelsPerMillimeter() {
-    // assume 96 DPI for now with GUI scale of 2
-    return (96 / 25.4f) * 2;
-  }
-
-  std::shared_ptr<FakeJni::JString> createUUID();
-
-  std::shared_ptr<FakeJni::JByteArray>
-  getFileDataBytes(std::shared_ptr<FakeJni::JString> path);
-
-  std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getIPAddresses() {
-    return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
-  }
-
-  std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getBroadcastAddresses() {
-    return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
-  }
-
-  void showKeyboard(std::shared_ptr<FakeJni::JString> text,
-                    FakeJni::JInt maxLen, FakeJni::JBoolean ignored,
-                    FakeJni::JBoolean ignored2, FakeJni::JBoolean multiline) {
-    ignoreNextHideKeyboard = false;
-    if (textInput)
-      textInput->enable(text->asStdString(), multiline);
-  }
-
-  void hideKeyboard() {
-    if (ignoreNextHideKeyboard) {
-      ignoreNextHideKeyboard = false;
-      return;
+    int getScreenWidth()
+    {
+        int width, height;
+        window->getWindowSize(width, height);
+        return width;
     }
-    if (textInput)
-      textInput->disable();
-  }
 
-  void updateTextboxText(std::shared_ptr<FakeJni::JString> newText) {
-    if (textInput)
-      textInput->update(newText->asStdString());
-    ignoreNextHideKeyboard = true;
-  }
+    int getScreenHeight()
+    {
+        int width, height;
+        window->getWindowSize(width, height);
+        return height;
+    }
 
-  FakeJni::JInt getCursorPosition() {
-    ignoreNextHideKeyboard = false;
-    if (textInput)
-      return textInput->getCursorPosition();
-    return -1;
-  }
+    int getDisplayWidth()
+    {
+        int width, height;
+        window->getWindowSize(width, height);
+        return width;
+    }
 
-  void lockCursor() { window->setCursorDisabled(true); }
+    int getDisplayHeight()
+    {
+        int width, height;
+        window->getWindowSize(width, height);
+        return height;
+    }
 
-  void unlockCursor() { window->setCursorDisabled(false); }
+    void tick() {}
 
-  FakeJni::JLong getUsedMemory();
+    FakeJni::JBoolean isNetworkEnabled(FakeJni::JBoolean wifi) { return true; }
 
-  FakeJni::JLong getFreeMemory();
+    FakeJni::JBoolean isChromebook() { return false; }
 
-  FakeJni::JLong getTotalMemory();
+    std::shared_ptr<FakeJni::JString> getLocale() { return std::make_shared<FakeJni::JString>("en"); }
 
-  FakeJni::JLong getMemoryLimit();
+    std::shared_ptr<FakeJni::JString> getDeviceModel() { return std::make_shared<FakeJni::JString>("Linux"); }
 
-  FakeJni::JLong getAvailableMemory();
+    std::shared_ptr<File> getFilesDir() override { return std::make_shared<File>(storageDirectory); }
 
-  void pickImage(FakeJni::JLong callback);
+    std::shared_ptr<File> getCacheDir() override { return std::make_shared<File>(storageDirectory); }
 
-  void initializeXboxLive(FakeJni::JLong xalinit, FakeJni::JLong xblinit);
+    std::shared_ptr<FakeJni::JString> getExternalStoragePath()
+    {
+        return std::make_shared<FakeJni::JString>(storageDirectory);
+    }
 
-  FakeJni::JLong initializeXboxLive2(FakeJni::JLong xalinit,
-                                     FakeJni::JLong xblinit);
+    std::shared_ptr<FakeJni::JString> getInternalStoragePath() { return getExternalStoragePath(); }
 
-  FakeJni::JLong initializeLibHttpClient(FakeJni::JLong init);
+    std::shared_ptr<FakeJni::JString> getLegacyExternalStoragePath(std::shared_ptr<FakeJni::JString> gameFolder)
+    {
+        return std::make_shared<FakeJni::JString>("");
+    }
 
-  std::shared_ptr<FakeJni::JIntArray>
-  getImageData(std::shared_ptr<FakeJni::JString> filename);
+    FakeJni::JBoolean hasWriteExternalStoragePermission() { return true; }
+
+    std::shared_ptr<HardwareInfo> getHardwareInfo() { return std::make_shared<HardwareInfo>(); }
+
+    FakeJni::JFloat getPixelsPerMillimeter()
+    {
+        // assume 96 DPI for now with GUI scale of 2
+        return (96 / 25.4f) * 2;
+    }
+
+    std::shared_ptr<FakeJni::JString> createUUID();
+
+    std::shared_ptr<FakeJni::JByteArray> getFileDataBytes(std::shared_ptr<FakeJni::JString> path);
+
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getIPAddresses()
+    {
+        return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
+    }
+
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getBroadcastAddresses()
+    {
+        return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
+    }
+
+    void showKeyboard(std::shared_ptr<FakeJni::JString> text, FakeJni::JInt maxLen, FakeJni::JBoolean ignored,
+                      FakeJni::JBoolean ignored2, FakeJni::JBoolean multiline)
+    {
+        ignoreNextHideKeyboard = false;
+        if (textInput)
+            textInput->enable(text->asStdString(), multiline);
+    }
+
+    void hideKeyboard()
+    {
+        if (ignoreNextHideKeyboard)
+        {
+            ignoreNextHideKeyboard = false;
+            return;
+        }
+        if (textInput)
+            textInput->disable();
+    }
+
+    void updateTextboxText(std::shared_ptr<FakeJni::JString> newText)
+    {
+        if (textInput)
+            textInput->update(newText->asStdString());
+        ignoreNextHideKeyboard = true;
+    }
+
+    FakeJni::JInt getCursorPosition()
+    {
+        ignoreNextHideKeyboard = false;
+        if (textInput)
+            return textInput->getCursorPosition();
+        return -1;
+    }
+
+    void lockCursor() { window->setCursorDisabled(true); }
+
+    void unlockCursor() { window->setCursorDisabled(false); }
+
+    FakeJni::JLong getUsedMemory();
+
+    FakeJni::JLong getFreeMemory();
+
+    FakeJni::JLong getTotalMemory();
+
+    FakeJni::JLong getMemoryLimit();
+
+    FakeJni::JLong getAvailableMemory();
+
+    void pickImage(FakeJni::JLong callback);
+
+    void initializeXboxLive(FakeJni::JLong xalinit, FakeJni::JLong xblinit);
+
+    FakeJni::JLong initializeXboxLive2(FakeJni::JLong xalinit, FakeJni::JLong xblinit);
+
+    FakeJni::JLong initializeLibHttpClient(FakeJni::JLong init);
+
+    std::shared_ptr<FakeJni::JIntArray> getImageData(std::shared_ptr<FakeJni::JString> filename);
 };
 
-class JellyBeanDeviceManager : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/input/JellyBeanDeviceManager")
+class JellyBeanDeviceManager : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/input/JellyBeanDeviceManager")
 };

--- a/src/jni/main_activity.h
+++ b/src/jni/main_activity.h
@@ -1,273 +1,259 @@
 #pragma once
 
-#include <fake-jni/fake-jni.h>
-#include "java_types.h"
 #include "../text_input_handler.h"
+#include "java_types.h"
+#include <fake-jni/fake-jni.h>
 
 class BuildVersion : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("android/os/Build$VERSION")
+  DEFINE_CLASS_NAME("android/os/Build$VERSION")
 
-    static FakeJni::JInt SDK_INT;
-    static std::shared_ptr<FakeJni::JString> RELEASE;
-
+  static FakeJni::JInt SDK_INT;
+  static std::shared_ptr<FakeJni::JString> RELEASE;
 };
 
 class PackageInfo : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("android/content/pm/PackageInfo")
+  DEFINE_CLASS_NAME("android/content/pm/PackageInfo")
 
-    PackageInfo() {
-        versionName = std::make_shared<FakeJni::JString>("TODO");
-    }
-    std::shared_ptr<FakeJni::JString> versionName;
-
+  PackageInfo() { versionName = std::make_shared<FakeJni::JString>("TODO"); }
+  std::shared_ptr<FakeJni::JString> versionName;
 };
 
 class PackageManager : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("android/content/pm/PackageManager")
+  DEFINE_CLASS_NAME("android/content/pm/PackageManager")
 
-    std::shared_ptr<PackageInfo> getPackageInfo(std::shared_ptr<FakeJni::JString> packageName, FakeJni::JInt flags) {
-        return std::make_shared<PackageInfo>(PackageInfo());
-    }
-
+  std::shared_ptr<PackageInfo>
+  getPackageInfo(std::shared_ptr<FakeJni::JString> packageName,
+                 FakeJni::JInt flags) {
+    return std::make_shared<PackageInfo>(PackageInfo());
+  }
 };
 
 class Context : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("android/content/Context")
+  DEFINE_CLASS_NAME("android/content/Context")
 
-    virtual std::shared_ptr<File> getFilesDir() = 0;
+  virtual std::shared_ptr<File> getFilesDir() = 0;
 
-    virtual std::shared_ptr<File> getCacheDir() = 0;
+  virtual std::shared_ptr<File> getCacheDir() = 0;
 
-    std::shared_ptr<ClassLoader> getClassLoader() {
-        return ClassLoader::getInstance();
-    }
+  std::shared_ptr<ClassLoader> getClassLoader() {
+    return ClassLoader::getInstance();
+  }
 
-    std::shared_ptr<Context> getApplicationContext() {
-        return std::static_pointer_cast<Context>(shared_from_this());
-    }
+  std::shared_ptr<Context> getApplicationContext() {
+    return std::static_pointer_cast<Context>(shared_from_this());
+  }
 
-    std::shared_ptr<FakeJni::JString> getPackageName() {
-        return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
-    }
+  std::shared_ptr<FakeJni::JString> getPackageName() {
+    return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
+  }
 
-    std::shared_ptr<PackageManager> getPackageManager() {
-        return std::make_shared<PackageManager>(PackageManager());
-    }
-
+  std::shared_ptr<PackageManager> getPackageManager() {
+    return std::make_shared<PackageManager>(PackageManager());
+  }
 };
 
 class ContextWrapper : public Context {
 
 public:
-    DEFINE_CLASS_NAME("android/content/ContextWrapper", Context)
-
+  DEFINE_CLASS_NAME("android/content/ContextWrapper", Context)
 };
 
 class Activity : public ContextWrapper {
 
 public:
-    DEFINE_CLASS_NAME("android/app/Activity", ContextWrapper)
-
+  DEFINE_CLASS_NAME("android/app/Activity", ContextWrapper)
 };
 
 class NativeActivity : public Activity {
 
 public:
-    DEFINE_CLASS_NAME("android/app/NativeActivity", Activity)
-
+  DEFINE_CLASS_NAME("android/app/NativeActivity", Activity)
 };
 
 class HardwareInfo : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/HardwareInformation")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/HardwareInformation")
 
-    static std::shared_ptr<FakeJni::JString> getAndroidVersion() {
-        return std::make_shared<FakeJni::JString>("Linux");
-    }
+  static std::shared_ptr<FakeJni::JString> getAndroidVersion() {
+    return std::make_shared<FakeJni::JString>("Linux");
+  }
 
-    std::shared_ptr<FakeJni::JString> getInstallerPackageName() {
-        return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
-    }
-
+  std::shared_ptr<FakeJni::JString> getInstallerPackageName() {
+    return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
+  }
 };
 #include <fstream>
 class MainActivity : public NativeActivity {
 
 private:
-    bool ignoreNextHideKeyboard = false;
+  bool ignoreNextHideKeyboard = false;
 
 public:
-    unsigned char* (*stbi_load_from_memory)(unsigned char const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
-    void (*stbi_image_free)(void *retval_from_stbi_load);
+  unsigned char *(*stbi_load_from_memory)(unsigned char const *buffer, int len,
+                                          int *x, int *y, int *channels_in_file,
+                                          int desired_channels);
+  void (*stbi_image_free)(void *retval_from_stbi_load);
 
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/MainActivity", NativeActivity)
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/MainActivity", NativeActivity)
 
-    std::string storageDirectory;
-    TextInputHandler *textInput = nullptr;
-    std::function<void ()> quitCallback;
-    GameWindow* window;
+  std::string storageDirectory;
+  TextInputHandler *textInput = nullptr;
+  std::function<void()> quitCallback;
+  GameWindow *window;
 
-    int getAndroidVersion() {
-        return 27;
+  int getAndroidVersion() { return 27; }
+
+  int getScreenWidth() {
+    int width, height;
+    window->getWindowSize(width, height);
+    return width;
+  }
+
+  int getScreenHeight() {
+    int width, height;
+    window->getWindowSize(width, height);
+    return height;
+  }
+
+  int getDisplayWidth() {
+    int width, height;
+    window->getWindowSize(width, height);
+    return width;
+  }
+
+  int getDisplayHeight() {
+    int width, height;
+    window->getWindowSize(width, height);
+    return height;
+  }
+
+  void tick() {}
+
+  FakeJni::JBoolean isNetworkEnabled(FakeJni::JBoolean wifi) { return true; }
+
+  FakeJni::JBoolean isChromebook() { return false; }
+
+  std::shared_ptr<FakeJni::JString> getLocale() {
+    return std::make_shared<FakeJni::JString>("en");
+  }
+
+  std::shared_ptr<FakeJni::JString> getDeviceModel() {
+    return std::make_shared<FakeJni::JString>("Linux");
+  }
+
+  std::shared_ptr<File> getFilesDir() override {
+    return std::make_shared<File>(storageDirectory);
+  }
+
+  std::shared_ptr<File> getCacheDir() override {
+    return std::make_shared<File>(storageDirectory);
+  }
+
+  std::shared_ptr<FakeJni::JString> getExternalStoragePath() {
+    return std::make_shared<FakeJni::JString>(storageDirectory);
+  }
+
+  std::shared_ptr<FakeJni::JString> getInternalStoragePath() {
+    return getExternalStoragePath();
+  }
+
+  std::shared_ptr<FakeJni::JString>
+  getLegacyExternalStoragePath(std::shared_ptr<FakeJni::JString> gameFolder) {
+    return std::make_shared<FakeJni::JString>("");
+  }
+
+  FakeJni::JBoolean hasWriteExternalStoragePermission() { return true; }
+
+  std::shared_ptr<HardwareInfo> getHardwareInfo() {
+    return std::make_shared<HardwareInfo>();
+  }
+
+  FakeJni::JFloat getPixelsPerMillimeter() {
+    // assume 96 DPI for now with GUI scale of 2
+    return (96 / 25.4f) * 2;
+  }
+
+  std::shared_ptr<FakeJni::JString> createUUID();
+
+  std::shared_ptr<FakeJni::JByteArray>
+  getFileDataBytes(std::shared_ptr<FakeJni::JString> path);
+
+  std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getIPAddresses() {
+    return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
+  }
+
+  std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getBroadcastAddresses() {
+    return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
+  }
+
+  void showKeyboard(std::shared_ptr<FakeJni::JString> text,
+                    FakeJni::JInt maxLen, FakeJni::JBoolean ignored,
+                    FakeJni::JBoolean ignored2, FakeJni::JBoolean multiline) {
+    ignoreNextHideKeyboard = false;
+    if (textInput)
+      textInput->enable(text->asStdString(), multiline);
+  }
+
+  void hideKeyboard() {
+    if (ignoreNextHideKeyboard) {
+      ignoreNextHideKeyboard = false;
+      return;
     }
+    if (textInput)
+      textInput->disable();
+  }
 
-    int getScreenWidth() {
-        int width, height;
-        window->getWindowSize(width, height);
-        return width;
-    }
+  void updateTextboxText(std::shared_ptr<FakeJni::JString> newText) {
+    if (textInput)
+      textInput->update(newText->asStdString());
+    ignoreNextHideKeyboard = true;
+  }
 
-    int getScreenHeight() {
-        int width, height;
-        window->getWindowSize(width, height);
-        return height;
-    }
+  FakeJni::JInt getCursorPosition() {
+    ignoreNextHideKeyboard = false;
+    if (textInput)
+      return textInput->getCursorPosition();
+    return -1;
+  }
 
-    int getDisplayWidth() {
-        int width, height;
-        window->getWindowSize(width, height);
-        return width;
-    }
+  void lockCursor() { window->setCursorDisabled(true); }
 
-    int getDisplayHeight() {
-        int width, height;
-        window->getWindowSize(width, height);
-        return height;
-    }
+  void unlockCursor() { window->setCursorDisabled(false); }
 
-    void tick() { }
+  FakeJni::JLong getUsedMemory();
 
-    FakeJni::JBoolean isNetworkEnabled(FakeJni::JBoolean wifi) {
-        return true;
-    }
+  FakeJni::JLong getFreeMemory();
 
-    FakeJni::JBoolean isChromebook() {
-        return false;
-    }
+  FakeJni::JLong getTotalMemory();
 
-    std::shared_ptr<FakeJni::JString> getLocale() {
-        return std::make_shared<FakeJni::JString>("en");
-    }
+  FakeJni::JLong getMemoryLimit();
 
-    std::shared_ptr<FakeJni::JString> getDeviceModel() {
-        return std::make_shared<FakeJni::JString>("Linux");
-    }
+  FakeJni::JLong getAvailableMemory();
 
-    std::shared_ptr<File> getFilesDir() override {
-        return std::make_shared<File>(storageDirectory);
-    }
+  void pickImage(FakeJni::JLong callback);
 
-    std::shared_ptr<File> getCacheDir() override {
-        return std::make_shared<File>(storageDirectory);
-    }
+  void initializeXboxLive(FakeJni::JLong xalinit, FakeJni::JLong xblinit);
 
-    std::shared_ptr<FakeJni::JString> getExternalStoragePath() {
-        return std::make_shared<FakeJni::JString>(storageDirectory);
-    }
+  FakeJni::JLong initializeXboxLive2(FakeJni::JLong xalinit,
+                                     FakeJni::JLong xblinit);
 
-    std::shared_ptr<FakeJni::JString> getInternalStoragePath() {
-        return getExternalStoragePath();
-    }
+  FakeJni::JLong initializeLibHttpClient(FakeJni::JLong init);
 
-    std::shared_ptr<FakeJni::JString> getLegacyExternalStoragePath(std::shared_ptr<FakeJni::JString> gameFolder) {
-        return std::make_shared<FakeJni::JString>("");
-    }
-
-    FakeJni::JBoolean hasWriteExternalStoragePermission() {
-        return true;
-    }
-
-    std::shared_ptr<HardwareInfo> getHardwareInfo() {
-        return std::make_shared<HardwareInfo>();
-    }
-
-    FakeJni::JFloat getPixelsPerMillimeter() {
-        // assume 96 DPI for now with GUI scale of 2
-        return (96 / 25.4f)*2;
-    }
-
-    std::shared_ptr<FakeJni::JString> createUUID();
-
-    std::shared_ptr<FakeJni::JByteArray> getFileDataBytes(std::shared_ptr<FakeJni::JString> path);
-
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getIPAddresses() {
-        return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
-    }
-
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getBroadcastAddresses() {
-        return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
-    }
-
-    void showKeyboard(std::shared_ptr<FakeJni::JString> text, FakeJni::JInt maxLen, FakeJni::JBoolean ignored,
-            FakeJni::JBoolean ignored2, FakeJni::JBoolean multiline) {
-        ignoreNextHideKeyboard = false;
-        if (textInput)
-            textInput->enable(text->asStdString(), multiline);
-    }
-
-    void hideKeyboard() {
-        if (ignoreNextHideKeyboard) {
-            ignoreNextHideKeyboard = false;
-            return;
-        }
-        if (textInput)
-            textInput->disable();
-    }
-
-    void updateTextboxText(std::shared_ptr<FakeJni::JString> newText) {
-        if (textInput)
-            textInput->update(newText->asStdString());
-        ignoreNextHideKeyboard = true;
-    }
-
-    FakeJni::JInt getCursorPosition() {
-        ignoreNextHideKeyboard = false;
-        if (textInput)
-            return textInput->getCursorPosition();
-        return -1;
-    }
-
-    void lockCursor() {
-        window->setCursorDisabled(true);
-    }
-
-    void unlockCursor() {
-        window->setCursorDisabled(false);
-    }
-
-    FakeJni::JLong getUsedMemory();
-
-    FakeJni::JLong getFreeMemory();
-
-    FakeJni::JLong getTotalMemory();
-
-    FakeJni::JLong getMemoryLimit();
-
-    FakeJni::JLong getAvailableMemory();
-
-    void pickImage(FakeJni::JLong callback);
-
-    void initializeXboxLive(FakeJni::JLong xalinit, FakeJni::JLong xblinit);
-
-    FakeJni::JLong initializeXboxLive2(FakeJni::JLong xalinit, FakeJni::JLong xblinit);
-
-    FakeJni::JLong initializeLibHttpClient(FakeJni::JLong init);
-
-    std::shared_ptr<FakeJni::JIntArray> getImageData(std::shared_ptr<FakeJni::JString> filename);
+  std::shared_ptr<FakeJni::JIntArray>
+  getImageData(std::shared_ptr<FakeJni::JString> filename);
 };
 
 class JellyBeanDeviceManager : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/input/JellyBeanDeviceManager")
-
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/input/JellyBeanDeviceManager")
 };

--- a/src/jni/main_activity.h
+++ b/src/jni/main_activity.h
@@ -4,8 +4,7 @@
 #include "../text_input_handler.h"
 #include "java_types.h"
 
-class BuildVersion : public FakeJni::JObject
-{
+class BuildVersion : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("android/os/Build$VERSION")
 
@@ -13,8 +12,7 @@ class BuildVersion : public FakeJni::JObject
     static std::shared_ptr<FakeJni::JString> RELEASE;
 };
 
-class PackageInfo : public FakeJni::JObject
-{
+class PackageInfo : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("android/content/pm/PackageInfo")
 
@@ -22,19 +20,16 @@ class PackageInfo : public FakeJni::JObject
     std::shared_ptr<FakeJni::JString> versionName;
 };
 
-class PackageManager : public FakeJni::JObject
-{
+class PackageManager : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("android/content/pm/PackageManager")
 
-    std::shared_ptr<PackageInfo> getPackageInfo(std::shared_ptr<FakeJni::JString> packageName, FakeJni::JInt flags)
-    {
+    std::shared_ptr<PackageInfo> getPackageInfo(std::shared_ptr<FakeJni::JString> packageName, FakeJni::JInt flags) {
         return std::make_shared<PackageInfo>(PackageInfo());
     }
 };
 
-class Context : public FakeJni::JObject
-{
+class Context : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("android/content/Context")
 
@@ -46,47 +41,40 @@ class Context : public FakeJni::JObject
 
     std::shared_ptr<Context> getApplicationContext() { return std::static_pointer_cast<Context>(shared_from_this()); }
 
-    std::shared_ptr<FakeJni::JString> getPackageName()
-    {
+    std::shared_ptr<FakeJni::JString> getPackageName() {
         return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
     }
 
     std::shared_ptr<PackageManager> getPackageManager() { return std::make_shared<PackageManager>(PackageManager()); }
 };
 
-class ContextWrapper : public Context
-{
+class ContextWrapper : public Context {
    public:
     DEFINE_CLASS_NAME("android/content/ContextWrapper", Context)
 };
 
-class Activity : public ContextWrapper
-{
+class Activity : public ContextWrapper {
    public:
     DEFINE_CLASS_NAME("android/app/Activity", ContextWrapper)
 };
 
-class NativeActivity : public Activity
-{
+class NativeActivity : public Activity {
    public:
     DEFINE_CLASS_NAME("android/app/NativeActivity", Activity)
 };
 
-class HardwareInfo : public FakeJni::JObject
-{
+class HardwareInfo : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/HardwareInformation")
 
     static std::shared_ptr<FakeJni::JString> getAndroidVersion() { return std::make_shared<FakeJni::JString>("Linux"); }
 
-    std::shared_ptr<FakeJni::JString> getInstallerPackageName()
-    {
+    std::shared_ptr<FakeJni::JString> getInstallerPackageName() {
         return std::make_shared<FakeJni::JString>("com.mojang.minecraftpe");
     }
 };
 #include <fstream>
-class MainActivity : public NativeActivity
-{
+class MainActivity : public NativeActivity {
    private:
     bool ignoreNextHideKeyboard = false;
 
@@ -104,29 +92,25 @@ class MainActivity : public NativeActivity
 
     int getAndroidVersion() { return 27; }
 
-    int getScreenWidth()
-    {
+    int getScreenWidth() {
         int width, height;
         window->getWindowSize(width, height);
         return width;
     }
 
-    int getScreenHeight()
-    {
+    int getScreenHeight() {
         int width, height;
         window->getWindowSize(width, height);
         return height;
     }
 
-    int getDisplayWidth()
-    {
+    int getDisplayWidth() {
         int width, height;
         window->getWindowSize(width, height);
         return width;
     }
 
-    int getDisplayHeight()
-    {
+    int getDisplayHeight() {
         int width, height;
         window->getWindowSize(width, height);
         return height;
@@ -146,15 +130,13 @@ class MainActivity : public NativeActivity
 
     std::shared_ptr<File> getCacheDir() override { return std::make_shared<File>(storageDirectory); }
 
-    std::shared_ptr<FakeJni::JString> getExternalStoragePath()
-    {
+    std::shared_ptr<FakeJni::JString> getExternalStoragePath() {
         return std::make_shared<FakeJni::JString>(storageDirectory);
     }
 
     std::shared_ptr<FakeJni::JString> getInternalStoragePath() { return getExternalStoragePath(); }
 
-    std::shared_ptr<FakeJni::JString> getLegacyExternalStoragePath(std::shared_ptr<FakeJni::JString> gameFolder)
-    {
+    std::shared_ptr<FakeJni::JString> getLegacyExternalStoragePath(std::shared_ptr<FakeJni::JString> gameFolder) {
         return std::make_shared<FakeJni::JString>("");
     }
 
@@ -162,8 +144,7 @@ class MainActivity : public NativeActivity
 
     std::shared_ptr<HardwareInfo> getHardwareInfo() { return std::make_shared<HardwareInfo>(); }
 
-    FakeJni::JFloat getPixelsPerMillimeter()
-    {
+    FakeJni::JFloat getPixelsPerMillimeter() {
         // assume 96 DPI for now with GUI scale of 2
         return (96 / 25.4f) * 2;
     }
@@ -172,28 +153,23 @@ class MainActivity : public NativeActivity
 
     std::shared_ptr<FakeJni::JByteArray> getFileDataBytes(std::shared_ptr<FakeJni::JString> path);
 
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getIPAddresses()
-    {
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getIPAddresses() {
         return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
     }
 
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getBroadcastAddresses()
-    {
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> getBroadcastAddresses() {
         return std::make_shared<FakeJni::JArray<FakeJni::JString>>();
     }
 
     void showKeyboard(std::shared_ptr<FakeJni::JString> text, FakeJni::JInt maxLen, FakeJni::JBoolean ignored,
-                      FakeJni::JBoolean ignored2, FakeJni::JBoolean multiline)
-    {
+                      FakeJni::JBoolean ignored2, FakeJni::JBoolean multiline) {
         ignoreNextHideKeyboard = false;
         if (textInput)
             textInput->enable(text->asStdString(), multiline);
     }
 
-    void hideKeyboard()
-    {
-        if (ignoreNextHideKeyboard)
-        {
+    void hideKeyboard() {
+        if (ignoreNextHideKeyboard) {
             ignoreNextHideKeyboard = false;
             return;
         }
@@ -201,15 +177,13 @@ class MainActivity : public NativeActivity
             textInput->disable();
     }
 
-    void updateTextboxText(std::shared_ptr<FakeJni::JString> newText)
-    {
+    void updateTextboxText(std::shared_ptr<FakeJni::JString> newText) {
         if (textInput)
             textInput->update(newText->asStdString());
         ignoreNextHideKeyboard = true;
     }
 
-    FakeJni::JInt getCursorPosition()
-    {
+    FakeJni::JInt getCursorPosition() {
         ignoreNextHideKeyboard = false;
         if (textInput)
             return textInput->getCursorPosition();
@@ -241,8 +215,7 @@ class MainActivity : public NativeActivity
     std::shared_ptr<FakeJni::JIntArray> getImageData(std::shared_ptr<FakeJni::JString> filename);
 };
 
-class JellyBeanDeviceManager : public FakeJni::JObject
-{
+class JellyBeanDeviceManager : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/input/JellyBeanDeviceManager")
 };

--- a/src/jni/package_source.cpp
+++ b/src/jni/package_source.cpp
@@ -1,8 +1,10 @@
 #include "package_source.h"
 
-NativePackageSourceListener::NativePackageSourceListener() {
-}
+NativePackageSourceListener::NativePackageSourceListener() {}
 
-std::shared_ptr<PackageSource> PackageSourceFactory::createGooglePlayPackageSource(std::shared_ptr<FakeJni::JString> a, std::shared_ptr<PackageSourceListener> l) {
-    return std::make_shared<PackageSource>();
+std::shared_ptr<PackageSource>
+PackageSourceFactory::createGooglePlayPackageSource(
+    std::shared_ptr<FakeJni::JString> a,
+    std::shared_ptr<PackageSourceListener> l) {
+  return std::make_shared<PackageSource>();
 }

--- a/src/jni/package_source.cpp
+++ b/src/jni/package_source.cpp
@@ -3,7 +3,6 @@
 NativePackageSourceListener::NativePackageSourceListener() {}
 
 std::shared_ptr<PackageSource> PackageSourceFactory::createGooglePlayPackageSource(
-    std::shared_ptr<FakeJni::JString> a, std::shared_ptr<PackageSourceListener> l)
-{
+    std::shared_ptr<FakeJni::JString> a, std::shared_ptr<PackageSourceListener> l) {
     return std::make_shared<PackageSource>();
 }

--- a/src/jni/package_source.cpp
+++ b/src/jni/package_source.cpp
@@ -2,9 +2,8 @@
 
 NativePackageSourceListener::NativePackageSourceListener() {}
 
-std::shared_ptr<PackageSource>
-PackageSourceFactory::createGooglePlayPackageSource(
-    std::shared_ptr<FakeJni::JString> a,
-    std::shared_ptr<PackageSourceListener> l) {
-  return std::make_shared<PackageSource>();
+std::shared_ptr<PackageSource> PackageSourceFactory::createGooglePlayPackageSource(
+    std::shared_ptr<FakeJni::JString> a, std::shared_ptr<PackageSourceListener> l)
+{
+    return std::make_shared<PackageSource>();
 }

--- a/src/jni/package_source.h
+++ b/src/jni/package_source.h
@@ -1,31 +1,36 @@
 #pragma once
 
-#include <fake-jni/fake-jni.h>
 #include "java_types.h"
+#include <fake-jni/fake-jni.h>
 
 class PackageSource : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSource")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSource")
 };
 
 class PackageSourceListener : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSourceListener")
+  DEFINE_CLASS_NAME(
+      "com/mojang/minecraftpe/packagesource/PackageSourceListener")
 };
 
 class NativePackageSourceListener : public PackageSourceListener {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/NativePackageSourceListener", PackageSourceListener)
-    NativePackageSourceListener();
+  DEFINE_CLASS_NAME(
+      "com/mojang/minecraftpe/packagesource/NativePackageSourceListener",
+      PackageSourceListener)
+  NativePackageSourceListener();
 };
 
 class PackageSourceFactory : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSourceFactory")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSourceFactory")
 
-    static std::shared_ptr<PackageSource> createGooglePlayPackageSource(std::shared_ptr<FakeJni::JString>, std::shared_ptr<PackageSourceListener>);
+  static std::shared_ptr<PackageSource>
+      createGooglePlayPackageSource(std::shared_ptr<FakeJni::JString>,
+                                    std::shared_ptr<PackageSourceListener>);
 };

--- a/src/jni/package_source.h
+++ b/src/jni/package_source.h
@@ -3,27 +3,23 @@
 #include <fake-jni/fake-jni.h>
 #include "java_types.h"
 
-class PackageSource : public FakeJni::JObject
-{
+class PackageSource : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSource")
 };
 
-class PackageSourceListener : public FakeJni::JObject
-{
+class PackageSourceListener : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSourceListener")
 };
 
-class NativePackageSourceListener : public PackageSourceListener
-{
+class NativePackageSourceListener : public PackageSourceListener {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/NativePackageSourceListener", PackageSourceListener)
     NativePackageSourceListener();
 };
 
-class PackageSourceFactory : public FakeJni::JObject
-{
+class PackageSourceFactory : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSourceFactory")
 

--- a/src/jni/package_source.h
+++ b/src/jni/package_source.h
@@ -1,36 +1,32 @@
 #pragma once
 
-#include "java_types.h"
 #include <fake-jni/fake-jni.h>
+#include "java_types.h"
 
-class PackageSource : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSource")
+class PackageSource : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSource")
 };
 
-class PackageSourceListener : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME(
-      "com/mojang/minecraftpe/packagesource/PackageSourceListener")
+class PackageSourceListener : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSourceListener")
 };
 
-class NativePackageSourceListener : public PackageSourceListener {
-
-public:
-  DEFINE_CLASS_NAME(
-      "com/mojang/minecraftpe/packagesource/NativePackageSourceListener",
-      PackageSourceListener)
-  NativePackageSourceListener();
+class NativePackageSourceListener : public PackageSourceListener
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/NativePackageSourceListener", PackageSourceListener)
+    NativePackageSourceListener();
 };
 
-class PackageSourceFactory : public FakeJni::JObject {
+class PackageSourceFactory : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSourceFactory")
 
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/packagesource/PackageSourceFactory")
-
-  static std::shared_ptr<PackageSource>
-      createGooglePlayPackageSource(std::shared_ptr<FakeJni::JString>,
-                                    std::shared_ptr<PackageSourceListener>);
+    static std::shared_ptr<PackageSource> createGooglePlayPackageSource(std::shared_ptr<FakeJni::JString>,
+                                                                        std::shared_ptr<PackageSourceListener>);
 };

--- a/src/jni/pulseaudio.cpp
+++ b/src/jni/pulseaudio.cpp
@@ -5,10 +5,9 @@
 
 AudioDevice::AudioDevice() { s = nullptr; }
 
-FakeJni::JBoolean AudioDevice::init(FakeJni::JInt channels, FakeJni::JInt samplerate, FakeJni::JInt c, FakeJni::JInt d)
-{
-    if (s != NULL)
-    {
+FakeJni::JBoolean AudioDevice::init(FakeJni::JInt channels, FakeJni::JInt samplerate, FakeJni::JInt c,
+                                    FakeJni::JInt d) {
+    if (s != NULL) {
         GameWindowManager::getManager()->getErrorHandler()->onError("Pulseaudio failed",
                                                                     "pulseaudio already initialized");
     }
@@ -33,8 +32,7 @@ FakeJni::JBoolean AudioDevice::init(FakeJni::JInt channels, FakeJni::JInt sample
                       &b,       // buffering attributes.
                       &error    // error code.
     );
-    if (s == NULL)
-    {
+    if (s == NULL) {
         auto errormsg = pa_strerror(error);
         GameWindowManager::getManager()->getErrorHandler()->onError(
             "Pulseaudio failed", std::string("pulseaudio pa_simple_new failed, audio will be unavailable: ") +
@@ -44,11 +42,9 @@ FakeJni::JBoolean AudioDevice::init(FakeJni::JInt channels, FakeJni::JInt sample
     return true;
 }
 
-void AudioDevice::write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt length)
-{
+void AudioDevice::write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt length) {
     int error = 0;
-    if (s && pa_simple_write(s, data->getArray(), length, &error))
-    {
+    if (s && pa_simple_write(s, data->getArray(), length, &error)) {
         pa_simple_free(s);
         s = nullptr;
         auto errormsg = pa_strerror(error);
@@ -59,11 +55,9 @@ void AudioDevice::write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt
     }
 }
 
-void AudioDevice::close()
-{
+void AudioDevice::close() {
     int error = 0;
-    if (pa_simple_flush(s, &error))
-    {
+    if (pa_simple_flush(s, &error)) {
         auto errormsg = pa_strerror(error);
         GameWindowManager::getManager()->getErrorHandler()->onError(
             "Pulseaudio failed",

--- a/src/jni/pulseaudio.cpp
+++ b/src/jni/pulseaudio.cpp
@@ -1,61 +1,74 @@
 #include "pulseaudio.h"
-#include <pulse/simple.h>
-#include <pulse/error.h>
 #include <game_window_manager.h>
+#include <pulse/error.h>
+#include <pulse/simple.h>
 
-AudioDevice::AudioDevice() {
-    s = nullptr;
-}
+AudioDevice::AudioDevice() { s = nullptr; }
 
-FakeJni::JBoolean AudioDevice::init(FakeJni::JInt channels, FakeJni::JInt samplerate, FakeJni::JInt c, FakeJni::JInt d) {
-    if (s != NULL) {
-        GameWindowManager::getManager()->getErrorHandler()->onError("Pulseaudio failed", "pulseaudio already initialized");
-    }
-    pa_sample_spec ss;
-    ss.format = PA_SAMPLE_S16NE;
-    ss.channels = channels;
-    ss.rate = samplerate;
-    pa_buffer_attr b;
-    b.fragsize = -1;
-    b.maxlength = c * d * channels * 2;
-    b.minreq = -1;
-    b.prebuf = -1;
-    b.tlength = -1;
-    int error = 0;
-    s = pa_simple_new(NULL,             // Use the default server.
-                    "mcpelauncher",     // Our application's name.
+FakeJni::JBoolean AudioDevice::init(FakeJni::JInt channels,
+                                    FakeJni::JInt samplerate, FakeJni::JInt c,
+                                    FakeJni::JInt d) {
+  if (s != NULL) {
+    GameWindowManager::getManager()->getErrorHandler()->onError(
+        "Pulseaudio failed", "pulseaudio already initialized");
+  }
+  pa_sample_spec ss;
+  ss.format = PA_SAMPLE_S16NE;
+  ss.channels = channels;
+  ss.rate = samplerate;
+  pa_buffer_attr b;
+  b.fragsize = -1;
+  b.maxlength = c * d * channels * 2;
+  b.minreq = -1;
+  b.prebuf = -1;
+  b.tlength = -1;
+  int error = 0;
+  s = pa_simple_new(NULL,           // Use the default server.
+                    "mcpelauncher", // Our application's name.
                     PA_STREAM_PLAYBACK,
-                    NULL,               // Use the default device.
-                    "Music",            // Description of our stream.
-                    &ss,                // Our sample format.
-                    NULL,               // Use default channel map
-                    &b,                 // buffering attributes.
-                    &error              // error code.
-                    );
-    if (s == NULL) {
-        auto errormsg = pa_strerror(error);
-        GameWindowManager::getManager()->getErrorHandler()->onError("Pulseaudio failed", std::string("pulseaudio pa_simple_new failed, audio will be unavailable: ") + (errormsg ? errormsg : "No message from pulseaudio"));
-        return false;
-    }
-    return true;
+                    NULL,    // Use the default device.
+                    "Music", // Description of our stream.
+                    &ss,     // Our sample format.
+                    NULL,    // Use default channel map
+                    &b,      // buffering attributes.
+                    &error   // error code.
+  );
+  if (s == NULL) {
+    auto errormsg = pa_strerror(error);
+    GameWindowManager::getManager()->getErrorHandler()->onError(
+        "Pulseaudio failed",
+        std::string(
+            "pulseaudio pa_simple_new failed, audio will be unavailable: ") +
+            (errormsg ? errormsg : "No message from pulseaudio"));
+    return false;
+  }
+  return true;
 }
 
-void AudioDevice::write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt length) {
-    int error = 0;
-    if (s && pa_simple_write(s, data->getArray(), length, &error)) {
-        pa_simple_free(s);
-        s = nullptr;
-        auto errormsg = pa_strerror(error);
-        GameWindowManager::getManager()->getErrorHandler()->onError("Pulseaudio failed", std::string("pulseaudio pa_simple_write failed, please reopen the Launcher to reconnect: ") + (errormsg ? errormsg : "No message from pulseaudio"));
-    }
+void AudioDevice::write(std::shared_ptr<FakeJni::JByteArray> data,
+                        FakeJni::JInt length) {
+  int error = 0;
+  if (s && pa_simple_write(s, data->getArray(), length, &error)) {
+    pa_simple_free(s);
+    s = nullptr;
+    auto errormsg = pa_strerror(error);
+    GameWindowManager::getManager()->getErrorHandler()->onError(
+        "Pulseaudio failed",
+        std::string("pulseaudio pa_simple_write failed, please reopen the "
+                    "Launcher to reconnect: ") +
+            (errormsg ? errormsg : "No message from pulseaudio"));
+  }
 }
 
 void AudioDevice::close() {
-    int error = 0;
-    if (pa_simple_flush(s, &error)) {
-        auto errormsg = pa_strerror(error);
-        GameWindowManager::getManager()->getErrorHandler()->onError("Pulseaudio failed", std::string("pulseaudio pa_simple_flush failed: ") + (errormsg ? errormsg : "No message from pulseaudio"));
-    }
-    pa_simple_free(s);
-    s = nullptr;
+  int error = 0;
+  if (pa_simple_flush(s, &error)) {
+    auto errormsg = pa_strerror(error);
+    GameWindowManager::getManager()->getErrorHandler()->onError(
+        "Pulseaudio failed",
+        std::string("pulseaudio pa_simple_flush failed: ") +
+            (errormsg ? errormsg : "No message from pulseaudio"));
+  }
+  pa_simple_free(s);
+  s = nullptr;
 }

--- a/src/jni/pulseaudio.cpp
+++ b/src/jni/pulseaudio.cpp
@@ -5,70 +5,70 @@
 
 AudioDevice::AudioDevice() { s = nullptr; }
 
-FakeJni::JBoolean AudioDevice::init(FakeJni::JInt channels,
-                                    FakeJni::JInt samplerate, FakeJni::JInt c,
-                                    FakeJni::JInt d) {
-  if (s != NULL) {
-    GameWindowManager::getManager()->getErrorHandler()->onError(
-        "Pulseaudio failed", "pulseaudio already initialized");
-  }
-  pa_sample_spec ss;
-  ss.format = PA_SAMPLE_S16NE;
-  ss.channels = channels;
-  ss.rate = samplerate;
-  pa_buffer_attr b;
-  b.fragsize = -1;
-  b.maxlength = c * d * channels * 2;
-  b.minreq = -1;
-  b.prebuf = -1;
-  b.tlength = -1;
-  int error = 0;
-  s = pa_simple_new(NULL,           // Use the default server.
-                    "mcpelauncher", // Our application's name.
-                    PA_STREAM_PLAYBACK,
-                    NULL,    // Use the default device.
-                    "Music", // Description of our stream.
-                    &ss,     // Our sample format.
-                    NULL,    // Use default channel map
-                    &b,      // buffering attributes.
-                    &error   // error code.
-  );
-  if (s == NULL) {
-    auto errormsg = pa_strerror(error);
-    GameWindowManager::getManager()->getErrorHandler()->onError(
-        "Pulseaudio failed",
-        std::string(
-            "pulseaudio pa_simple_new failed, audio will be unavailable: ") +
-            (errormsg ? errormsg : "No message from pulseaudio"));
-    return false;
-  }
-  return true;
+FakeJni::JBoolean AudioDevice::init(FakeJni::JInt channels, FakeJni::JInt samplerate, FakeJni::JInt c, FakeJni::JInt d)
+{
+    if (s != NULL)
+    {
+        GameWindowManager::getManager()->getErrorHandler()->onError("Pulseaudio failed",
+                                                                    "pulseaudio already initialized");
+    }
+    pa_sample_spec ss;
+    ss.format = PA_SAMPLE_S16NE;
+    ss.channels = channels;
+    ss.rate = samplerate;
+    pa_buffer_attr b;
+    b.fragsize = -1;
+    b.maxlength = c * d * channels * 2;
+    b.minreq = -1;
+    b.prebuf = -1;
+    b.tlength = -1;
+    int error = 0;
+    s = pa_simple_new(NULL,            // Use the default server.
+                      "mcpelauncher",  // Our application's name.
+                      PA_STREAM_PLAYBACK,
+                      NULL,     // Use the default device.
+                      "Music",  // Description of our stream.
+                      &ss,      // Our sample format.
+                      NULL,     // Use default channel map
+                      &b,       // buffering attributes.
+                      &error    // error code.
+    );
+    if (s == NULL)
+    {
+        auto errormsg = pa_strerror(error);
+        GameWindowManager::getManager()->getErrorHandler()->onError(
+            "Pulseaudio failed", std::string("pulseaudio pa_simple_new failed, audio will be unavailable: ") +
+                                     (errormsg ? errormsg : "No message from pulseaudio"));
+        return false;
+    }
+    return true;
 }
 
-void AudioDevice::write(std::shared_ptr<FakeJni::JByteArray> data,
-                        FakeJni::JInt length) {
-  int error = 0;
-  if (s && pa_simple_write(s, data->getArray(), length, &error)) {
+void AudioDevice::write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt length)
+{
+    int error = 0;
+    if (s && pa_simple_write(s, data->getArray(), length, &error))
+    {
+        pa_simple_free(s);
+        s = nullptr;
+        auto errormsg = pa_strerror(error);
+        GameWindowManager::getManager()->getErrorHandler()->onError(
+            "Pulseaudio failed", std::string("pulseaudio pa_simple_write failed, please reopen the "
+                                             "Launcher to reconnect: ") +
+                                     (errormsg ? errormsg : "No message from pulseaudio"));
+    }
+}
+
+void AudioDevice::close()
+{
+    int error = 0;
+    if (pa_simple_flush(s, &error))
+    {
+        auto errormsg = pa_strerror(error);
+        GameWindowManager::getManager()->getErrorHandler()->onError(
+            "Pulseaudio failed",
+            std::string("pulseaudio pa_simple_flush failed: ") + (errormsg ? errormsg : "No message from pulseaudio"));
+    }
     pa_simple_free(s);
     s = nullptr;
-    auto errormsg = pa_strerror(error);
-    GameWindowManager::getManager()->getErrorHandler()->onError(
-        "Pulseaudio failed",
-        std::string("pulseaudio pa_simple_write failed, please reopen the "
-                    "Launcher to reconnect: ") +
-            (errormsg ? errormsg : "No message from pulseaudio"));
-  }
-}
-
-void AudioDevice::close() {
-  int error = 0;
-  if (pa_simple_flush(s, &error)) {
-    auto errormsg = pa_strerror(error);
-    GameWindowManager::getManager()->getErrorHandler()->onError(
-        "Pulseaudio failed",
-        std::string("pulseaudio pa_simple_flush failed: ") +
-            (errormsg ? errormsg : "No message from pulseaudio"));
-  }
-  pa_simple_free(s);
-  s = nullptr;
 }

--- a/src/jni/pulseaudio.h
+++ b/src/jni/pulseaudio.h
@@ -3,19 +3,18 @@
 #include <fake-jni/fake-jni.h>
 #include <pulse/simple.h>
 
-class AudioDevice : public FakeJni::JObject {
+class AudioDevice : public FakeJni::JObject
+{
+    pa_simple *s;
 
-  pa_simple *s;
+   public:
+    DEFINE_CLASS_NAME("org/fmod/AudioDevice")
 
-public:
-  DEFINE_CLASS_NAME("org/fmod/AudioDevice")
+    AudioDevice();
 
-  AudioDevice();
+    FakeJni::JBoolean init(FakeJni::JInt channels, FakeJni::JInt samplerate, FakeJni::JInt c, FakeJni::JInt d);
 
-  FakeJni::JBoolean init(FakeJni::JInt channels, FakeJni::JInt samplerate,
-                         FakeJni::JInt c, FakeJni::JInt d);
+    void write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt length);
 
-  void write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt length);
-
-  void close();
+    void close();
 };

--- a/src/jni/pulseaudio.h
+++ b/src/jni/pulseaudio.h
@@ -3,8 +3,7 @@
 #include <fake-jni/fake-jni.h>
 #include <pulse/simple.h>
 
-class AudioDevice : public FakeJni::JObject
-{
+class AudioDevice : public FakeJni::JObject {
     pa_simple *s;
 
    public:

--- a/src/jni/pulseaudio.h
+++ b/src/jni/pulseaudio.h
@@ -5,16 +5,17 @@
 
 class AudioDevice : public FakeJni::JObject {
 
-    pa_simple* s;
+  pa_simple *s;
 
 public:
-    DEFINE_CLASS_NAME("org/fmod/AudioDevice")
+  DEFINE_CLASS_NAME("org/fmod/AudioDevice")
 
-    AudioDevice();
+  AudioDevice();
 
-    FakeJni::JBoolean init(FakeJni::JInt channels, FakeJni::JInt samplerate, FakeJni::JInt c, FakeJni::JInt d);
+  FakeJni::JBoolean init(FakeJni::JInt channels, FakeJni::JInt samplerate,
+                         FakeJni::JInt c, FakeJni::JInt d);
 
-    void write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt length);
+  void write(std::shared_ptr<FakeJni::JByteArray> data, FakeJni::JInt length);
 
-    void close();
+  void close();
 };

--- a/src/jni/securerandom.cpp
+++ b/src/jni/securerandom.cpp
@@ -1,6 +1,6 @@
 #include "securerandom.h"
 
-std::shared_ptr<FakeJni::JByteArray>
-SecureRandom::GenerateRandomBytes(int bytes) {
-  return std::make_shared<FakeJni::JByteArray>(bytes);
+std::shared_ptr<FakeJni::JByteArray> SecureRandom::GenerateRandomBytes(int bytes)
+{
+    return std::make_shared<FakeJni::JByteArray>(bytes);
 }

--- a/src/jni/securerandom.cpp
+++ b/src/jni/securerandom.cpp
@@ -1,5 +1,6 @@
 #include "securerandom.h"
 
-std::shared_ptr<FakeJni::JByteArray> SecureRandom::GenerateRandomBytes(int bytes) {
-    return std::make_shared<FakeJni::JByteArray>(bytes);
+std::shared_ptr<FakeJni::JByteArray>
+SecureRandom::GenerateRandomBytes(int bytes) {
+  return std::make_shared<FakeJni::JByteArray>(bytes);
 }

--- a/src/jni/securerandom.cpp
+++ b/src/jni/securerandom.cpp
@@ -1,6 +1,5 @@
 #include "securerandom.h"
 
-std::shared_ptr<FakeJni::JByteArray> SecureRandom::GenerateRandomBytes(int bytes)
-{
+std::shared_ptr<FakeJni::JByteArray> SecureRandom::GenerateRandomBytes(int bytes) {
     return std::make_shared<FakeJni::JByteArray>(bytes);
 }

--- a/src/jni/securerandom.h
+++ b/src/jni/securerandom.h
@@ -3,6 +3,6 @@
 
 class SecureRandom : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xal/crypto/SecureRandom")
-    static std::shared_ptr<FakeJni::JByteArray> GenerateRandomBytes(int bytes);
+  DEFINE_CLASS_NAME("com/microsoft/xal/crypto/SecureRandom")
+  static std::shared_ptr<FakeJni::JByteArray> GenerateRandomBytes(int bytes);
 };

--- a/src/jni/securerandom.h
+++ b/src/jni/securerandom.h
@@ -1,8 +1,9 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class SecureRandom : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xal/crypto/SecureRandom")
-  static std::shared_ptr<FakeJni::JByteArray> GenerateRandomBytes(int bytes);
+class SecureRandom : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xal/crypto/SecureRandom")
+    static std::shared_ptr<FakeJni::JByteArray> GenerateRandomBytes(int bytes);
 };

--- a/src/jni/securerandom.h
+++ b/src/jni/securerandom.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class SecureRandom : public FakeJni::JObject
-{
+class SecureRandom : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/microsoft/xal/crypto/SecureRandom")
     static std::shared_ptr<FakeJni::JByteArray> GenerateRandomBytes(int bytes);

--- a/src/jni/shahasher.cpp
+++ b/src/jni/shahasher.cpp
@@ -1,41 +1,33 @@
 #include "shahasher.h"
 
-ShaHasher::ShaHasher()
-{
+ShaHasher::ShaHasher() {
     const EVP_MD *md = EVP_get_digestbynid(NID_sha256);
-    if (md == NULL)
-    {
+    if (md == NULL) {
         throw std::runtime_error("OpenSSL failed to get \"SHA2-256\"");
     }
     mdctx = EVP_MD_CTX_new();
-    if (md == NULL)
-    {
+    if (md == NULL) {
         throw std::runtime_error("OpenSSL failed to create mdctx");
     }
-    if (EVP_DigestInit_ex(mdctx, md, NULL) != 1)
-    {
+    if (EVP_DigestInit_ex(mdctx, md, NULL) != 1) {
         throw std::runtime_error("OpenSSL failed to initialize evp digest");
     }
 }
 
 ShaHasher::~ShaHasher() { EVP_MD_CTX_free(mdctx); }
 
-void ShaHasher::AddBytes(std::shared_ptr<FakeJni::JByteArray> barray)
-{
+void ShaHasher::AddBytes(std::shared_ptr<FakeJni::JByteArray> barray) {
     auto data = barray->getArray();
     auto len = barray->getSize();
-    if (EVP_DigestUpdate(mdctx, data, len) != 1)
-    {
+    if (EVP_DigestUpdate(mdctx, data, len) != 1) {
         throw std::runtime_error("OpenSSL failed to update evp digest");
     }
 }
 
-std::shared_ptr<FakeJni::JByteArray> ShaHasher::SignHash()
-{
+std::shared_ptr<FakeJni::JByteArray> ShaHasher::SignHash() {
     unsigned char md_value[EVP_MAX_MD_SIZE];
     unsigned int md_len = 0;
-    if (EVP_DigestFinal_ex(mdctx, md_value, &md_len) != 1)
-    {
+    if (EVP_DigestFinal_ex(mdctx, md_value, &md_len) != 1) {
         throw std::runtime_error("OpenSSL failed to finish evp digest");
     }
     auto arr = std::make_shared<FakeJni::JByteArray>(md_len);

--- a/src/jni/shahasher.cpp
+++ b/src/jni/shahasher.cpp
@@ -1,38 +1,36 @@
 #include "shahasher.h"
 
-ShaHasher::ShaHasher()  {
-    const EVP_MD* md = EVP_get_digestbynid(NID_sha256);
-    if (md == NULL) {
-        throw std::runtime_error("OpenSSL failed to get \"SHA2-256\"");
-    }
-    mdctx = EVP_MD_CTX_new();
-    if (md == NULL) {
-        throw std::runtime_error("OpenSSL failed to create mdctx");
-    }
-    if (EVP_DigestInit_ex(mdctx, md, NULL) != 1) {
-        throw std::runtime_error("OpenSSL failed to initialize evp digest");
-    }
+ShaHasher::ShaHasher() {
+  const EVP_MD *md = EVP_get_digestbynid(NID_sha256);
+  if (md == NULL) {
+    throw std::runtime_error("OpenSSL failed to get \"SHA2-256\"");
+  }
+  mdctx = EVP_MD_CTX_new();
+  if (md == NULL) {
+    throw std::runtime_error("OpenSSL failed to create mdctx");
+  }
+  if (EVP_DigestInit_ex(mdctx, md, NULL) != 1) {
+    throw std::runtime_error("OpenSSL failed to initialize evp digest");
+  }
 }
 
-ShaHasher::~ShaHasher() {
-    EVP_MD_CTX_free(mdctx);
-}
+ShaHasher::~ShaHasher() { EVP_MD_CTX_free(mdctx); }
 
 void ShaHasher::AddBytes(std::shared_ptr<FakeJni::JByteArray> barray) {
-    auto data = barray->getArray();
-    auto len = barray->getSize();
-    if (EVP_DigestUpdate(mdctx, data, len) != 1) {
-        throw std::runtime_error("OpenSSL failed to update evp digest");
-    }
+  auto data = barray->getArray();
+  auto len = barray->getSize();
+  if (EVP_DigestUpdate(mdctx, data, len) != 1) {
+    throw std::runtime_error("OpenSSL failed to update evp digest");
+  }
 }
 
 std::shared_ptr<FakeJni::JByteArray> ShaHasher::SignHash() {
-    unsigned char md_value[EVP_MAX_MD_SIZE];
-    unsigned int md_len = 0;
-    if (EVP_DigestFinal_ex(mdctx, md_value, &md_len) != 1) {
-        throw std::runtime_error("OpenSSL failed to finish evp digest");
-    }
-    auto arr = std::make_shared<FakeJni::JByteArray>(md_len);
-    memcpy(arr->getArray(), md_value, md_len);
-    return arr;
+  unsigned char md_value[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+  if (EVP_DigestFinal_ex(mdctx, md_value, &md_len) != 1) {
+    throw std::runtime_error("OpenSSL failed to finish evp digest");
+  }
+  auto arr = std::make_shared<FakeJni::JByteArray>(md_len);
+  memcpy(arr->getArray(), md_value, md_len);
+  return arr;
 }

--- a/src/jni/shahasher.cpp
+++ b/src/jni/shahasher.cpp
@@ -1,36 +1,44 @@
 #include "shahasher.h"
 
-ShaHasher::ShaHasher() {
-  const EVP_MD *md = EVP_get_digestbynid(NID_sha256);
-  if (md == NULL) {
-    throw std::runtime_error("OpenSSL failed to get \"SHA2-256\"");
-  }
-  mdctx = EVP_MD_CTX_new();
-  if (md == NULL) {
-    throw std::runtime_error("OpenSSL failed to create mdctx");
-  }
-  if (EVP_DigestInit_ex(mdctx, md, NULL) != 1) {
-    throw std::runtime_error("OpenSSL failed to initialize evp digest");
-  }
+ShaHasher::ShaHasher()
+{
+    const EVP_MD *md = EVP_get_digestbynid(NID_sha256);
+    if (md == NULL)
+    {
+        throw std::runtime_error("OpenSSL failed to get \"SHA2-256\"");
+    }
+    mdctx = EVP_MD_CTX_new();
+    if (md == NULL)
+    {
+        throw std::runtime_error("OpenSSL failed to create mdctx");
+    }
+    if (EVP_DigestInit_ex(mdctx, md, NULL) != 1)
+    {
+        throw std::runtime_error("OpenSSL failed to initialize evp digest");
+    }
 }
 
 ShaHasher::~ShaHasher() { EVP_MD_CTX_free(mdctx); }
 
-void ShaHasher::AddBytes(std::shared_ptr<FakeJni::JByteArray> barray) {
-  auto data = barray->getArray();
-  auto len = barray->getSize();
-  if (EVP_DigestUpdate(mdctx, data, len) != 1) {
-    throw std::runtime_error("OpenSSL failed to update evp digest");
-  }
+void ShaHasher::AddBytes(std::shared_ptr<FakeJni::JByteArray> barray)
+{
+    auto data = barray->getArray();
+    auto len = barray->getSize();
+    if (EVP_DigestUpdate(mdctx, data, len) != 1)
+    {
+        throw std::runtime_error("OpenSSL failed to update evp digest");
+    }
 }
 
-std::shared_ptr<FakeJni::JByteArray> ShaHasher::SignHash() {
-  unsigned char md_value[EVP_MAX_MD_SIZE];
-  unsigned int md_len = 0;
-  if (EVP_DigestFinal_ex(mdctx, md_value, &md_len) != 1) {
-    throw std::runtime_error("OpenSSL failed to finish evp digest");
-  }
-  auto arr = std::make_shared<FakeJni::JByteArray>(md_len);
-  memcpy(arr->getArray(), md_value, md_len);
-  return arr;
+std::shared_ptr<FakeJni::JByteArray> ShaHasher::SignHash()
+{
+    unsigned char md_value[EVP_MAX_MD_SIZE];
+    unsigned int md_len = 0;
+    if (EVP_DigestFinal_ex(mdctx, md_value, &md_len) != 1)
+    {
+        throw std::runtime_error("OpenSSL failed to finish evp digest");
+    }
+    auto arr = std::make_shared<FakeJni::JByteArray>(md_len);
+    memcpy(arr->getArray(), md_value, md_len);
+    return arr;
 }

--- a/src/jni/shahasher.h
+++ b/src/jni/shahasher.h
@@ -2,17 +2,18 @@
 #include <fake-jni/fake-jni.h>
 #include <openssl/evp.h>
 
-class ShaHasher : public FakeJni::JObject {
-  EVP_MD_CTX *mdctx = NULL;
+class ShaHasher : public FakeJni::JObject
+{
+    EVP_MD_CTX *mdctx = NULL;
 
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xal/crypto/ShaHasher")
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xal/crypto/ShaHasher")
 
-  ShaHasher();
+    ShaHasher();
 
-  ~ShaHasher();
+    ~ShaHasher();
 
-  void AddBytes(std::shared_ptr<FakeJni::JByteArray> barray);
+    void AddBytes(std::shared_ptr<FakeJni::JByteArray> barray);
 
-  std::shared_ptr<FakeJni::JByteArray> SignHash();
+    std::shared_ptr<FakeJni::JByteArray> SignHash();
 };

--- a/src/jni/shahasher.h
+++ b/src/jni/shahasher.h
@@ -3,16 +3,16 @@
 #include <openssl/evp.h>
 
 class ShaHasher : public FakeJni::JObject {
-    EVP_MD_CTX *mdctx = NULL;
+  EVP_MD_CTX *mdctx = NULL;
 
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xal/crypto/ShaHasher")
-    
-    ShaHasher();
-    
-    ~ShaHasher();
+  DEFINE_CLASS_NAME("com/microsoft/xal/crypto/ShaHasher")
 
-    void AddBytes(std::shared_ptr<FakeJni::JByteArray> barray);
+  ShaHasher();
 
-    std::shared_ptr<FakeJni::JByteArray> SignHash();
+  ~ShaHasher();
+
+  void AddBytes(std::shared_ptr<FakeJni::JByteArray> barray);
+
+  std::shared_ptr<FakeJni::JByteArray> SignHash();
 };

--- a/src/jni/shahasher.h
+++ b/src/jni/shahasher.h
@@ -2,8 +2,7 @@
 #include <fake-jni/fake-jni.h>
 #include <openssl/evp.h>
 
-class ShaHasher : public FakeJni::JObject
-{
+class ShaHasher : public FakeJni::JObject {
     EVP_MD_CTX *mdctx = NULL;
 
    public:

--- a/src/jni/signature.cpp
+++ b/src/jni/signature.cpp
@@ -2,11 +2,9 @@
 
 void Signature::initVerify(std::shared_ptr<PublicKey> key) {}
 
-FakeJni::JBoolean Signature::verify(std::shared_ptr<FakeJni::JByteArray> a) {
-  return true;
-}
+FakeJni::JBoolean Signature::verify(std::shared_ptr<FakeJni::JByteArray> a) { return true; }
 
-std::shared_ptr<Signature>
-Signature::getInstance(std::shared_ptr<FakeJni::JString>) {
-  return std::make_shared<Signature>();
+std::shared_ptr<Signature> Signature::getInstance(std::shared_ptr<FakeJni::JString>)
+{
+    return std::make_shared<Signature>();
 }

--- a/src/jni/signature.cpp
+++ b/src/jni/signature.cpp
@@ -4,7 +4,6 @@ void Signature::initVerify(std::shared_ptr<PublicKey> key) {}
 
 FakeJni::JBoolean Signature::verify(std::shared_ptr<FakeJni::JByteArray> a) { return true; }
 
-std::shared_ptr<Signature> Signature::getInstance(std::shared_ptr<FakeJni::JString>)
-{
+std::shared_ptr<Signature> Signature::getInstance(std::shared_ptr<FakeJni::JString>) {
     return std::make_shared<Signature>();
 }

--- a/src/jni/signature.cpp
+++ b/src/jni/signature.cpp
@@ -1,13 +1,12 @@
 #include "signature.h"
 
-void Signature::initVerify(std::shared_ptr<PublicKey> key) {
-
-}
+void Signature::initVerify(std::shared_ptr<PublicKey> key) {}
 
 FakeJni::JBoolean Signature::verify(std::shared_ptr<FakeJni::JByteArray> a) {
-    return true;
+  return true;
 }
 
-std::shared_ptr<Signature> Signature::getInstance(std::shared_ptr<FakeJni::JString>) {
-    return std::make_shared<Signature>();
+std::shared_ptr<Signature>
+Signature::getInstance(std::shared_ptr<FakeJni::JString>) {
+  return std::make_shared<Signature>();
 }

--- a/src/jni/signature.h
+++ b/src/jni/signature.h
@@ -1,14 +1,12 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class PublicKey : public FakeJni::JObject
-{
+class PublicKey : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/security/PublicKey")
 };
 
-class Signature : public FakeJni::JObject
-{
+class Signature : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/security/Signature")
 

--- a/src/jni/signature.h
+++ b/src/jni/signature.h
@@ -1,20 +1,19 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class PublicKey : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("java/security/PublicKey")
+class PublicKey : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/security/PublicKey")
 };
 
-class Signature : public FakeJni::JObject {
+class Signature : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/security/Signature")
 
-public:
-  DEFINE_CLASS_NAME("java/security/Signature")
+    void initVerify(std::shared_ptr<PublicKey>);
+    FakeJni::JBoolean verify(std::shared_ptr<FakeJni::JByteArray>);
 
-  void initVerify(std::shared_ptr<PublicKey>);
-  FakeJni::JBoolean verify(std::shared_ptr<FakeJni::JByteArray>);
-
-  static std::shared_ptr<Signature>
-      getInstance(std::shared_ptr<FakeJni::JString>);
+    static std::shared_ptr<Signature> getInstance(std::shared_ptr<FakeJni::JString>);
 };

--- a/src/jni/signature.h
+++ b/src/jni/signature.h
@@ -4,16 +4,17 @@
 class PublicKey : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/security/PublicKey")
+  DEFINE_CLASS_NAME("java/security/PublicKey")
 };
 
 class Signature : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("java/security/Signature")
+  DEFINE_CLASS_NAME("java/security/Signature")
 
-    void initVerify(std::shared_ptr<PublicKey>);
-    FakeJni::JBoolean verify(std::shared_ptr<FakeJni::JByteArray>);
+  void initVerify(std::shared_ptr<PublicKey>);
+  FakeJni::JBoolean verify(std::shared_ptr<FakeJni::JByteArray>);
 
-    static std::shared_ptr<Signature> getInstance(std::shared_ptr<FakeJni::JString>);
+  static std::shared_ptr<Signature>
+      getInstance(std::shared_ptr<FakeJni::JString>);
 };

--- a/src/jni/store.cpp
+++ b/src/jni/store.cpp
@@ -1,47 +1,40 @@
 #include "store.h"
 
-NativeStoreListener::NativeStoreListener(FakeJni::JLong nativePtr)
-    : nativePtr(nativePtr) {}
+NativeStoreListener::NativeStoreListener(FakeJni::JLong nativePtr) : nativePtr(nativePtr) {}
 
-void NativeStoreListener::onStoreInitialized(bool available) {
-  auto method = getClass().getMethod("(JZ)V", "onStoreInitialized");
-  FakeJni::LocalFrame frame;
-  method->invoke(frame.getJniEnv(), this, nativePtr, true);
+void NativeStoreListener::onStoreInitialized(bool available)
+{
+    auto method = getClass().getMethod("(JZ)V", "onStoreInitialized");
+    FakeJni::LocalFrame frame;
+    method->invoke(frame.getJniEnv(), this, nativePtr, true);
 }
 
-void NativeStoreListener::onPurchaseFailed(
-    std::shared_ptr<FakeJni::JString> message) {
-  auto method =
-      getClass().getMethod("(JLjava/lang/String;)V", "onPurchaseFailed");
-  FakeJni::LocalFrame frame;
-  method->invoke(frame.getJniEnv(), this, nativePtr,
-                 frame.getJniEnv().createLocalReference(message));
+void NativeStoreListener::onPurchaseFailed(std::shared_ptr<FakeJni::JString> message)
+{
+    auto method = getClass().getMethod("(JLjava/lang/String;)V", "onPurchaseFailed");
+    FakeJni::LocalFrame frame;
+    method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(message));
 }
 
-void NativeStoreListener::onQueryProductsSuccess(
-    std::shared_ptr<FakeJni::JArray<Product>> products) {
-  auto method = getClass().getMethod(
-      "(J[Lcom/mojang/minecraftpe/store/Product;)V", "onQueryProductsSuccess");
-  FakeJni::LocalFrame frame;
-  method->invoke(frame.getJniEnv(), this, nativePtr,
-                 frame.getJniEnv().createLocalReference(products));
+void NativeStoreListener::onQueryProductsSuccess(std::shared_ptr<FakeJni::JArray<Product>> products)
+{
+    auto method = getClass().getMethod("(J[Lcom/mojang/minecraftpe/store/Product;)V", "onQueryProductsSuccess");
+    FakeJni::LocalFrame frame;
+    method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(products));
 }
 
-void NativeStoreListener::onQueryPurchasesSuccess(
-    std::shared_ptr<FakeJni::JArray<Purchase>> purchases) {
-  auto method =
-      getClass().getMethod("(J[Lcom/mojang/minecraftpe/store/Purchase;)V",
-                           "onQueryPurchasesSuccess");
-  FakeJni::LocalFrame frame;
-  method->invoke(frame.getJniEnv(), this, nativePtr,
-                 frame.getJniEnv().createLocalReference(purchases));
+void NativeStoreListener::onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases)
+{
+    auto method = getClass().getMethod("(J[Lcom/mojang/minecraftpe/store/Purchase;)V", "onQueryPurchasesSuccess");
+    FakeJni::LocalFrame frame;
+    method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(purchases));
 }
 
-Store::Store(std::shared_ptr<NativeStoreListener> storeListener,
-             bool _hasVerifiedLicense) {
-  this->_hasVerifiedLicense = _hasVerifiedLicense;
-  storeListener->onStoreInitialized(true);
-  this->storeListener = storeListener;
+Store::Store(std::shared_ptr<NativeStoreListener> storeListener, bool _hasVerifiedLicense)
+{
+    this->_hasVerifiedLicense = _hasVerifiedLicense;
+    storeListener->onStoreInitialized(true);
+    this->storeListener = storeListener;
 }
 
 FakeJni::JBoolean Store::receivedLicenseResponse() { return true; }
@@ -54,29 +47,27 @@ std::shared_ptr<FakeJni::JString> Store::getProductSkuPrefix() { return {}; }
 
 std::shared_ptr<FakeJni::JString> Store::getRealmsSkuPrefix() { return {}; }
 
-std::shared_ptr<ExtraLicenseResponseData> Store::getExtraLicenseData() {
-  return std::make_shared<ExtraLicenseResponseData>();
+std::shared_ptr<ExtraLicenseResponseData> Store::getExtraLicenseData()
+{
+    return std::make_shared<ExtraLicenseResponseData>();
 }
 
-void Store::queryProducts(
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> arg0) {
-  this->storeListener->onQueryProductsSuccess(
-      std::make_shared<FakeJni::JArray<Product>>(arg0->getSize()));
+void Store::queryProducts(std::shared_ptr<FakeJni::JArray<FakeJni::JString>> arg0)
+{
+    this->storeListener->onQueryProductsSuccess(std::make_shared<FakeJni::JArray<Product>>(arg0->getSize()));
 }
 
-void Store::purchase(std::shared_ptr<FakeJni::JString> arg0,
-                     FakeJni::JBoolean arg1,
-                     std::shared_ptr<FakeJni::JString> arg2) {
-  this->storeListener->onPurchaseFailed(
-      std::make_shared<FakeJni::JString>("Hi"));
+void Store::purchase(std::shared_ptr<FakeJni::JString> arg0, FakeJni::JBoolean arg1,
+                     std::shared_ptr<FakeJni::JString> arg2)
+{
+    this->storeListener->onPurchaseFailed(std::make_shared<FakeJni::JString>("Hi"));
 }
 
-void Store::acknowledgePurchase(std::shared_ptr<FakeJni::JString> arg0,
-                                std::shared_ptr<FakeJni::JString> arg1) {}
+void Store::acknowledgePurchase(std::shared_ptr<FakeJni::JString> arg0, std::shared_ptr<FakeJni::JString> arg1) {}
 
-void Store::queryPurchases() {
-  this->storeListener->onQueryPurchasesSuccess(
-      std::make_shared<FakeJni::JArray<Purchase>>());
+void Store::queryPurchases()
+{
+    this->storeListener->onQueryPurchasesSuccess(std::make_shared<FakeJni::JArray<Purchase>>());
 }
 
 void Store::destructor() {}
@@ -84,17 +75,15 @@ void Store::destructor() {}
 bool StoreFactory::hasVerifiedGooglePlayStoreLicense = true;
 bool StoreFactory::hasVerifiedAmazonAppStoreLicense = true;
 
-std::shared_ptr<Store> StoreFactory::createGooglePlayStore(
-    std::shared_ptr<FakeJni::JString> googlePlayLicenseKey,
-    std::shared_ptr<StoreListener> storeListener) {
-  return std::make_shared<Store>(
-      std::dynamic_pointer_cast<NativeStoreListener>(storeListener),
-      hasVerifiedGooglePlayStoreLicense);
+std::shared_ptr<Store> StoreFactory::createGooglePlayStore(std::shared_ptr<FakeJni::JString> googlePlayLicenseKey,
+                                                           std::shared_ptr<StoreListener> storeListener)
+{
+    return std::make_shared<Store>(std::dynamic_pointer_cast<NativeStoreListener>(storeListener),
+                                   hasVerifiedGooglePlayStoreLicense);
 }
 
-std::shared_ptr<Store> StoreFactory::createAmazonAppStore(
-    std::shared_ptr<StoreListener> storeListener) {
-  return std::make_shared<Store>(
-      std::dynamic_pointer_cast<NativeStoreListener>(storeListener),
-      hasVerifiedAmazonAppStoreLicense);
+std::shared_ptr<Store> StoreFactory::createAmazonAppStore(std::shared_ptr<StoreListener> storeListener)
+{
+    return std::make_shared<Store>(std::dynamic_pointer_cast<NativeStoreListener>(storeListener),
+                                   hasVerifiedAmazonAppStoreLicense);
 }

--- a/src/jni/store.cpp
+++ b/src/jni/store.cpp
@@ -1,89 +1,100 @@
 #include "store.h"
 
-NativeStoreListener::NativeStoreListener(FakeJni::JLong nativePtr) : nativePtr(nativePtr) {
-}
+NativeStoreListener::NativeStoreListener(FakeJni::JLong nativePtr)
+    : nativePtr(nativePtr) {}
 
 void NativeStoreListener::onStoreInitialized(bool available) {
-    auto method = getClass().getMethod("(JZ)V", "onStoreInitialized");
-    FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), this, nativePtr, true);
+  auto method = getClass().getMethod("(JZ)V", "onStoreInitialized");
+  FakeJni::LocalFrame frame;
+  method->invoke(frame.getJniEnv(), this, nativePtr, true);
 }
 
-void NativeStoreListener::onPurchaseFailed(std::shared_ptr<FakeJni::JString> message) {
-    auto method = getClass().getMethod("(JLjava/lang/String;)V", "onPurchaseFailed");
-    FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(message));
+void NativeStoreListener::onPurchaseFailed(
+    std::shared_ptr<FakeJni::JString> message) {
+  auto method =
+      getClass().getMethod("(JLjava/lang/String;)V", "onPurchaseFailed");
+  FakeJni::LocalFrame frame;
+  method->invoke(frame.getJniEnv(), this, nativePtr,
+                 frame.getJniEnv().createLocalReference(message));
 }
 
-void NativeStoreListener::onQueryProductsSuccess(std::shared_ptr<FakeJni::JArray<Product>> products) {
-    auto method = getClass().getMethod("(J[Lcom/mojang/minecraftpe/store/Product;)V", "onQueryProductsSuccess");
-    FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(products));
+void NativeStoreListener::onQueryProductsSuccess(
+    std::shared_ptr<FakeJni::JArray<Product>> products) {
+  auto method = getClass().getMethod(
+      "(J[Lcom/mojang/minecraftpe/store/Product;)V", "onQueryProductsSuccess");
+  FakeJni::LocalFrame frame;
+  method->invoke(frame.getJniEnv(), this, nativePtr,
+                 frame.getJniEnv().createLocalReference(products));
 }
 
-void NativeStoreListener::onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases) {
-    auto method = getClass().getMethod("(J[Lcom/mojang/minecraftpe/store/Purchase;)V", "onQueryPurchasesSuccess");
-    FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(purchases));
+void NativeStoreListener::onQueryPurchasesSuccess(
+    std::shared_ptr<FakeJni::JArray<Purchase>> purchases) {
+  auto method =
+      getClass().getMethod("(J[Lcom/mojang/minecraftpe/store/Purchase;)V",
+                           "onQueryPurchasesSuccess");
+  FakeJni::LocalFrame frame;
+  method->invoke(frame.getJniEnv(), this, nativePtr,
+                 frame.getJniEnv().createLocalReference(purchases));
 }
 
-Store::Store(std::shared_ptr<NativeStoreListener> storeListener, bool _hasVerifiedLicense) {
-    this->_hasVerifiedLicense = _hasVerifiedLicense;
-    storeListener->onStoreInitialized(true);
-    this->storeListener = storeListener;
+Store::Store(std::shared_ptr<NativeStoreListener> storeListener,
+             bool _hasVerifiedLicense) {
+  this->_hasVerifiedLicense = _hasVerifiedLicense;
+  storeListener->onStoreInitialized(true);
+  this->storeListener = storeListener;
 }
 
-FakeJni::JBoolean Store::receivedLicenseResponse() {
-    return true;
-}
+FakeJni::JBoolean Store::receivedLicenseResponse() { return true; }
 
-FakeJni::JBoolean Store::hasVerifiedLicense() {
-    return _hasVerifiedLicense;
-}
+FakeJni::JBoolean Store::hasVerifiedLicense() { return _hasVerifiedLicense; }
 
-std::shared_ptr<FakeJni::JString> Store::getStoreId() {
-    return {};
-}
+std::shared_ptr<FakeJni::JString> Store::getStoreId() { return {}; }
 
-std::shared_ptr<FakeJni::JString> Store::getProductSkuPrefix() {
-    return {};
-}
+std::shared_ptr<FakeJni::JString> Store::getProductSkuPrefix() { return {}; }
 
-std::shared_ptr<FakeJni::JString> Store::getRealmsSkuPrefix() {
-    return {};
-}
+std::shared_ptr<FakeJni::JString> Store::getRealmsSkuPrefix() { return {}; }
 
 std::shared_ptr<ExtraLicenseResponseData> Store::getExtraLicenseData() {
-    return std::make_shared<ExtraLicenseResponseData>();
+  return std::make_shared<ExtraLicenseResponseData>();
 }
 
-void Store::queryProducts(std::shared_ptr<FakeJni::JArray<FakeJni::JString>> arg0) {
-    this->storeListener->onQueryProductsSuccess(std::make_shared<FakeJni::JArray<Product>>(arg0->getSize()));
+void Store::queryProducts(
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> arg0) {
+  this->storeListener->onQueryProductsSuccess(
+      std::make_shared<FakeJni::JArray<Product>>(arg0->getSize()));
 }
 
-void Store::purchase(std::shared_ptr<FakeJni::JString> arg0, FakeJni::JBoolean arg1, std::shared_ptr<FakeJni::JString> arg2) {
-    this->storeListener->onPurchaseFailed(std::make_shared<FakeJni::JString>("Hi"));
+void Store::purchase(std::shared_ptr<FakeJni::JString> arg0,
+                     FakeJni::JBoolean arg1,
+                     std::shared_ptr<FakeJni::JString> arg2) {
+  this->storeListener->onPurchaseFailed(
+      std::make_shared<FakeJni::JString>("Hi"));
 }
 
-void Store::acknowledgePurchase(std::shared_ptr<FakeJni::JString> arg0, std::shared_ptr<FakeJni::JString> arg1) {
-    
-}
+void Store::acknowledgePurchase(std::shared_ptr<FakeJni::JString> arg0,
+                                std::shared_ptr<FakeJni::JString> arg1) {}
 
 void Store::queryPurchases() {
-    this->storeListener->onQueryPurchasesSuccess(std::make_shared<FakeJni::JArray<Purchase>>());
+  this->storeListener->onQueryPurchasesSuccess(
+      std::make_shared<FakeJni::JArray<Purchase>>());
 }
 
-void Store::destructor() {
-    
-}
+void Store::destructor() {}
 
 bool StoreFactory::hasVerifiedGooglePlayStoreLicense = true;
 bool StoreFactory::hasVerifiedAmazonAppStoreLicense = true;
 
-std::shared_ptr<Store> StoreFactory::createGooglePlayStore(std::shared_ptr<FakeJni::JString> googlePlayLicenseKey, std::shared_ptr<StoreListener> storeListener) {
-    return std::make_shared<Store>(std::dynamic_pointer_cast<NativeStoreListener>(storeListener), hasVerifiedGooglePlayStoreLicense);
+std::shared_ptr<Store> StoreFactory::createGooglePlayStore(
+    std::shared_ptr<FakeJni::JString> googlePlayLicenseKey,
+    std::shared_ptr<StoreListener> storeListener) {
+  return std::make_shared<Store>(
+      std::dynamic_pointer_cast<NativeStoreListener>(storeListener),
+      hasVerifiedGooglePlayStoreLicense);
 }
 
-std::shared_ptr<Store> StoreFactory::createAmazonAppStore(std::shared_ptr<StoreListener> storeListener) {
-    return std::make_shared<Store>(std::dynamic_pointer_cast<NativeStoreListener>(storeListener), hasVerifiedAmazonAppStoreLicense);
+std::shared_ptr<Store> StoreFactory::createAmazonAppStore(
+    std::shared_ptr<StoreListener> storeListener) {
+  return std::make_shared<Store>(
+      std::dynamic_pointer_cast<NativeStoreListener>(storeListener),
+      hasVerifiedAmazonAppStoreLicense);
 }

--- a/src/jni/store.cpp
+++ b/src/jni/store.cpp
@@ -2,36 +2,31 @@
 
 NativeStoreListener::NativeStoreListener(FakeJni::JLong nativePtr) : nativePtr(nativePtr) {}
 
-void NativeStoreListener::onStoreInitialized(bool available)
-{
+void NativeStoreListener::onStoreInitialized(bool available) {
     auto method = getClass().getMethod("(JZ)V", "onStoreInitialized");
     FakeJni::LocalFrame frame;
     method->invoke(frame.getJniEnv(), this, nativePtr, true);
 }
 
-void NativeStoreListener::onPurchaseFailed(std::shared_ptr<FakeJni::JString> message)
-{
+void NativeStoreListener::onPurchaseFailed(std::shared_ptr<FakeJni::JString> message) {
     auto method = getClass().getMethod("(JLjava/lang/String;)V", "onPurchaseFailed");
     FakeJni::LocalFrame frame;
     method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(message));
 }
 
-void NativeStoreListener::onQueryProductsSuccess(std::shared_ptr<FakeJni::JArray<Product>> products)
-{
+void NativeStoreListener::onQueryProductsSuccess(std::shared_ptr<FakeJni::JArray<Product>> products) {
     auto method = getClass().getMethod("(J[Lcom/mojang/minecraftpe/store/Product;)V", "onQueryProductsSuccess");
     FakeJni::LocalFrame frame;
     method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(products));
 }
 
-void NativeStoreListener::onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases)
-{
+void NativeStoreListener::onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases) {
     auto method = getClass().getMethod("(J[Lcom/mojang/minecraftpe/store/Purchase;)V", "onQueryPurchasesSuccess");
     FakeJni::LocalFrame frame;
     method->invoke(frame.getJniEnv(), this, nativePtr, frame.getJniEnv().createLocalReference(purchases));
 }
 
-Store::Store(std::shared_ptr<NativeStoreListener> storeListener, bool _hasVerifiedLicense)
-{
+Store::Store(std::shared_ptr<NativeStoreListener> storeListener, bool _hasVerifiedLicense) {
     this->_hasVerifiedLicense = _hasVerifiedLicense;
     storeListener->onStoreInitialized(true);
     this->storeListener = storeListener;
@@ -47,26 +42,22 @@ std::shared_ptr<FakeJni::JString> Store::getProductSkuPrefix() { return {}; }
 
 std::shared_ptr<FakeJni::JString> Store::getRealmsSkuPrefix() { return {}; }
 
-std::shared_ptr<ExtraLicenseResponseData> Store::getExtraLicenseData()
-{
+std::shared_ptr<ExtraLicenseResponseData> Store::getExtraLicenseData() {
     return std::make_shared<ExtraLicenseResponseData>();
 }
 
-void Store::queryProducts(std::shared_ptr<FakeJni::JArray<FakeJni::JString>> arg0)
-{
+void Store::queryProducts(std::shared_ptr<FakeJni::JArray<FakeJni::JString>> arg0) {
     this->storeListener->onQueryProductsSuccess(std::make_shared<FakeJni::JArray<Product>>(arg0->getSize()));
 }
 
 void Store::purchase(std::shared_ptr<FakeJni::JString> arg0, FakeJni::JBoolean arg1,
-                     std::shared_ptr<FakeJni::JString> arg2)
-{
+                     std::shared_ptr<FakeJni::JString> arg2) {
     this->storeListener->onPurchaseFailed(std::make_shared<FakeJni::JString>("Hi"));
 }
 
 void Store::acknowledgePurchase(std::shared_ptr<FakeJni::JString> arg0, std::shared_ptr<FakeJni::JString> arg1) {}
 
-void Store::queryPurchases()
-{
+void Store::queryPurchases() {
     this->storeListener->onQueryPurchasesSuccess(std::make_shared<FakeJni::JArray<Purchase>>());
 }
 
@@ -76,14 +67,12 @@ bool StoreFactory::hasVerifiedGooglePlayStoreLicense = true;
 bool StoreFactory::hasVerifiedAmazonAppStoreLicense = true;
 
 std::shared_ptr<Store> StoreFactory::createGooglePlayStore(std::shared_ptr<FakeJni::JString> googlePlayLicenseKey,
-                                                           std::shared_ptr<StoreListener> storeListener)
-{
+                                                           std::shared_ptr<StoreListener> storeListener) {
     return std::make_shared<Store>(std::dynamic_pointer_cast<NativeStoreListener>(storeListener),
                                    hasVerifiedGooglePlayStoreLicense);
 }
 
-std::shared_ptr<Store> StoreFactory::createAmazonAppStore(std::shared_ptr<StoreListener> storeListener)
-{
+std::shared_ptr<Store> StoreFactory::createAmazonAppStore(std::shared_ptr<StoreListener> storeListener) {
     return std::make_shared<Store>(std::dynamic_pointer_cast<NativeStoreListener>(storeListener),
                                    hasVerifiedAmazonAppStoreLicense);
 }

--- a/src/jni/store.h
+++ b/src/jni/store.h
@@ -2,19 +2,16 @@
 
 #include <fake-jni/fake-jni.h>
 
-class StoreListener : public FakeJni::JObject
-{
+class StoreListener : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreListener")
 };
 
-class Product : public FakeJni::JObject
-{
+class Product : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Product")
 
-    Product()
-    {
+    Product() {
         mId = std::make_shared<FakeJni::JString>("");
         mPrice = std::make_shared<FakeJni::JString>("");
         mCurrencyCode = std::make_shared<FakeJni::JString>("");
@@ -27,13 +24,11 @@ class Product : public FakeJni::JObject
     std::shared_ptr<FakeJni::JString> mUnformattedPrice;
 };
 
-class Purchase : public FakeJni::JObject
-{
+class Purchase : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Purchase")
 
-    Purchase()
-    {
+    Purchase() {
         mProductId = std::make_shared<FakeJni::JString>("");
         mReceipt = std::make_shared<FakeJni::JString>("");
         mPurchaseActive = true;
@@ -44,8 +39,7 @@ class Purchase : public FakeJni::JObject
     FakeJni::JBoolean mPurchaseActive;
 };
 
-class ExtraLicenseResponseData : public FakeJni::JObject
-{
+class ExtraLicenseResponseData : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/ExtraLicenseResponseData")
 
@@ -54,8 +48,7 @@ class ExtraLicenseResponseData : public FakeJni::JObject
     FakeJni::JLong getRetryAttempts() { return 0; }
 };
 
-class NativeStoreListener : public StoreListener
-{
+class NativeStoreListener : public StoreListener {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/NativeStoreListener", StoreListener)
 
@@ -72,8 +65,7 @@ class NativeStoreListener : public StoreListener
     void onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases);
 };
 
-class Store : public FakeJni::JObject
-{
+class Store : public FakeJni::JObject {
     bool _hasVerifiedLicense = false;
     std::shared_ptr<NativeStoreListener> storeListener;
 
@@ -97,18 +89,15 @@ class Store : public FakeJni::JObject
     void destructor();
 };
 
-class NotificationListenerService : public FakeJni::JObject
-{
+class NotificationListenerService : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/NotificationListenerService")
-    static std::shared_ptr<FakeJni::JString> getDeviceRegistrationToken()
-    {
+    static std::shared_ptr<FakeJni::JString> getDeviceRegistrationToken() {
         return std::make_shared<FakeJni::JString>("ebe97d6c-5b83-11ec-9193-9fbef390d94b");
     }
 };
 
-class StoreFactory : public FakeJni::JObject
-{
+class StoreFactory : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreFactory")
 

--- a/src/jni/store.h
+++ b/src/jni/store.h
@@ -2,120 +2,119 @@
 
 #include <fake-jni/fake-jni.h>
 
-class StoreListener : public FakeJni::JObject {
-
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreListener")
+class StoreListener : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreListener")
 };
 
-class Product : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Product")
+class Product : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Product")
 
-  Product() {
-    mId = std::make_shared<FakeJni::JString>("");
-    mPrice = std::make_shared<FakeJni::JString>("");
-    mCurrencyCode = std::make_shared<FakeJni::JString>("");
-    mUnformattedPrice = std::make_shared<FakeJni::JString>("");
-  }
+    Product()
+    {
+        mId = std::make_shared<FakeJni::JString>("");
+        mPrice = std::make_shared<FakeJni::JString>("");
+        mCurrencyCode = std::make_shared<FakeJni::JString>("");
+        mUnformattedPrice = std::make_shared<FakeJni::JString>("");
+    }
 
-  std::shared_ptr<FakeJni::JString> mId;
-  std::shared_ptr<FakeJni::JString> mPrice;
-  std::shared_ptr<FakeJni::JString> mCurrencyCode;
-  std::shared_ptr<FakeJni::JString> mUnformattedPrice;
+    std::shared_ptr<FakeJni::JString> mId;
+    std::shared_ptr<FakeJni::JString> mPrice;
+    std::shared_ptr<FakeJni::JString> mCurrencyCode;
+    std::shared_ptr<FakeJni::JString> mUnformattedPrice;
 };
 
-class Purchase : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Purchase")
+class Purchase : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Purchase")
 
-  Purchase() {
-    mProductId = std::make_shared<FakeJni::JString>("");
-    mReceipt = std::make_shared<FakeJni::JString>("");
-    mPurchaseActive = true;
-  }
+    Purchase()
+    {
+        mProductId = std::make_shared<FakeJni::JString>("");
+        mReceipt = std::make_shared<FakeJni::JString>("");
+        mPurchaseActive = true;
+    }
 
-  std::shared_ptr<FakeJni::JString> mProductId;
-  std::shared_ptr<FakeJni::JString> mReceipt;
-  FakeJni::JBoolean mPurchaseActive;
+    std::shared_ptr<FakeJni::JString> mProductId;
+    std::shared_ptr<FakeJni::JString> mReceipt;
+    FakeJni::JBoolean mPurchaseActive;
 };
 
-class ExtraLicenseResponseData : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/ExtraLicenseResponseData")
+class ExtraLicenseResponseData : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/ExtraLicenseResponseData")
 
-  FakeJni::JLong getValidationTime() { return 60000; }
-  FakeJni::JLong getRetryUntilTime() { return 0; }
-  FakeJni::JLong getRetryAttempts() { return 0; }
+    FakeJni::JLong getValidationTime() { return 60000; }
+    FakeJni::JLong getRetryUntilTime() { return 0; }
+    FakeJni::JLong getRetryAttempts() { return 0; }
 };
 
-class NativeStoreListener : public StoreListener {
+class NativeStoreListener : public StoreListener
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/NativeStoreListener", StoreListener)
 
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/NativeStoreListener",
-                    StoreListener)
+    FakeJni::JLong nativePtr;
 
-  FakeJni::JLong nativePtr;
+    NativeStoreListener(FakeJni::JLong nativePtr);
 
-  NativeStoreListener(FakeJni::JLong nativePtr);
+    void onStoreInitialized(bool available);
 
-  void onStoreInitialized(bool available);
+    void onPurchaseFailed(std::shared_ptr<FakeJni::JString> message);
 
-  void onPurchaseFailed(std::shared_ptr<FakeJni::JString> message);
+    void onQueryProductsSuccess(std::shared_ptr<FakeJni::JArray<Product>> products);
 
-  void
-  onQueryProductsSuccess(std::shared_ptr<FakeJni::JArray<Product>> products);
-
-  void
-  onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases);
+    void onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases);
 };
 
-class Store : public FakeJni::JObject {
-  bool _hasVerifiedLicense = false;
-  std::shared_ptr<NativeStoreListener> storeListener;
+class Store : public FakeJni::JObject
+{
+    bool _hasVerifiedLicense = false;
+    std::shared_ptr<NativeStoreListener> storeListener;
 
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Store")
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Store")
 
-  explicit Store(std::shared_ptr<NativeStoreListener> storeListener,
-                 bool _hasVerifiedLicense);
+    explicit Store(std::shared_ptr<NativeStoreListener> storeListener, bool _hasVerifiedLicense);
 
-  FakeJni::JBoolean receivedLicenseResponse();
+    FakeJni::JBoolean receivedLicenseResponse();
 
-  FakeJni::JBoolean hasVerifiedLicense();
+    FakeJni::JBoolean hasVerifiedLicense();
 
-  std::shared_ptr<FakeJni::JString> getStoreId();
-  std::shared_ptr<FakeJni::JString> getProductSkuPrefix();
-  std::shared_ptr<FakeJni::JString> getRealmsSkuPrefix();
-  std::shared_ptr<ExtraLicenseResponseData> getExtraLicenseData();
-  void queryProducts(std::shared_ptr<FakeJni::JArray<FakeJni::JString>>);
-  void purchase(std::shared_ptr<FakeJni::JString>, FakeJni::JBoolean,
-                std::shared_ptr<FakeJni::JString>);
-  void acknowledgePurchase(std::shared_ptr<FakeJni::JString>,
-                           std::shared_ptr<FakeJni::JString>);
-  void queryPurchases();
-  void destructor();
+    std::shared_ptr<FakeJni::JString> getStoreId();
+    std::shared_ptr<FakeJni::JString> getProductSkuPrefix();
+    std::shared_ptr<FakeJni::JString> getRealmsSkuPrefix();
+    std::shared_ptr<ExtraLicenseResponseData> getExtraLicenseData();
+    void queryProducts(std::shared_ptr<FakeJni::JArray<FakeJni::JString>>);
+    void purchase(std::shared_ptr<FakeJni::JString>, FakeJni::JBoolean, std::shared_ptr<FakeJni::JString>);
+    void acknowledgePurchase(std::shared_ptr<FakeJni::JString>, std::shared_ptr<FakeJni::JString>);
+    void queryPurchases();
+    void destructor();
 };
 
-class NotificationListenerService : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/NotificationListenerService")
-  static std::shared_ptr<FakeJni::JString> getDeviceRegistrationToken() {
-    return std::make_shared<FakeJni::JString>(
-        "ebe97d6c-5b83-11ec-9193-9fbef390d94b");
-  }
+class NotificationListenerService : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/NotificationListenerService")
+    static std::shared_ptr<FakeJni::JString> getDeviceRegistrationToken()
+    {
+        return std::make_shared<FakeJni::JString>("ebe97d6c-5b83-11ec-9193-9fbef390d94b");
+    }
 };
 
-class StoreFactory : public FakeJni::JObject {
+class StoreFactory : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreFactory")
 
-public:
-  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreFactory")
-
-  static bool hasVerifiedGooglePlayStoreLicense;
-  static bool hasVerifiedAmazonAppStoreLicense;
-  static std::shared_ptr<Store>
-  createGooglePlayStore(std::shared_ptr<FakeJni::JString> googlePlayLicenseKey,
-                        std::shared_ptr<StoreListener> storeListener);
-  static std::shared_ptr<Store>
-  createAmazonAppStore(std::shared_ptr<StoreListener> storeListener);
+    static bool hasVerifiedGooglePlayStoreLicense;
+    static bool hasVerifiedAmazonAppStoreLicense;
+    static std::shared_ptr<Store> createGooglePlayStore(std::shared_ptr<FakeJni::JString> googlePlayLicenseKey,
+                                                        std::shared_ptr<StoreListener> storeListener);
+    static std::shared_ptr<Store> createAmazonAppStore(std::shared_ptr<StoreListener> storeListener);
 };

--- a/src/jni/store.h
+++ b/src/jni/store.h
@@ -5,113 +5,117 @@
 class StoreListener : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreListener")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreListener")
 };
 
 class Product : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Product")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Product")
 
-    Product() {
-        mId = std::make_shared<FakeJni::JString>("");
-        mPrice = std::make_shared<FakeJni::JString>("");
-        mCurrencyCode = std::make_shared<FakeJni::JString>("");
-        mUnformattedPrice = std::make_shared<FakeJni::JString>("");
-    }
+  Product() {
+    mId = std::make_shared<FakeJni::JString>("");
+    mPrice = std::make_shared<FakeJni::JString>("");
+    mCurrencyCode = std::make_shared<FakeJni::JString>("");
+    mUnformattedPrice = std::make_shared<FakeJni::JString>("");
+  }
 
-    std::shared_ptr<FakeJni::JString> mId;
-    std::shared_ptr<FakeJni::JString> mPrice;
-    std::shared_ptr<FakeJni::JString> mCurrencyCode;
-    std::shared_ptr<FakeJni::JString> mUnformattedPrice;
+  std::shared_ptr<FakeJni::JString> mId;
+  std::shared_ptr<FakeJni::JString> mPrice;
+  std::shared_ptr<FakeJni::JString> mCurrencyCode;
+  std::shared_ptr<FakeJni::JString> mUnformattedPrice;
 };
 
 class Purchase : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Purchase")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Purchase")
 
-    Purchase() {
-        mProductId = std::make_shared<FakeJni::JString>("");
-        mReceipt = std::make_shared<FakeJni::JString>("");
-        mPurchaseActive = true;
-    }
+  Purchase() {
+    mProductId = std::make_shared<FakeJni::JString>("");
+    mReceipt = std::make_shared<FakeJni::JString>("");
+    mPurchaseActive = true;
+  }
 
-    std::shared_ptr<FakeJni::JString> mProductId;
-    std::shared_ptr<FakeJni::JString> mReceipt;
-    FakeJni::JBoolean mPurchaseActive;
+  std::shared_ptr<FakeJni::JString> mProductId;
+  std::shared_ptr<FakeJni::JString> mReceipt;
+  FakeJni::JBoolean mPurchaseActive;
 };
 
 class ExtraLicenseResponseData : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/ExtraLicenseResponseData")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/ExtraLicenseResponseData")
 
-    FakeJni::JLong getValidationTime() {
-        return 60000;
-    }
-    FakeJni::JLong getRetryUntilTime() {
-        return 0;
-    }
-    FakeJni::JLong getRetryAttempts() {
-        return 0;
-    }
+  FakeJni::JLong getValidationTime() { return 60000; }
+  FakeJni::JLong getRetryUntilTime() { return 0; }
+  FakeJni::JLong getRetryAttempts() { return 0; }
 };
-
 
 class NativeStoreListener : public StoreListener {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/NativeStoreListener", StoreListener)
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/NativeStoreListener",
+                    StoreListener)
 
-    FakeJni::JLong nativePtr;
+  FakeJni::JLong nativePtr;
 
-    NativeStoreListener(FakeJni::JLong nativePtr);
+  NativeStoreListener(FakeJni::JLong nativePtr);
 
-    void onStoreInitialized(bool available);
+  void onStoreInitialized(bool available);
 
-    void onPurchaseFailed(std::shared_ptr<FakeJni::JString> message);
+  void onPurchaseFailed(std::shared_ptr<FakeJni::JString> message);
 
-    void onQueryProductsSuccess(std::shared_ptr<FakeJni::JArray<Product>> products);
+  void
+  onQueryProductsSuccess(std::shared_ptr<FakeJni::JArray<Product>> products);
 
-    void onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases);
+  void
+  onQueryPurchasesSuccess(std::shared_ptr<FakeJni::JArray<Purchase>> purchases);
 };
 
 class Store : public FakeJni::JObject {
-    bool _hasVerifiedLicense = false;
-    std::shared_ptr<NativeStoreListener> storeListener;
+  bool _hasVerifiedLicense = false;
+  std::shared_ptr<NativeStoreListener> storeListener;
+
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Store")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/Store")
 
-    explicit Store(std::shared_ptr<NativeStoreListener> storeListener, bool _hasVerifiedLicense);
+  explicit Store(std::shared_ptr<NativeStoreListener> storeListener,
+                 bool _hasVerifiedLicense);
 
-    FakeJni::JBoolean receivedLicenseResponse();
+  FakeJni::JBoolean receivedLicenseResponse();
 
-    FakeJni::JBoolean hasVerifiedLicense();
+  FakeJni::JBoolean hasVerifiedLicense();
 
-    std::shared_ptr<FakeJni::JString> getStoreId();
-    std::shared_ptr<FakeJni::JString> getProductSkuPrefix();
-    std::shared_ptr<FakeJni::JString> getRealmsSkuPrefix();
-    std::shared_ptr<ExtraLicenseResponseData> getExtraLicenseData();
-    void queryProducts(std::shared_ptr<FakeJni::JArray<FakeJni::JString>>);
-    void purchase(std::shared_ptr<FakeJni::JString>, FakeJni::JBoolean, std::shared_ptr<FakeJni::JString>);
-    void acknowledgePurchase(std::shared_ptr<FakeJni::JString>, std::shared_ptr<FakeJni::JString>);
-    void queryPurchases();
-    void destructor();
+  std::shared_ptr<FakeJni::JString> getStoreId();
+  std::shared_ptr<FakeJni::JString> getProductSkuPrefix();
+  std::shared_ptr<FakeJni::JString> getRealmsSkuPrefix();
+  std::shared_ptr<ExtraLicenseResponseData> getExtraLicenseData();
+  void queryProducts(std::shared_ptr<FakeJni::JArray<FakeJni::JString>>);
+  void purchase(std::shared_ptr<FakeJni::JString>, FakeJni::JBoolean,
+                std::shared_ptr<FakeJni::JString>);
+  void acknowledgePurchase(std::shared_ptr<FakeJni::JString>,
+                           std::shared_ptr<FakeJni::JString>);
+  void queryPurchases();
+  void destructor();
 };
 
 class NotificationListenerService : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/NotificationListenerService")
-    static std::shared_ptr<FakeJni::JString> getDeviceRegistrationToken() {
-        return std::make_shared<FakeJni::JString>("ebe97d6c-5b83-11ec-9193-9fbef390d94b");
-    }
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/NotificationListenerService")
+  static std::shared_ptr<FakeJni::JString> getDeviceRegistrationToken() {
+    return std::make_shared<FakeJni::JString>(
+        "ebe97d6c-5b83-11ec-9193-9fbef390d94b");
+  }
 };
 
 class StoreFactory : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreFactory")
+  DEFINE_CLASS_NAME("com/mojang/minecraftpe/store/StoreFactory")
 
-    static bool hasVerifiedGooglePlayStoreLicense;
-    static bool hasVerifiedAmazonAppStoreLicense;
-    static std::shared_ptr<Store> createGooglePlayStore(std::shared_ptr<FakeJni::JString> googlePlayLicenseKey, std::shared_ptr<StoreListener> storeListener);
-    static std::shared_ptr<Store> createAmazonAppStore(std::shared_ptr<StoreListener> storeListener);
+  static bool hasVerifiedGooglePlayStoreLicense;
+  static bool hasVerifiedAmazonAppStoreLicense;
+  static std::shared_ptr<Store>
+  createGooglePlayStore(std::shared_ptr<FakeJni::JString> googlePlayLicenseKey,
+                        std::shared_ptr<StoreListener> storeListener);
+  static std::shared_ptr<Store>
+  createAmazonAppStore(std::shared_ptr<StoreListener> storeListener);
 };

--- a/src/jni/uuid.cpp
+++ b/src/jni/uuid.cpp
@@ -4,26 +4,21 @@
 
 UUID::UUID(std::shared_ptr<FakeJni::JString> uuid) : uuid(uuid) {}
 
-std::shared_ptr<UUID> UUID::randomUUID() {
-  static std::independent_bits_engine<std::random_device, CHAR_BIT,
-                                      unsigned char>
-      engine;
-  unsigned char rawBytes[16];
-  std::generate(rawBytes, rawBytes + 16, std::ref(engine));
-  rawBytes[6] = (rawBytes[6] & (unsigned char)0x0Fu) | (unsigned char)0x40u;
-  rawBytes[8] = (rawBytes[6] & (unsigned char)0x3Fu) | (unsigned char)0x80u;
-  std::string ret;
-  ret.resize(37);
-  snprintf(
-      (char *)ret.c_str(), 37,
-      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-      rawBytes[0], rawBytes[1], rawBytes[2], rawBytes[3], rawBytes[4],
-      rawBytes[5], rawBytes[6], rawBytes[7], rawBytes[8], rawBytes[9],
-      rawBytes[10], rawBytes[11], rawBytes[12], rawBytes[13], rawBytes[14],
-      rawBytes[15]);
-  ret.resize(36);
-  return std::shared_ptr<UUID>(
-      new UUID(std::make_shared<FakeJni::JString>(ret)));
+std::shared_ptr<UUID> UUID::randomUUID()
+{
+    static std::independent_bits_engine<std::random_device, CHAR_BIT, unsigned char> engine;
+    unsigned char rawBytes[16];
+    std::generate(rawBytes, rawBytes + 16, std::ref(engine));
+    rawBytes[6] = (rawBytes[6] & (unsigned char)0x0Fu) | (unsigned char)0x40u;
+    rawBytes[8] = (rawBytes[6] & (unsigned char)0x3Fu) | (unsigned char)0x80u;
+    std::string ret;
+    ret.resize(37);
+    snprintf((char *)ret.c_str(), 37, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             rawBytes[0], rawBytes[1], rawBytes[2], rawBytes[3], rawBytes[4], rawBytes[5], rawBytes[6], rawBytes[7],
+             rawBytes[8], rawBytes[9], rawBytes[10], rawBytes[11], rawBytes[12], rawBytes[13], rawBytes[14],
+             rawBytes[15]);
+    ret.resize(36);
+    return std::shared_ptr<UUID>(new UUID(std::make_shared<FakeJni::JString>(ret)));
 }
 
 std::shared_ptr<FakeJni::JString> UUID::toString() { return uuid; }

--- a/src/jni/uuid.cpp
+++ b/src/jni/uuid.cpp
@@ -1,27 +1,29 @@
 #include "uuid.h"
-#include <random>
 #include <climits>
+#include <random>
 
-UUID::UUID(std::shared_ptr<FakeJni::JString> uuid) : uuid(uuid) {
-    
-}
+UUID::UUID(std::shared_ptr<FakeJni::JString> uuid) : uuid(uuid) {}
 
 std::shared_ptr<UUID> UUID::randomUUID() {
-    static std::independent_bits_engine<std::random_device, CHAR_BIT, unsigned char> engine;
-    unsigned char rawBytes[16];
-    std::generate(rawBytes, rawBytes + 16, std::ref(engine));
-    rawBytes[6] = (rawBytes[6] & (unsigned char) 0x0Fu) | (unsigned char) 0x40u;
-    rawBytes[8] = (rawBytes[6] & (unsigned char) 0x3Fu) | (unsigned char) 0x80u;
-    std::string ret;
-    ret.resize(37);
-    snprintf((char*) ret.c_str(), 37, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-             rawBytes[0], rawBytes[1], rawBytes[2], rawBytes[3],
-             rawBytes[4], rawBytes[5], rawBytes[6], rawBytes[7], rawBytes[8], rawBytes[9],
-             rawBytes[10], rawBytes[11], rawBytes[12], rawBytes[13], rawBytes[14], rawBytes[15]);
-    ret.resize(36);
-    return std::shared_ptr<UUID>(new UUID(std::make_shared<FakeJni::JString>(ret)));
+  static std::independent_bits_engine<std::random_device, CHAR_BIT,
+                                      unsigned char>
+      engine;
+  unsigned char rawBytes[16];
+  std::generate(rawBytes, rawBytes + 16, std::ref(engine));
+  rawBytes[6] = (rawBytes[6] & (unsigned char)0x0Fu) | (unsigned char)0x40u;
+  rawBytes[8] = (rawBytes[6] & (unsigned char)0x3Fu) | (unsigned char)0x80u;
+  std::string ret;
+  ret.resize(37);
+  snprintf(
+      (char *)ret.c_str(), 37,
+      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+      rawBytes[0], rawBytes[1], rawBytes[2], rawBytes[3], rawBytes[4],
+      rawBytes[5], rawBytes[6], rawBytes[7], rawBytes[8], rawBytes[9],
+      rawBytes[10], rawBytes[11], rawBytes[12], rawBytes[13], rawBytes[14],
+      rawBytes[15]);
+  ret.resize(36);
+  return std::shared_ptr<UUID>(
+      new UUID(std::make_shared<FakeJni::JString>(ret)));
 }
 
-std::shared_ptr<FakeJni::JString> UUID::toString() {
-    return uuid;
-}
+std::shared_ptr<FakeJni::JString> UUID::toString() { return uuid; }

--- a/src/jni/uuid.cpp
+++ b/src/jni/uuid.cpp
@@ -4,8 +4,7 @@
 
 UUID::UUID(std::shared_ptr<FakeJni::JString> uuid) : uuid(uuid) {}
 
-std::shared_ptr<UUID> UUID::randomUUID()
-{
+std::shared_ptr<UUID> UUID::randomUUID() {
     static std::independent_bits_engine<std::random_device, CHAR_BIT, unsigned char> engine;
     unsigned char rawBytes[16];
     std::generate(rawBytes, rawBytes + 16, std::ref(engine));

--- a/src/jni/uuid.h
+++ b/src/jni/uuid.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class UUID : public FakeJni::JObject
-{
+class UUID : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("java/util/UUID")
 

--- a/src/jni/uuid.h
+++ b/src/jni/uuid.h
@@ -3,14 +3,13 @@
 
 class UUID : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("java/util/UUID")
+  DEFINE_CLASS_NAME("java/util/UUID")
 
-    static std::shared_ptr<UUID> randomUUID();
-    std::shared_ptr<FakeJni::JString> toString();
+  static std::shared_ptr<UUID> randomUUID();
+  std::shared_ptr<FakeJni::JString> toString();
 
 private:
-    UUID(std::shared_ptr<FakeJni::JString> uuid);
+  UUID(std::shared_ptr<FakeJni::JString> uuid);
 
-    std::shared_ptr<FakeJni::JString> uuid;
-
+  std::shared_ptr<FakeJni::JString> uuid;
 };

--- a/src/jni/uuid.h
+++ b/src/jni/uuid.h
@@ -1,15 +1,16 @@
 #pragma once
 #include <fake-jni/fake-jni.h>
 
-class UUID : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("java/util/UUID")
+class UUID : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("java/util/UUID")
 
-  static std::shared_ptr<UUID> randomUUID();
-  std::shared_ptr<FakeJni::JString> toString();
+    static std::shared_ptr<UUID> randomUUID();
+    std::shared_ptr<FakeJni::JString> toString();
 
-private:
-  UUID(std::shared_ptr<FakeJni::JString> uuid);
+   private:
+    UUID(std::shared_ptr<FakeJni::JString> uuid);
 
-  std::shared_ptr<FakeJni::JString> uuid;
+    std::shared_ptr<FakeJni::JString> uuid;
 };

--- a/src/jni/webview.cpp
+++ b/src/jni/webview.cpp
@@ -1,26 +1,65 @@
 #include "webview.h"
 #include "../xal_webview_factory.h"
 
-void WebView::showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl, std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, FakeJni::JBoolean z, FakeJni::JLong j2) {
-    auto webview = XalWebViewFactory::createXalWebView();
-    auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
-    auto method = WebView::getDescriptor()->getMethod("(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
-    FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), WebView::getDescriptor().get(), l, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(finalendurl)), false, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
+void WebView::showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx,
+                      std::shared_ptr<FakeJni::JString> starturl,
+                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+                      FakeJni::JBoolean z, FakeJni::JLong j2) {
+  auto webview = XalWebViewFactory::createXalWebView();
+  auto finalendurl =
+      webview->show(starturl->asStdString(), endurl->asStdString());
+  auto method = WebView::getDescriptor()->getMethod(
+      "(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
+  FakeJni::LocalFrame frame;
+  method->invoke(
+      frame.getJniEnv(), WebView::getDescriptor().get(), l,
+      frame.getJniEnv().createLocalReference(
+          std::make_shared<FakeJni::JString>(finalendurl)),
+      false,
+      frame.getJniEnv().createLocalReference(
+          std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
 }
 
-void BrowserLaunchActivity::showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl, std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, std::shared_ptr<FakeJni::JArray<FakeJni::JString>>_a, std::shared_ptr<FakeJni::JArray<FakeJni::JString>>_b, FakeJni::JBoolean z, FakeJni::JLong j2) {
-    auto webview = XalWebViewFactory::createXalWebView();
-    auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
-    auto method = BrowserLaunchActivity::getDescriptor()->getMethod("(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
-    FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), BrowserLaunchActivity::getDescriptor().get(), l, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(finalendurl)), false, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
+void BrowserLaunchActivity::showUrl(
+    FakeJni::JLong l, std::shared_ptr<Context> ctx,
+    std::shared_ptr<FakeJni::JString> starturl,
+    std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _a,
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b, FakeJni::JBoolean z,
+    FakeJni::JLong j2) {
+  auto webview = XalWebViewFactory::createXalWebView();
+  auto finalendurl =
+      webview->show(starturl->asStdString(), endurl->asStdString());
+  auto method = BrowserLaunchActivity::getDescriptor()->getMethod(
+      "(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
+  FakeJni::LocalFrame frame;
+  method->invoke(
+      frame.getJniEnv(), BrowserLaunchActivity::getDescriptor().get(), l,
+      frame.getJniEnv().createLocalReference(
+          std::make_shared<FakeJni::JString>(finalendurl)),
+      false,
+      frame.getJniEnv().createLocalReference(
+          std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
 }
 
-void BrowserLaunchActivity::showUrl2(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl, std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, std::shared_ptr<FakeJni::JArray<FakeJni::JString>>_a, std::shared_ptr<FakeJni::JArray<FakeJni::JString>>_b, FakeJni::JBoolean z) {
-    auto webview = XalWebViewFactory::createXalWebView();
-    auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
-    auto method = BrowserLaunchActivity::getDescriptor()->getMethod("(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
-    FakeJni::LocalFrame frame;
-    method->invoke(frame.getJniEnv(), BrowserLaunchActivity::getDescriptor().get(), l, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(finalendurl)), false, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
+void BrowserLaunchActivity::showUrl2(
+    FakeJni::JLong l, std::shared_ptr<Context> ctx,
+    std::shared_ptr<FakeJni::JString> starturl,
+    std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _a,
+    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b,
+    FakeJni::JBoolean z) {
+  auto webview = XalWebViewFactory::createXalWebView();
+  auto finalendurl =
+      webview->show(starturl->asStdString(), endurl->asStdString());
+  auto method = BrowserLaunchActivity::getDescriptor()->getMethod(
+      "(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
+  FakeJni::LocalFrame frame;
+  method->invoke(
+      frame.getJniEnv(), BrowserLaunchActivity::getDescriptor().get(), l,
+      frame.getJniEnv().createLocalReference(
+          std::make_shared<FakeJni::JString>(finalendurl)),
+      false,
+      frame.getJniEnv().createLocalReference(
+          std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
 }

--- a/src/jni/webview.cpp
+++ b/src/jni/webview.cpp
@@ -2,8 +2,8 @@
 #include "../xal_webview_factory.h"
 
 void WebView::showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl,
-                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, FakeJni::JBoolean z, FakeJni::JLong j2)
-{
+                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, FakeJni::JBoolean z,
+                      FakeJni::JLong j2) {
     auto webview = XalWebViewFactory::createXalWebView();
     auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
     auto method =
@@ -20,8 +20,7 @@ void BrowserLaunchActivity::showUrl(FakeJni::JLong l, std::shared_ptr<Context> c
                                     std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
                                     std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _a,
                                     std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b, FakeJni::JBoolean z,
-                                    FakeJni::JLong j2)
-{
+                                    FakeJni::JLong j2) {
     auto webview = XalWebViewFactory::createXalWebView();
     auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
     auto method = BrowserLaunchActivity::getDescriptor()->getMethod("(JLjava/lang/String;ZLjava/lang/String;)V",
@@ -37,8 +36,7 @@ void BrowserLaunchActivity::showUrl2(FakeJni::JLong l, std::shared_ptr<Context> 
                                      std::shared_ptr<FakeJni::JString> starturl,
                                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
                                      std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _a,
-                                     std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b, FakeJni::JBoolean z)
-{
+                                     std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b, FakeJni::JBoolean z) {
     auto webview = XalWebViewFactory::createXalWebView();
     auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
     auto method = BrowserLaunchActivity::getDescriptor()->getMethod("(JLjava/lang/String;ZLjava/lang/String;)V",

--- a/src/jni/webview.cpp
+++ b/src/jni/webview.cpp
@@ -1,65 +1,51 @@
 #include "webview.h"
 #include "../xal_webview_factory.h"
 
-void WebView::showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx,
-                      std::shared_ptr<FakeJni::JString> starturl,
-                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
-                      FakeJni::JBoolean z, FakeJni::JLong j2) {
-  auto webview = XalWebViewFactory::createXalWebView();
-  auto finalendurl =
-      webview->show(starturl->asStdString(), endurl->asStdString());
-  auto method = WebView::getDescriptor()->getMethod(
-      "(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
-  FakeJni::LocalFrame frame;
-  method->invoke(
-      frame.getJniEnv(), WebView::getDescriptor().get(), l,
-      frame.getJniEnv().createLocalReference(
-          std::make_shared<FakeJni::JString>(finalendurl)),
-      false,
-      frame.getJniEnv().createLocalReference(
-          std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
+void WebView::showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl,
+                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, FakeJni::JBoolean z, FakeJni::JLong j2)
+{
+    auto webview = XalWebViewFactory::createXalWebView();
+    auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
+    auto method =
+        WebView::getDescriptor()->getMethod("(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
+    FakeJni::LocalFrame frame;
+    method->invoke(
+        frame.getJniEnv(), WebView::getDescriptor().get(), l,
+        frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(finalendurl)), false,
+        frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
 }
 
-void BrowserLaunchActivity::showUrl(
-    FakeJni::JLong l, std::shared_ptr<Context> ctx,
-    std::shared_ptr<FakeJni::JString> starturl,
-    std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _a,
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b, FakeJni::JBoolean z,
-    FakeJni::JLong j2) {
-  auto webview = XalWebViewFactory::createXalWebView();
-  auto finalendurl =
-      webview->show(starturl->asStdString(), endurl->asStdString());
-  auto method = BrowserLaunchActivity::getDescriptor()->getMethod(
-      "(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
-  FakeJni::LocalFrame frame;
-  method->invoke(
-      frame.getJniEnv(), BrowserLaunchActivity::getDescriptor().get(), l,
-      frame.getJniEnv().createLocalReference(
-          std::make_shared<FakeJni::JString>(finalendurl)),
-      false,
-      frame.getJniEnv().createLocalReference(
-          std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
+void BrowserLaunchActivity::showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx,
+                                    std::shared_ptr<FakeJni::JString> starturl,
+                                    std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+                                    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _a,
+                                    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b, FakeJni::JBoolean z,
+                                    FakeJni::JLong j2)
+{
+    auto webview = XalWebViewFactory::createXalWebView();
+    auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
+    auto method = BrowserLaunchActivity::getDescriptor()->getMethod("(JLjava/lang/String;ZLjava/lang/String;)V",
+                                                                    "urlOperationSucceeded");
+    FakeJni::LocalFrame frame;
+    method->invoke(
+        frame.getJniEnv(), BrowserLaunchActivity::getDescriptor().get(), l,
+        frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(finalendurl)), false,
+        frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
 }
 
-void BrowserLaunchActivity::showUrl2(
-    FakeJni::JLong l, std::shared_ptr<Context> ctx,
-    std::shared_ptr<FakeJni::JString> starturl,
-    std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _a,
-    std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b,
-    FakeJni::JBoolean z) {
-  auto webview = XalWebViewFactory::createXalWebView();
-  auto finalendurl =
-      webview->show(starturl->asStdString(), endurl->asStdString());
-  auto method = BrowserLaunchActivity::getDescriptor()->getMethod(
-      "(JLjava/lang/String;ZLjava/lang/String;)V", "urlOperationSucceeded");
-  FakeJni::LocalFrame frame;
-  method->invoke(
-      frame.getJniEnv(), BrowserLaunchActivity::getDescriptor().get(), l,
-      frame.getJniEnv().createLocalReference(
-          std::make_shared<FakeJni::JString>(finalendurl)),
-      false,
-      frame.getJniEnv().createLocalReference(
-          std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
+void BrowserLaunchActivity::showUrl2(FakeJni::JLong l, std::shared_ptr<Context> ctx,
+                                     std::shared_ptr<FakeJni::JString> starturl,
+                                     std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+                                     std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _a,
+                                     std::shared_ptr<FakeJni::JArray<FakeJni::JString>> _b, FakeJni::JBoolean z)
+{
+    auto webview = XalWebViewFactory::createXalWebView();
+    auto finalendurl = webview->show(starturl->asStdString(), endurl->asStdString());
+    auto method = BrowserLaunchActivity::getDescriptor()->getMethod("(JLjava/lang/String;ZLjava/lang/String;)V",
+                                                                    "urlOperationSucceeded");
+    FakeJni::LocalFrame frame;
+    method->invoke(
+        frame.getJniEnv(), BrowserLaunchActivity::getDescriptor().get(), l,
+        frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(finalendurl)), false,
+        frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("webkit-noDefault::0::none")));
 }

--- a/src/jni/webview.h
+++ b/src/jni/webview.h
@@ -2,8 +2,7 @@
 #include <fake-jni/fake-jni.h>
 #include "main_activity.h"
 
-class WebView : public FakeJni::JObject
-{
+class WebView : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/microsoft/xal/browser/WebView")
 
@@ -12,8 +11,7 @@ class WebView : public FakeJni::JObject
                         FakeJni::JLong j2);
 };
 
-class BrowserLaunchActivity : public FakeJni::JObject
-{
+class BrowserLaunchActivity : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/microsoft/xal/browser/BrowserLaunchActivity")
 

--- a/src/jni/webview.h
+++ b/src/jni/webview.h
@@ -1,18 +1,32 @@
 #pragma once
-#include <fake-jni/fake-jni.h>
 #include "main_activity.h"
+#include <fake-jni/fake-jni.h>
 
 class WebView : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xal/browser/WebView")
+  DEFINE_CLASS_NAME("com/microsoft/xal/browser/WebView")
 
-    static void showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl, std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, FakeJni::JBoolean z, FakeJni::JLong j2);
+  static void showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx,
+                      std::shared_ptr<FakeJni::JString> starturl,
+                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+                      FakeJni::JBoolean z, FakeJni::JLong j2);
 };
 
 class BrowserLaunchActivity : public FakeJni::JObject {
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xal/browser/BrowserLaunchActivity")
-    
-    static void showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl, std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, std::shared_ptr<FakeJni::JArray<FakeJni::JString>>, std::shared_ptr<FakeJni::JArray<FakeJni::JString>>, FakeJni::JBoolean z, FakeJni::JLong j2);
-    static void showUrl2(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl, std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, std::shared_ptr<FakeJni::JArray<FakeJni::JString>>, std::shared_ptr<FakeJni::JArray<FakeJni::JString>>, FakeJni::JBoolean z);
+  DEFINE_CLASS_NAME("com/microsoft/xal/browser/BrowserLaunchActivity")
+
+  static void showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx,
+                      std::shared_ptr<FakeJni::JString> starturl,
+                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+                      std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
+                      std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
+                      FakeJni::JBoolean z, FakeJni::JLong j2);
+  static void showUrl2(FakeJni::JLong l, std::shared_ptr<Context> ctx,
+                       std::shared_ptr<FakeJni::JString> starturl,
+                       std::shared_ptr<FakeJni::JString> endurl,
+                       FakeJni::JInt i,
+                       std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
+                       std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
+                       FakeJni::JBoolean z);
 };

--- a/src/jni/webview.h
+++ b/src/jni/webview.h
@@ -1,32 +1,28 @@
 #pragma once
-#include "main_activity.h"
 #include <fake-jni/fake-jni.h>
+#include "main_activity.h"
 
-class WebView : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xal/browser/WebView")
+class WebView : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xal/browser/WebView")
 
-  static void showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx,
-                      std::shared_ptr<FakeJni::JString> starturl,
-                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
-                      FakeJni::JBoolean z, FakeJni::JLong j2);
+    static void showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl,
+                        std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i, FakeJni::JBoolean z,
+                        FakeJni::JLong j2);
 };
 
-class BrowserLaunchActivity : public FakeJni::JObject {
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xal/browser/BrowserLaunchActivity")
+class BrowserLaunchActivity : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xal/browser/BrowserLaunchActivity")
 
-  static void showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx,
-                      std::shared_ptr<FakeJni::JString> starturl,
-                      std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
-                      std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
-                      std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
-                      FakeJni::JBoolean z, FakeJni::JLong j2);
-  static void showUrl2(FakeJni::JLong l, std::shared_ptr<Context> ctx,
-                       std::shared_ptr<FakeJni::JString> starturl,
-                       std::shared_ptr<FakeJni::JString> endurl,
-                       FakeJni::JInt i,
-                       std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
-                       std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
-                       FakeJni::JBoolean z);
+    static void showUrl(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl,
+                        std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+                        std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
+                        std::shared_ptr<FakeJni::JArray<FakeJni::JString>>, FakeJni::JBoolean z, FakeJni::JLong j2);
+    static void showUrl2(FakeJni::JLong l, std::shared_ptr<Context> ctx, std::shared_ptr<FakeJni::JString> starturl,
+                         std::shared_ptr<FakeJni::JString> endurl, FakeJni::JInt i,
+                         std::shared_ptr<FakeJni::JArray<FakeJni::JString>>,
+                         std::shared_ptr<FakeJni::JArray<FakeJni::JString>>, FakeJni::JBoolean z);
 };

--- a/src/jni/xbox_live.cpp
+++ b/src/jni/xbox_live.cpp
@@ -1,128 +1,176 @@
-#include <FileUtil.h>
-#include <mcpelauncher/path_helper.h>
-#include <log.h>
 #include "xbox_live.h"
 #include "../xbox_live_helper.h"
+#include <FileUtil.h>
+#include <log.h>
+#include <mcpelauncher/path_helper.h>
 #include <msa/client/error.h>
 
-std::shared_ptr<FakeJni::JString> XboxInterop::getLocalStoragePath(std::shared_ptr<Context> context) {
-    return std::make_shared<FakeJni::JString>(PathHelper::getPrimaryDataDirectory());
+std::shared_ptr<FakeJni::JString>
+XboxInterop::getLocalStoragePath(std::shared_ptr<Context> context) {
+  return std::make_shared<FakeJni::JString>(
+      PathHelper::getPrimaryDataDirectory());
 }
 
-std::shared_ptr<FakeJni::JString> XboxInterop::readConfigFile(std::shared_ptr<Context> context) {
-    std::string str;
-    if (!FileUtil::readFile(PathHelper::findGameFile("assets/xboxservices.config"), str))
-        str = "{}";
-    return std::make_shared<FakeJni::JString>(str);
+std::shared_ptr<FakeJni::JString>
+XboxInterop::readConfigFile(std::shared_ptr<Context> context) {
+  std::string str;
+  if (!FileUtil::readFile(
+          PathHelper::findGameFile("assets/xboxservices.config"), str))
+    str = "{}";
+  return std::make_shared<FakeJni::JString>(str);
 }
 
 std::shared_ptr<FakeJni::JString> XboxInterop::getLocale() {
-    return std::make_shared<FakeJni::JString>("en");
+  return std::make_shared<FakeJni::JString>("en");
 }
 
-void XboxInterop::invokeMSA(std::shared_ptr<Context> context, FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
+void XboxInterop::invokeMSA(std::shared_ptr<Context> context,
+                            FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
                             std::shared_ptr<FakeJni::JString> cid) {
-    Log::info("XboxInterop", "InvokeMSA: requestCode=%i cid=%s", requestCode, cid->asStdString().c_str());
-    FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
+  Log::info("XboxInterop", "InvokeMSA: requestCode=%i cid=%s", requestCode,
+            cid->asStdString().c_str());
+  FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
 
-    if (requestCode == 1) { // Silent sign in
-        XboxLiveHelper::getInstance().requestXblToken(cid->asStdString(), true,
-                [vm, requestCode](std::string const& cid, std::string const& binaryToken) {
-                    ticketCallback(*vm, binaryToken, requestCode, TICKET_OK, "");
-                }, [vm, requestCode](simpleipc::rpc_error_code code, std::string const &err) {
-                    if (code == msa::client::ErrorCodes::NoSuchAccount)
-                        ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED, "Must show UI to acquire an account.");
-                    else if (code == msa::client::ErrorCodes::MustShowUI)
-                        ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED, "Must show UI to update account information.");
-                    else
-                        ticketCallback(*vm, "", requestCode, TICKET_UNKNOWN_ERROR, err);
-                });
-    } else if (requestCode == 6) { // Sign out
-        signOutCallback();
-    } else {
-        throw std::runtime_error("Unsupported requestCode");
-    }
+  if (requestCode == 1) { // Silent sign in
+    XboxLiveHelper::getInstance().requestXblToken(
+        cid->asStdString(), true,
+        [vm, requestCode](std::string const &cid,
+                          std::string const &binaryToken) {
+          ticketCallback(*vm, binaryToken, requestCode, TICKET_OK, "");
+        },
+        [vm, requestCode](simpleipc::rpc_error_code code,
+                          std::string const &err) {
+          if (code == msa::client::ErrorCodes::NoSuchAccount)
+            ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED,
+                           "Must show UI to acquire an account.");
+          else if (code == msa::client::ErrorCodes::MustShowUI)
+            ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED,
+                           "Must show UI to update account information.");
+          else
+            ticketCallback(*vm, "", requestCode, TICKET_UNKNOWN_ERROR, err);
+        });
+  } else if (requestCode == 6) { // Sign out
+    signOutCallback();
+  } else {
+    throw std::runtime_error("Unsupported requestCode");
+  }
 }
 
-void XboxInterop::invokeAuthFlow(FakeJni::JLong userPtr, std::shared_ptr<Activity> activity, FakeJni::JBoolean isProd,
+void XboxInterop::invokeAuthFlow(FakeJni::JLong userPtr,
+                                 std::shared_ptr<Activity> activity,
+                                 FakeJni::JBoolean isProd,
                                  std::shared_ptr<FakeJni::JString> signInText) {
-    Log::info("XboxInterop", "InvokeAuthFlow");
-    FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
+  Log::info("XboxInterop", "InvokeAuthFlow");
+  FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
 
-    XboxLiveHelper::getInstance().invokeMsaAuthFlow([vm, userPtr](std::string const& cid, std::string const& binaryToken) {
-        auto cb = std::make_shared<XboxLoginCallback>(*vm, userPtr, cid, binaryToken);
+  XboxLiveHelper::getInstance().invokeMsaAuthFlow(
+      [vm, userPtr](std::string const &cid, std::string const &binaryToken) {
+        auto cb =
+            std::make_shared<XboxLoginCallback>(*vm, userPtr, cid, binaryToken);
         invokeXBLogin(*vm, userPtr, binaryToken, cb);
-    }, [vm, userPtr](simpleipc::rpc_error_code c, std::string const &) {
+      },
+      [vm, userPtr](simpleipc::rpc_error_code c, std::string const &) {
         if (c == msa::client::ErrorCodes::OperationCancelled)
-            authFlowCallback(*vm, userPtr, AUTH_FLOW_CANCEL, "");
+          authFlowCallback(*vm, userPtr, AUTH_FLOW_CANCEL, "");
         else
-            authFlowCallback(*vm, userPtr, AUTH_FLOW_ERROR, "");
-    });
+          authFlowCallback(*vm, userPtr, AUTH_FLOW_ERROR, "");
+      });
 }
 
-void XboxInterop::initCLL(std::shared_ptr<Context> arg0, std::shared_ptr<FakeJni::JString> arg1) {
-    XboxLiveHelper::getInstance().initCll();
+void XboxInterop::initCLL(std::shared_ptr<Context> arg0,
+                          std::shared_ptr<FakeJni::JString> arg1) {
+  XboxLiveHelper::getInstance().initCll();
 }
 
-void XboxInterop::logCLL(std::shared_ptr<FakeJni::JString> ticket, std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> data) {
-    cll::Event event(name->asStdString(), nlohmann::json::parse(data->asStdString()),
-                     cll::EventFlags::PersistenceCritical | cll::EventFlags::LatencyRealtime, {ticket->asStdString()});
-    XboxLiveHelper::getInstance().logCll(event);
+void XboxInterop::logCLL(std::shared_ptr<FakeJni::JString> ticket,
+                         std::shared_ptr<FakeJni::JString> name,
+                         std::shared_ptr<FakeJni::JString> data) {
+  cll::Event event(
+      name->asStdString(), nlohmann::json::parse(data->asStdString()),
+      cll::EventFlags::PersistenceCritical | cll::EventFlags::LatencyRealtime,
+      {ticket->asStdString()});
+  XboxLiveHelper::getInstance().logCll(event);
 }
 
-void XboxInterop::ticketCallback(FakeJni::Jvm const &vm, std::string const &ticket, int requestCode, int errorCode,
-        std::string const &error) {
-    FakeJni::LocalFrame env (vm);
-    auto callback = getDescriptor()->getMethod("(Ljava/lang/String;IILjava/lang/String;)V", "ticket_callback");
-    auto ticketRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(ticket));
-    auto errorStrRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(error));
-    callback->invoke(env.getJniEnv(), getDescriptor().get(), ticketRef, requestCode, errorCode, errorStrRef);
+void XboxInterop::ticketCallback(FakeJni::Jvm const &vm,
+                                 std::string const &ticket, int requestCode,
+                                 int errorCode, std::string const &error) {
+  FakeJni::LocalFrame env(vm);
+  auto callback = getDescriptor()->getMethod(
+      "(Ljava/lang/String;IILjava/lang/String;)V", "ticket_callback");
+  auto ticketRef = env.getJniEnv().createLocalReference(
+      std::make_shared<FakeJni::JString>(ticket));
+  auto errorStrRef = env.getJniEnv().createLocalReference(
+      std::make_shared<FakeJni::JString>(error));
+  callback->invoke(env.getJniEnv(), getDescriptor().get(), ticketRef,
+                   requestCode, errorCode, errorStrRef);
 }
 
-void XboxInterop::authFlowCallback(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, int status, std::string const &cid) {
-    FakeJni::LocalFrame env (vm);
-    auto callback = getDescriptor()->getMethod("(JILjava/lang/String;)V", "auth_flow_callback");
-    auto cidRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(cid));
-    callback->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, status, cidRef);
+void XboxInterop::authFlowCallback(FakeJni::Jvm const &vm,
+                                   FakeJni::JLong userPtr, int status,
+                                   std::string const &cid) {
+  FakeJni::LocalFrame env(vm);
+  auto callback = getDescriptor()->getMethod("(JILjava/lang/String;)V",
+                                             "auth_flow_callback");
+  auto cidRef = env.getJniEnv().createLocalReference(
+      std::make_shared<FakeJni::JString>(cid));
+  callback->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, status,
+                   cidRef);
 }
 
 void XboxInterop::signOutCallback() {
-    FakeJni::LocalFrame env;
-    auto callback = getDescriptor()->getMethod("()V", "sign_out_callback");
-    callback->invoke(env.getJniEnv(), getDescriptor().get());
+  FakeJni::LocalFrame env;
+  auto callback = getDescriptor()->getMethod("()V", "sign_out_callback");
+  callback->invoke(env.getJniEnv(), getDescriptor().get());
 }
 
-void XboxInterop::invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
-        std::shared_ptr<XboxLoginCallback> callback) {
-    FakeJni::LocalFrame env (vm);
-    auto fn = getDescriptor()->getMethod("(JLjava/lang/String;Lcom/microsoft/xbox/idp/interop/Interop$XBLoginCallback;)V", "invoke_xb_login");
-    auto ticketRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(ticket));
-    auto callbackRef = env.getJniEnv().createLocalReference(callback);
-    fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef, callbackRef);
+void XboxInterop::invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr,
+                                std::string const &ticket,
+                                std::shared_ptr<XboxLoginCallback> callback) {
+  FakeJni::LocalFrame env(vm);
+  auto fn =
+      getDescriptor()->getMethod("(JLjava/lang/String;Lcom/microsoft/xbox/idp/"
+                                 "interop/Interop$XBLoginCallback;)V",
+                                 "invoke_xb_login");
+  auto ticketRef = env.getJniEnv().createLocalReference(
+      std::make_shared<FakeJni::JString>(ticket));
+  auto callbackRef = env.getJniEnv().createLocalReference(callback);
+  fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef,
+             callbackRef);
 }
 
-void XboxInterop::invokeEventInitialization(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
-        std::shared_ptr<XboxLoginCallback> callback) {
-    FakeJni::LocalFrame env (vm);
-    auto fn = getDescriptor()->getMethod("(JLjava/lang/String;Lcom/microsoft/xbox/idp/interop/Interop$EventInitializationCallback;)V", "invoke_event_initialization");
-    auto ticketRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(ticket));
-    auto callbackRef = env.getJniEnv().createLocalReference(callback);
-    fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef, callbackRef);
+void XboxInterop::invokeEventInitialization(
+    FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
+    std::shared_ptr<XboxLoginCallback> callback) {
+  FakeJni::LocalFrame env(vm);
+  auto fn = getDescriptor()->getMethod(
+      "(JLjava/lang/String;Lcom/microsoft/xbox/idp/interop/"
+      "Interop$EventInitializationCallback;)V",
+      "invoke_event_initialization");
+  auto ticketRef = env.getJniEnv().createLocalReference(
+      std::make_shared<FakeJni::JString>(ticket));
+  auto callbackRef = env.getJniEnv().createLocalReference(callback);
+  fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef,
+             callbackRef);
 }
 
-void XboxLoginCallback::onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount) {
-    XboxInterop::invokeEventInitialization(jvm, userPtr, ticket,
-            std::static_pointer_cast<XboxLoginCallback>(shared_from_this()));
+void XboxLoginCallback::onLogin(FakeJni::JLong nativePtr,
+                                FakeJni::JBoolean newAccount) {
+  XboxInterop::invokeEventInitialization(
+      jvm, userPtr, ticket,
+      std::static_pointer_cast<XboxLoginCallback>(shared_from_this()));
 }
 
 void XboxLoginCallback::onSuccess() {
-    XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_OK, cid);
+  XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_OK, cid);
 }
 
-void XboxLoginCallback::onError(int httpStatus, int status, std::shared_ptr<FakeJni::JString> message) {
-    XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_ERROR, "");
+void XboxLoginCallback::onError(int httpStatus, int status,
+                                std::shared_ptr<FakeJni::JString> message) {
+  XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_ERROR, "");
 }
 
-std::shared_ptr<FakeJni::JString> XboxLocalStorage::getPath(std::shared_ptr<Context> context) {
-    return XboxInterop::getLocalStoragePath(context);
+std::shared_ptr<FakeJni::JString>
+XboxLocalStorage::getPath(std::shared_ptr<Context> context) {
+  return XboxInterop::getLocalStoragePath(context);
 }

--- a/src/jni/xbox_live.cpp
+++ b/src/jni/xbox_live.cpp
@@ -1,176 +1,158 @@
 #include "xbox_live.h"
-#include "../xbox_live_helper.h"
 #include <FileUtil.h>
 #include <log.h>
 #include <mcpelauncher/path_helper.h>
 #include <msa/client/error.h>
+#include "../xbox_live_helper.h"
 
-std::shared_ptr<FakeJni::JString>
-XboxInterop::getLocalStoragePath(std::shared_ptr<Context> context) {
-  return std::make_shared<FakeJni::JString>(
-      PathHelper::getPrimaryDataDirectory());
+std::shared_ptr<FakeJni::JString> XboxInterop::getLocalStoragePath(std::shared_ptr<Context> context)
+{
+    return std::make_shared<FakeJni::JString>(PathHelper::getPrimaryDataDirectory());
 }
 
-std::shared_ptr<FakeJni::JString>
-XboxInterop::readConfigFile(std::shared_ptr<Context> context) {
-  std::string str;
-  if (!FileUtil::readFile(
-          PathHelper::findGameFile("assets/xboxservices.config"), str))
-    str = "{}";
-  return std::make_shared<FakeJni::JString>(str);
+std::shared_ptr<FakeJni::JString> XboxInterop::readConfigFile(std::shared_ptr<Context> context)
+{
+    std::string str;
+    if (!FileUtil::readFile(PathHelper::findGameFile("assets/xboxservices.config"), str))
+        str = "{}";
+    return std::make_shared<FakeJni::JString>(str);
 }
 
-std::shared_ptr<FakeJni::JString> XboxInterop::getLocale() {
-  return std::make_shared<FakeJni::JString>("en");
+std::shared_ptr<FakeJni::JString> XboxInterop::getLocale() { return std::make_shared<FakeJni::JString>("en"); }
+
+void XboxInterop::invokeMSA(std::shared_ptr<Context> context, FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
+                            std::shared_ptr<FakeJni::JString> cid)
+{
+    Log::info("XboxInterop", "InvokeMSA: requestCode=%i cid=%s", requestCode, cid->asStdString().c_str());
+    FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
+
+    if (requestCode == 1)
+    {  // Silent sign in
+        XboxLiveHelper::getInstance().requestXblToken(
+            cid->asStdString(), true,
+            [vm, requestCode](std::string const &cid, std::string const &binaryToken)
+            { ticketCallback(*vm, binaryToken, requestCode, TICKET_OK, ""); },
+            [vm, requestCode](simpleipc::rpc_error_code code, std::string const &err)
+            {
+                if (code == msa::client::ErrorCodes::NoSuchAccount)
+                    ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED,
+                                   "Must show UI to acquire an account.");
+                else if (code == msa::client::ErrorCodes::MustShowUI)
+                    ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED,
+                                   "Must show UI to update account information.");
+                else
+                    ticketCallback(*vm, "", requestCode, TICKET_UNKNOWN_ERROR, err);
+            });
+    }
+    else if (requestCode == 6)
+    {  // Sign out
+        signOutCallback();
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported requestCode");
+    }
 }
 
-void XboxInterop::invokeMSA(std::shared_ptr<Context> context,
-                            FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
-                            std::shared_ptr<FakeJni::JString> cid) {
-  Log::info("XboxInterop", "InvokeMSA: requestCode=%i cid=%s", requestCode,
-            cid->asStdString().c_str());
-  FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
+void XboxInterop::invokeAuthFlow(FakeJni::JLong userPtr, std::shared_ptr<Activity> activity, FakeJni::JBoolean isProd,
+                                 std::shared_ptr<FakeJni::JString> signInText)
+{
+    Log::info("XboxInterop", "InvokeAuthFlow");
+    FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
 
-  if (requestCode == 1) { // Silent sign in
-    XboxLiveHelper::getInstance().requestXblToken(
-        cid->asStdString(), true,
-        [vm, requestCode](std::string const &cid,
-                          std::string const &binaryToken) {
-          ticketCallback(*vm, binaryToken, requestCode, TICKET_OK, "");
+    XboxLiveHelper::getInstance().invokeMsaAuthFlow(
+        [vm, userPtr](std::string const &cid, std::string const &binaryToken)
+        {
+            auto cb = std::make_shared<XboxLoginCallback>(*vm, userPtr, cid, binaryToken);
+            invokeXBLogin(*vm, userPtr, binaryToken, cb);
         },
-        [vm, requestCode](simpleipc::rpc_error_code code,
-                          std::string const &err) {
-          if (code == msa::client::ErrorCodes::NoSuchAccount)
-            ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED,
-                           "Must show UI to acquire an account.");
-          else if (code == msa::client::ErrorCodes::MustShowUI)
-            ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED,
-                           "Must show UI to update account information.");
-          else
-            ticketCallback(*vm, "", requestCode, TICKET_UNKNOWN_ERROR, err);
+        [vm, userPtr](simpleipc::rpc_error_code c, std::string const &)
+        {
+            if (c == msa::client::ErrorCodes::OperationCancelled)
+                authFlowCallback(*vm, userPtr, AUTH_FLOW_CANCEL, "");
+            else
+                authFlowCallback(*vm, userPtr, AUTH_FLOW_ERROR, "");
         });
-  } else if (requestCode == 6) { // Sign out
-    signOutCallback();
-  } else {
-    throw std::runtime_error("Unsupported requestCode");
-  }
 }
 
-void XboxInterop::invokeAuthFlow(FakeJni::JLong userPtr,
-                                 std::shared_ptr<Activity> activity,
-                                 FakeJni::JBoolean isProd,
-                                 std::shared_ptr<FakeJni::JString> signInText) {
-  Log::info("XboxInterop", "InvokeAuthFlow");
-  FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
-
-  XboxLiveHelper::getInstance().invokeMsaAuthFlow(
-      [vm, userPtr](std::string const &cid, std::string const &binaryToken) {
-        auto cb =
-            std::make_shared<XboxLoginCallback>(*vm, userPtr, cid, binaryToken);
-        invokeXBLogin(*vm, userPtr, binaryToken, cb);
-      },
-      [vm, userPtr](simpleipc::rpc_error_code c, std::string const &) {
-        if (c == msa::client::ErrorCodes::OperationCancelled)
-          authFlowCallback(*vm, userPtr, AUTH_FLOW_CANCEL, "");
-        else
-          authFlowCallback(*vm, userPtr, AUTH_FLOW_ERROR, "");
-      });
+void XboxInterop::initCLL(std::shared_ptr<Context> arg0, std::shared_ptr<FakeJni::JString> arg1)
+{
+    XboxLiveHelper::getInstance().initCll();
 }
 
-void XboxInterop::initCLL(std::shared_ptr<Context> arg0,
-                          std::shared_ptr<FakeJni::JString> arg1) {
-  XboxLiveHelper::getInstance().initCll();
+void XboxInterop::logCLL(std::shared_ptr<FakeJni::JString> ticket, std::shared_ptr<FakeJni::JString> name,
+                         std::shared_ptr<FakeJni::JString> data)
+{
+    cll::Event event(name->asStdString(), nlohmann::json::parse(data->asStdString()),
+                     cll::EventFlags::PersistenceCritical | cll::EventFlags::LatencyRealtime, {ticket->asStdString()});
+    XboxLiveHelper::getInstance().logCll(event);
 }
 
-void XboxInterop::logCLL(std::shared_ptr<FakeJni::JString> ticket,
-                         std::shared_ptr<FakeJni::JString> name,
-                         std::shared_ptr<FakeJni::JString> data) {
-  cll::Event event(
-      name->asStdString(), nlohmann::json::parse(data->asStdString()),
-      cll::EventFlags::PersistenceCritical | cll::EventFlags::LatencyRealtime,
-      {ticket->asStdString()});
-  XboxLiveHelper::getInstance().logCll(event);
+void XboxInterop::ticketCallback(FakeJni::Jvm const &vm, std::string const &ticket, int requestCode, int errorCode,
+                                 std::string const &error)
+{
+    FakeJni::LocalFrame env(vm);
+    auto callback = getDescriptor()->getMethod("(Ljava/lang/String;IILjava/lang/String;)V", "ticket_callback");
+    auto ticketRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(ticket));
+    auto errorStrRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(error));
+    callback->invoke(env.getJniEnv(), getDescriptor().get(), ticketRef, requestCode, errorCode, errorStrRef);
 }
 
-void XboxInterop::ticketCallback(FakeJni::Jvm const &vm,
-                                 std::string const &ticket, int requestCode,
-                                 int errorCode, std::string const &error) {
-  FakeJni::LocalFrame env(vm);
-  auto callback = getDescriptor()->getMethod(
-      "(Ljava/lang/String;IILjava/lang/String;)V", "ticket_callback");
-  auto ticketRef = env.getJniEnv().createLocalReference(
-      std::make_shared<FakeJni::JString>(ticket));
-  auto errorStrRef = env.getJniEnv().createLocalReference(
-      std::make_shared<FakeJni::JString>(error));
-  callback->invoke(env.getJniEnv(), getDescriptor().get(), ticketRef,
-                   requestCode, errorCode, errorStrRef);
+void XboxInterop::authFlowCallback(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, int status, std::string const &cid)
+{
+    FakeJni::LocalFrame env(vm);
+    auto callback = getDescriptor()->getMethod("(JILjava/lang/String;)V", "auth_flow_callback");
+    auto cidRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(cid));
+    callback->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, status, cidRef);
 }
 
-void XboxInterop::authFlowCallback(FakeJni::Jvm const &vm,
-                                   FakeJni::JLong userPtr, int status,
-                                   std::string const &cid) {
-  FakeJni::LocalFrame env(vm);
-  auto callback = getDescriptor()->getMethod("(JILjava/lang/String;)V",
-                                             "auth_flow_callback");
-  auto cidRef = env.getJniEnv().createLocalReference(
-      std::make_shared<FakeJni::JString>(cid));
-  callback->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, status,
-                   cidRef);
+void XboxInterop::signOutCallback()
+{
+    FakeJni::LocalFrame env;
+    auto callback = getDescriptor()->getMethod("()V", "sign_out_callback");
+    callback->invoke(env.getJniEnv(), getDescriptor().get());
 }
 
-void XboxInterop::signOutCallback() {
-  FakeJni::LocalFrame env;
-  auto callback = getDescriptor()->getMethod("()V", "sign_out_callback");
-  callback->invoke(env.getJniEnv(), getDescriptor().get());
+void XboxInterop::invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
+                                std::shared_ptr<XboxLoginCallback> callback)
+{
+    FakeJni::LocalFrame env(vm);
+    auto fn = getDescriptor()->getMethod(
+        "(JLjava/lang/String;Lcom/microsoft/xbox/idp/"
+        "interop/Interop$XBLoginCallback;)V",
+        "invoke_xb_login");
+    auto ticketRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(ticket));
+    auto callbackRef = env.getJniEnv().createLocalReference(callback);
+    fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef, callbackRef);
 }
 
-void XboxInterop::invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr,
-                                std::string const &ticket,
-                                std::shared_ptr<XboxLoginCallback> callback) {
-  FakeJni::LocalFrame env(vm);
-  auto fn =
-      getDescriptor()->getMethod("(JLjava/lang/String;Lcom/microsoft/xbox/idp/"
-                                 "interop/Interop$XBLoginCallback;)V",
-                                 "invoke_xb_login");
-  auto ticketRef = env.getJniEnv().createLocalReference(
-      std::make_shared<FakeJni::JString>(ticket));
-  auto callbackRef = env.getJniEnv().createLocalReference(callback);
-  fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef,
-             callbackRef);
+void XboxInterop::invokeEventInitialization(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
+                                            std::shared_ptr<XboxLoginCallback> callback)
+{
+    FakeJni::LocalFrame env(vm);
+    auto fn = getDescriptor()->getMethod(
+        "(JLjava/lang/String;Lcom/microsoft/xbox/idp/interop/"
+        "Interop$EventInitializationCallback;)V",
+        "invoke_event_initialization");
+    auto ticketRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(ticket));
+    auto callbackRef = env.getJniEnv().createLocalReference(callback);
+    fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef, callbackRef);
 }
 
-void XboxInterop::invokeEventInitialization(
-    FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
-    std::shared_ptr<XboxLoginCallback> callback) {
-  FakeJni::LocalFrame env(vm);
-  auto fn = getDescriptor()->getMethod(
-      "(JLjava/lang/String;Lcom/microsoft/xbox/idp/interop/"
-      "Interop$EventInitializationCallback;)V",
-      "invoke_event_initialization");
-  auto ticketRef = env.getJniEnv().createLocalReference(
-      std::make_shared<FakeJni::JString>(ticket));
-  auto callbackRef = env.getJniEnv().createLocalReference(callback);
-  fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef,
-             callbackRef);
+void XboxLoginCallback::onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount)
+{
+    XboxInterop::invokeEventInitialization(jvm, userPtr, ticket,
+                                           std::static_pointer_cast<XboxLoginCallback>(shared_from_this()));
 }
 
-void XboxLoginCallback::onLogin(FakeJni::JLong nativePtr,
-                                FakeJni::JBoolean newAccount) {
-  XboxInterop::invokeEventInitialization(
-      jvm, userPtr, ticket,
-      std::static_pointer_cast<XboxLoginCallback>(shared_from_this()));
+void XboxLoginCallback::onSuccess() { XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_OK, cid); }
+
+void XboxLoginCallback::onError(int httpStatus, int status, std::shared_ptr<FakeJni::JString> message)
+{
+    XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_ERROR, "");
 }
 
-void XboxLoginCallback::onSuccess() {
-  XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_OK, cid);
-}
-
-void XboxLoginCallback::onError(int httpStatus, int status,
-                                std::shared_ptr<FakeJni::JString> message) {
-  XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_ERROR, "");
-}
-
-std::shared_ptr<FakeJni::JString>
-XboxLocalStorage::getPath(std::shared_ptr<Context> context) {
-  return XboxInterop::getLocalStoragePath(context);
+std::shared_ptr<FakeJni::JString> XboxLocalStorage::getPath(std::shared_ptr<Context> context)
+{
+    return XboxInterop::getLocalStoragePath(context);
 }

--- a/src/jni/xbox_live.cpp
+++ b/src/jni/xbox_live.cpp
@@ -5,13 +5,11 @@
 #include <msa/client/error.h>
 #include "../xbox_live_helper.h"
 
-std::shared_ptr<FakeJni::JString> XboxInterop::getLocalStoragePath(std::shared_ptr<Context> context)
-{
+std::shared_ptr<FakeJni::JString> XboxInterop::getLocalStoragePath(std::shared_ptr<Context> context) {
     return std::make_shared<FakeJni::JString>(PathHelper::getPrimaryDataDirectory());
 }
 
-std::shared_ptr<FakeJni::JString> XboxInterop::readConfigFile(std::shared_ptr<Context> context)
-{
+std::shared_ptr<FakeJni::JString> XboxInterop::readConfigFile(std::shared_ptr<Context> context) {
     std::string str;
     if (!FileUtil::readFile(PathHelper::findGameFile("assets/xboxservices.config"), str))
         str = "{}";
@@ -21,19 +19,17 @@ std::shared_ptr<FakeJni::JString> XboxInterop::readConfigFile(std::shared_ptr<Co
 std::shared_ptr<FakeJni::JString> XboxInterop::getLocale() { return std::make_shared<FakeJni::JString>("en"); }
 
 void XboxInterop::invokeMSA(std::shared_ptr<Context> context, FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
-                            std::shared_ptr<FakeJni::JString> cid)
-{
+                            std::shared_ptr<FakeJni::JString> cid) {
     Log::info("XboxInterop", "InvokeMSA: requestCode=%i cid=%s", requestCode, cid->asStdString().c_str());
     FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
 
-    if (requestCode == 1)
-    {  // Silent sign in
+    if (requestCode == 1) {  // Silent sign in
         XboxLiveHelper::getInstance().requestXblToken(
             cid->asStdString(), true,
-            [vm, requestCode](std::string const &cid, std::string const &binaryToken)
-            { ticketCallback(*vm, binaryToken, requestCode, TICKET_OK, ""); },
-            [vm, requestCode](simpleipc::rpc_error_code code, std::string const &err)
-            {
+            [vm, requestCode](std::string const &cid, std::string const &binaryToken) {
+                ticketCallback(*vm, binaryToken, requestCode, TICKET_OK, "");
+            },
+            [vm, requestCode](simpleipc::rpc_error_code code, std::string const &err) {
                 if (code == msa::client::ErrorCodes::NoSuchAccount)
                     ticketCallback(*vm, "", requestCode, TICKET_UI_INTERACTION_REQUIRED,
                                    "Must show UI to acquire an account.");
@@ -43,31 +39,24 @@ void XboxInterop::invokeMSA(std::shared_ptr<Context> context, FakeJni::JInt requ
                 else
                     ticketCallback(*vm, "", requestCode, TICKET_UNKNOWN_ERROR, err);
             });
-    }
-    else if (requestCode == 6)
-    {  // Sign out
+    } else if (requestCode == 6) {  // Sign out
         signOutCallback();
-    }
-    else
-    {
+    } else {
         throw std::runtime_error("Unsupported requestCode");
     }
 }
 
 void XboxInterop::invokeAuthFlow(FakeJni::JLong userPtr, std::shared_ptr<Activity> activity, FakeJni::JBoolean isProd,
-                                 std::shared_ptr<FakeJni::JString> signInText)
-{
+                                 std::shared_ptr<FakeJni::JString> signInText) {
     Log::info("XboxInterop", "InvokeAuthFlow");
     FakeJni::Jvm const *vm = &FakeJni::JniEnv::getCurrentEnv()->getVM();
 
     XboxLiveHelper::getInstance().invokeMsaAuthFlow(
-        [vm, userPtr](std::string const &cid, std::string const &binaryToken)
-        {
+        [vm, userPtr](std::string const &cid, std::string const &binaryToken) {
             auto cb = std::make_shared<XboxLoginCallback>(*vm, userPtr, cid, binaryToken);
             invokeXBLogin(*vm, userPtr, binaryToken, cb);
         },
-        [vm, userPtr](simpleipc::rpc_error_code c, std::string const &)
-        {
+        [vm, userPtr](simpleipc::rpc_error_code c, std::string const &) {
             if (c == msa::client::ErrorCodes::OperationCancelled)
                 authFlowCallback(*vm, userPtr, AUTH_FLOW_CANCEL, "");
             else
@@ -75,22 +64,19 @@ void XboxInterop::invokeAuthFlow(FakeJni::JLong userPtr, std::shared_ptr<Activit
         });
 }
 
-void XboxInterop::initCLL(std::shared_ptr<Context> arg0, std::shared_ptr<FakeJni::JString> arg1)
-{
+void XboxInterop::initCLL(std::shared_ptr<Context> arg0, std::shared_ptr<FakeJni::JString> arg1) {
     XboxLiveHelper::getInstance().initCll();
 }
 
 void XboxInterop::logCLL(std::shared_ptr<FakeJni::JString> ticket, std::shared_ptr<FakeJni::JString> name,
-                         std::shared_ptr<FakeJni::JString> data)
-{
+                         std::shared_ptr<FakeJni::JString> data) {
     cll::Event event(name->asStdString(), nlohmann::json::parse(data->asStdString()),
                      cll::EventFlags::PersistenceCritical | cll::EventFlags::LatencyRealtime, {ticket->asStdString()});
     XboxLiveHelper::getInstance().logCll(event);
 }
 
 void XboxInterop::ticketCallback(FakeJni::Jvm const &vm, std::string const &ticket, int requestCode, int errorCode,
-                                 std::string const &error)
-{
+                                 std::string const &error) {
     FakeJni::LocalFrame env(vm);
     auto callback = getDescriptor()->getMethod("(Ljava/lang/String;IILjava/lang/String;)V", "ticket_callback");
     auto ticketRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(ticket));
@@ -98,24 +84,21 @@ void XboxInterop::ticketCallback(FakeJni::Jvm const &vm, std::string const &tick
     callback->invoke(env.getJniEnv(), getDescriptor().get(), ticketRef, requestCode, errorCode, errorStrRef);
 }
 
-void XboxInterop::authFlowCallback(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, int status, std::string const &cid)
-{
+void XboxInterop::authFlowCallback(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, int status, std::string const &cid) {
     FakeJni::LocalFrame env(vm);
     auto callback = getDescriptor()->getMethod("(JILjava/lang/String;)V", "auth_flow_callback");
     auto cidRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(cid));
     callback->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, status, cidRef);
 }
 
-void XboxInterop::signOutCallback()
-{
+void XboxInterop::signOutCallback() {
     FakeJni::LocalFrame env;
     auto callback = getDescriptor()->getMethod("()V", "sign_out_callback");
     callback->invoke(env.getJniEnv(), getDescriptor().get());
 }
 
 void XboxInterop::invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
-                                std::shared_ptr<XboxLoginCallback> callback)
-{
+                                std::shared_ptr<XboxLoginCallback> callback) {
     FakeJni::LocalFrame env(vm);
     auto fn = getDescriptor()->getMethod(
         "(JLjava/lang/String;Lcom/microsoft/xbox/idp/"
@@ -127,8 +110,7 @@ void XboxInterop::invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, 
 }
 
 void XboxInterop::invokeEventInitialization(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
-                                            std::shared_ptr<XboxLoginCallback> callback)
-{
+                                            std::shared_ptr<XboxLoginCallback> callback) {
     FakeJni::LocalFrame env(vm);
     auto fn = getDescriptor()->getMethod(
         "(JLjava/lang/String;Lcom/microsoft/xbox/idp/interop/"
@@ -139,20 +121,17 @@ void XboxInterop::invokeEventInitialization(FakeJni::Jvm const &vm, FakeJni::JLo
     fn->invoke(env.getJniEnv(), getDescriptor().get(), userPtr, ticketRef, callbackRef);
 }
 
-void XboxLoginCallback::onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount)
-{
+void XboxLoginCallback::onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount) {
     XboxInterop::invokeEventInitialization(jvm, userPtr, ticket,
                                            std::static_pointer_cast<XboxLoginCallback>(shared_from_this()));
 }
 
 void XboxLoginCallback::onSuccess() { XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_OK, cid); }
 
-void XboxLoginCallback::onError(int httpStatus, int status, std::shared_ptr<FakeJni::JString> message)
-{
+void XboxLoginCallback::onError(int httpStatus, int status, std::shared_ptr<FakeJni::JString> message) {
     XboxInterop::authFlowCallback(jvm, userPtr, XboxInterop::AUTH_FLOW_ERROR, "");
 }
 
-std::shared_ptr<FakeJni::JString> XboxLocalStorage::getPath(std::shared_ptr<Context> context)
-{
+std::shared_ptr<FakeJni::JString> XboxLocalStorage::getPath(std::shared_ptr<Context> context) {
     return XboxInterop::getLocalStoragePath(context);
 }

--- a/src/jni/xbox_live.h
+++ b/src/jni/xbox_live.h
@@ -5,8 +5,7 @@
 
 class XboxLoginCallback;
 
-class XboxInterop : public FakeJni::JObject
-{
+class XboxInterop : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop")
 
@@ -52,8 +51,7 @@ class XboxInterop : public FakeJni::JObject
                                           std::shared_ptr<XboxLoginCallback> callback);
 };
 
-class XboxLoginCallback : public FakeJni::JObject
-{
+class XboxLoginCallback : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop$XBLoginCallback")
 
@@ -62,9 +60,7 @@ class XboxLoginCallback : public FakeJni::JObject
     std::string cid, ticket;
 
     XboxLoginCallback(FakeJni::Jvm const &jvm, FakeJni::JLong userPtr, std::string cid, std::string ticket)
-        : jvm(jvm), userPtr(userPtr), cid(std::move(cid)), ticket(std::move(ticket))
-    {
-    }
+        : jvm(jvm), userPtr(userPtr), cid(std::move(cid)), ticket(std::move(ticket)) {}
 
     void onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount);
 
@@ -73,8 +69,7 @@ class XboxLoginCallback : public FakeJni::JObject
     void onError(int httpStatus, int status, std::shared_ptr<FakeJni::JString> message);
 };
 
-class XboxLocalStorage : public FakeJni::JObject
-{
+class XboxLocalStorage : public FakeJni::JObject {
    public:
     DEFINE_CLASS_NAME("com/microsoft/xboxlive/LocalStorage")
 

--- a/src/jni/xbox_live.h
+++ b/src/jni/xbox_live.h
@@ -1,96 +1,82 @@
 #pragma once
 
-#include "main_activity.h"
 #include <fake-jni/fake-jni.h>
+#include "main_activity.h"
 
 class XboxLoginCallback;
 
-class XboxInterop : public FakeJni::JObject {
+class XboxInterop : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop")
 
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop")
+    static std::shared_ptr<FakeJni::JString> getLocalStoragePath(std::shared_ptr<Context> context);
 
-  static std::shared_ptr<FakeJni::JString>
-  getLocalStoragePath(std::shared_ptr<Context> context);
+    static std::shared_ptr<FakeJni::JString> readConfigFile(std::shared_ptr<Context> context);
 
-  static std::shared_ptr<FakeJni::JString>
-  readConfigFile(std::shared_ptr<Context> context);
+    static std::shared_ptr<FakeJni::JString> getLocale();
 
-  static std::shared_ptr<FakeJni::JString> getLocale();
+    static void invokeMSA(std::shared_ptr<Context> context, FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
+                          std::shared_ptr<FakeJni::JString> cid);
 
-  static void invokeMSA(std::shared_ptr<Context> context,
-                        FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
-                        std::shared_ptr<FakeJni::JString> cid);
+    static void invokeAuthFlow(FakeJni::JLong userPtr, std::shared_ptr<Activity> activity, FakeJni::JBoolean isProd,
+                               std::shared_ptr<FakeJni::JString> signInText);
 
-  static void invokeAuthFlow(FakeJni::JLong userPtr,
-                             std::shared_ptr<Activity> activity,
-                             FakeJni::JBoolean isProd,
-                             std::shared_ptr<FakeJni::JString> signInText);
+    static void initCLL(std::shared_ptr<Context> arg0, std::shared_ptr<FakeJni::JString> arg1);
 
-  static void initCLL(std::shared_ptr<Context> arg0,
-                      std::shared_ptr<FakeJni::JString> arg1);
+    static void logCLL(std::shared_ptr<FakeJni::JString> ticket, std::shared_ptr<FakeJni::JString> name,
+                       std::shared_ptr<FakeJni::JString> data);
 
-  static void logCLL(std::shared_ptr<FakeJni::JString> ticket,
-                     std::shared_ptr<FakeJni::JString> name,
-                     std::shared_ptr<FakeJni::JString> data);
+   private:
+    friend class XboxLoginCallback;
 
-private:
-  friend class XboxLoginCallback;
+    static constexpr int AUTH_FLOW_OK = 0;
+    static constexpr int AUTH_FLOW_CANCEL = 1;
+    static constexpr int AUTH_FLOW_ERROR = 2;
 
-  static constexpr int AUTH_FLOW_OK = 0;
-  static constexpr int AUTH_FLOW_CANCEL = 1;
-  static constexpr int AUTH_FLOW_ERROR = 2;
+    static constexpr int TICKET_OK = 0;
+    static constexpr int TICKET_UI_INTERACTION_REQUIRED = 1;
+    static constexpr int TICKET_UNKNOWN_ERROR = 3;
 
-  static constexpr int TICKET_OK = 0;
-  static constexpr int TICKET_UI_INTERACTION_REQUIRED = 1;
-  static constexpr int TICKET_UNKNOWN_ERROR = 3;
+    static void ticketCallback(FakeJni::Jvm const &vm, std::string const &ticket, int requestCode, int errorCode,
+                               std::string const &errorStr);
 
-  static void ticketCallback(FakeJni::Jvm const &vm, std::string const &ticket,
-                             int requestCode, int errorCode,
-                             std::string const &errorStr);
+    static void authFlowCallback(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, int status, std::string const &cid);
 
-  static void authFlowCallback(FakeJni::Jvm const &vm, FakeJni::JLong userPtr,
-                               int status, std::string const &cid);
+    static void signOutCallback();
 
-  static void signOutCallback();
+    static void invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
+                              std::shared_ptr<XboxLoginCallback> callback);
 
-  static void invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr,
-                            std::string const &ticket,
-                            std::shared_ptr<XboxLoginCallback> callback);
-
-  static void
-  invokeEventInitialization(FakeJni::Jvm const &vm, FakeJni::JLong userPtr,
-                            std::string const &ticket,
-                            std::shared_ptr<XboxLoginCallback> callback);
+    static void invokeEventInitialization(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
+                                          std::shared_ptr<XboxLoginCallback> callback);
 };
 
-class XboxLoginCallback : public FakeJni::JObject {
+class XboxLoginCallback : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop$XBLoginCallback")
 
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop$XBLoginCallback")
+    FakeJni::Jvm const &jvm;
+    FakeJni::JLong userPtr;
+    std::string cid, ticket;
 
-  FakeJni::Jvm const &jvm;
-  FakeJni::JLong userPtr;
-  std::string cid, ticket;
+    XboxLoginCallback(FakeJni::Jvm const &jvm, FakeJni::JLong userPtr, std::string cid, std::string ticket)
+        : jvm(jvm), userPtr(userPtr), cid(std::move(cid)), ticket(std::move(ticket))
+    {
+    }
 
-  XboxLoginCallback(FakeJni::Jvm const &jvm, FakeJni::JLong userPtr,
-                    std::string cid, std::string ticket)
-      : jvm(jvm), userPtr(userPtr), cid(std::move(cid)),
-        ticket(std::move(ticket)) {}
+    void onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount);
 
-  void onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount);
+    void onSuccess();
 
-  void onSuccess();
-
-  void onError(int httpStatus, int status,
-               std::shared_ptr<FakeJni::JString> message);
+    void onError(int httpStatus, int status, std::shared_ptr<FakeJni::JString> message);
 };
 
-class XboxLocalStorage : public FakeJni::JObject {
+class XboxLocalStorage : public FakeJni::JObject
+{
+   public:
+    DEFINE_CLASS_NAME("com/microsoft/xboxlive/LocalStorage")
 
-public:
-  DEFINE_CLASS_NAME("com/microsoft/xboxlive/LocalStorage")
-
-  static std::shared_ptr<FakeJni::JString>
-  getPath(std::shared_ptr<Context> context);
+    static std::shared_ptr<FakeJni::JString> getPath(std::shared_ptr<Context> context);
 };

--- a/src/jni/xbox_live.h
+++ b/src/jni/xbox_live.h
@@ -1,81 +1,96 @@
 #pragma once
 
-#include <fake-jni/fake-jni.h>
 #include "main_activity.h"
+#include <fake-jni/fake-jni.h>
 
 class XboxLoginCallback;
 
 class XboxInterop : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop")
+  DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop")
 
-    static std::shared_ptr<FakeJni::JString> getLocalStoragePath(std::shared_ptr<Context> context);
+  static std::shared_ptr<FakeJni::JString>
+  getLocalStoragePath(std::shared_ptr<Context> context);
 
-    static std::shared_ptr<FakeJni::JString> readConfigFile(std::shared_ptr<Context> context);
+  static std::shared_ptr<FakeJni::JString>
+  readConfigFile(std::shared_ptr<Context> context);
 
-    static std::shared_ptr<FakeJni::JString> getLocale();
+  static std::shared_ptr<FakeJni::JString> getLocale();
 
-    static void invokeMSA(std::shared_ptr<Context> context, FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
-                          std::shared_ptr<FakeJni::JString> cid);
+  static void invokeMSA(std::shared_ptr<Context> context,
+                        FakeJni::JInt requestCode, FakeJni::JBoolean isProd,
+                        std::shared_ptr<FakeJni::JString> cid);
 
-    static void invokeAuthFlow(FakeJni::JLong userPtr, std::shared_ptr<Activity> activity, FakeJni::JBoolean isProd,
-            std::shared_ptr<FakeJni::JString> signInText);
+  static void invokeAuthFlow(FakeJni::JLong userPtr,
+                             std::shared_ptr<Activity> activity,
+                             FakeJni::JBoolean isProd,
+                             std::shared_ptr<FakeJni::JString> signInText);
 
-    static void initCLL(std::shared_ptr<Context> arg0, std::shared_ptr<FakeJni::JString> arg1);
+  static void initCLL(std::shared_ptr<Context> arg0,
+                      std::shared_ptr<FakeJni::JString> arg1);
 
-    static void logCLL(std::shared_ptr<FakeJni::JString> ticket, std::shared_ptr<FakeJni::JString> name, std::shared_ptr<FakeJni::JString> data);
+  static void logCLL(std::shared_ptr<FakeJni::JString> ticket,
+                     std::shared_ptr<FakeJni::JString> name,
+                     std::shared_ptr<FakeJni::JString> data);
 
 private:
-    friend class XboxLoginCallback;
+  friend class XboxLoginCallback;
 
-    static constexpr int AUTH_FLOW_OK = 0;
-    static constexpr int AUTH_FLOW_CANCEL = 1;
-    static constexpr int AUTH_FLOW_ERROR = 2;
+  static constexpr int AUTH_FLOW_OK = 0;
+  static constexpr int AUTH_FLOW_CANCEL = 1;
+  static constexpr int AUTH_FLOW_ERROR = 2;
 
-    static constexpr int TICKET_OK = 0;
-    static constexpr int TICKET_UI_INTERACTION_REQUIRED = 1;
-    static constexpr int TICKET_UNKNOWN_ERROR = 3;
+  static constexpr int TICKET_OK = 0;
+  static constexpr int TICKET_UI_INTERACTION_REQUIRED = 1;
+  static constexpr int TICKET_UNKNOWN_ERROR = 3;
 
-    static void ticketCallback(FakeJni::Jvm const &vm, std::string const &ticket, int requestCode, int errorCode,
-            std::string const &errorStr);
+  static void ticketCallback(FakeJni::Jvm const &vm, std::string const &ticket,
+                             int requestCode, int errorCode,
+                             std::string const &errorStr);
 
-    static void authFlowCallback(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, int status, std::string const &cid);
+  static void authFlowCallback(FakeJni::Jvm const &vm, FakeJni::JLong userPtr,
+                               int status, std::string const &cid);
 
-    static void signOutCallback();
+  static void signOutCallback();
 
-    static void invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
-            std::shared_ptr<XboxLoginCallback> callback);
+  static void invokeXBLogin(FakeJni::Jvm const &vm, FakeJni::JLong userPtr,
+                            std::string const &ticket,
+                            std::shared_ptr<XboxLoginCallback> callback);
 
-    static void invokeEventInitialization(FakeJni::Jvm const &vm, FakeJni::JLong userPtr, std::string const &ticket,
-            std::shared_ptr<XboxLoginCallback> callback);
-
+  static void
+  invokeEventInitialization(FakeJni::Jvm const &vm, FakeJni::JLong userPtr,
+                            std::string const &ticket,
+                            std::shared_ptr<XboxLoginCallback> callback);
 };
 
 class XboxLoginCallback : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop$XBLoginCallback")
+  DEFINE_CLASS_NAME("com/microsoft/xbox/idp/interop/Interop$XBLoginCallback")
 
-    FakeJni::Jvm const &jvm;
-    FakeJni::JLong userPtr;
-    std::string cid, ticket;
+  FakeJni::Jvm const &jvm;
+  FakeJni::JLong userPtr;
+  std::string cid, ticket;
 
-    XboxLoginCallback(FakeJni::Jvm const &jvm, FakeJni::JLong userPtr, std::string cid, std::string ticket) :
-        jvm(jvm), userPtr(userPtr), cid(std::move(cid)), ticket(std::move(ticket)) {}
+  XboxLoginCallback(FakeJni::Jvm const &jvm, FakeJni::JLong userPtr,
+                    std::string cid, std::string ticket)
+      : jvm(jvm), userPtr(userPtr), cid(std::move(cid)),
+        ticket(std::move(ticket)) {}
 
-    void onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount);
+  void onLogin(FakeJni::JLong nativePtr, FakeJni::JBoolean newAccount);
 
-    void onSuccess();
+  void onSuccess();
 
-    void onError(int httpStatus, int status, std::shared_ptr<FakeJni::JString> message);
-
+  void onError(int httpStatus, int status,
+               std::shared_ptr<FakeJni::JString> message);
 };
 
 class XboxLocalStorage : public FakeJni::JObject {
 
 public:
-    DEFINE_CLASS_NAME("com/microsoft/xboxlive/LocalStorage")
+  DEFINE_CLASS_NAME("com/microsoft/xboxlive/LocalStorage")
 
-    static std::shared_ptr<FakeJni::JString> getPath(std::shared_ptr<Context> context);
+  static std::shared_ptr<FakeJni::JString>
+  getPath(std::shared_ptr<Context> context);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,3 @@
-#include "gl_core_patch.h"
-#include "hbui_patch.h"
-#include "jni/jni_support.h"
-#include "jni/store.h"
-#include "shader_error_patch.h"
-#include "splitscreen_patch.h"
-#include "window_callbacks.h"
-#include "xbox_live_helper.h"
 #include <argparser.h>
 #include <dlfcn.h>
 #include <game_window_manager.h>
@@ -15,11 +7,24 @@
 #include <mcpelauncher/minecraft_version.h>
 #include <mcpelauncher/mod_loader.h>
 #include <mcpelauncher/path_helper.h>
+#include "gl_core_patch.h"
+#include "hbui_patch.h"
+#include "jni/jni_support.h"
+#include "jni/store.h"
+#include "shader_error_patch.h"
+#include "splitscreen_patch.h"
+#include "window_callbacks.h"
+#include "xbox_live_helper.h"
 #if defined(__i386__) || defined(__x86_64__)
 #include "cpuid.h"
 #include "texel_aa_patch.h"
 #include "xbox_shutdown_patch.h"
 #endif
+#include <build_info.h>
+#include <libc_shim.h>
+#include <mcpelauncher/linker.h>
+#include <mcpelauncher/patch_utils.h>
+#include <minecraft/imported/android_symbols.h>
 #include "core_patches.h"
 #include "fake_assetmanager.h"
 #include "fake_egl.h"
@@ -28,11 +33,6 @@
 #include "main.h"
 #include "symbols.h"
 #include "thread_mover.h"
-#include <build_info.h>
-#include <libc_shim.h>
-#include <mcpelauncher/linker.h>
-#include <mcpelauncher/patch_utils.h>
-#include <minecraft/imported/android_symbols.h>
 // For getpid
 #include <unistd.h>
 
@@ -41,281 +41,260 @@ LauncherOptions options;
 
 void printVersionInfo();
 
-int main(int argc, char *argv[]) {
-  auto windowManager = GameWindowManager::getManager();
-  CrashHandler::registerCrashHandler();
-  MinecraftUtils::workaroundLocaleBug();
+int main(int argc, char *argv[])
+{
+    auto windowManager = GameWindowManager::getManager();
+    CrashHandler::registerCrashHandler();
+    MinecraftUtils::workaroundLocaleBug();
 
-  argparser::arg_parser p;
-  argparser::arg<bool> printVersion(p, "--version", "-v",
-                                    "Prints version info");
-  argparser::arg<std::string> gameDir(p, "--game-dir", "-dg",
-                                      "Directory with the game and assets");
-  argparser::arg<std::string> dataDir(p, "--data-dir", "-dd",
-                                      "Directory to use for the data");
-  argparser::arg<std::string> cacheDir(p, "--cache-dir", "-dc",
-                                       "Directory to use for cache");
-  argparser::arg<int> windowWidth(p, "--width", "-ww", "Window width", 720);
-  argparser::arg<int> windowHeight(p, "--height", "-wh", "Window height", 480);
-  argparser::arg<bool> disableFmod(p, "--disable-fmod", "-df",
-                                   "Disables usage of the FMod audio library");
-  argparser::arg<bool> forceEgl(p, "--force-opengles", "-fes",
-                                "Force creating an OpenGL ES surface instead "
-                                "of using the glcorepatch hack",
-                                !GLCorePatch::mustUseDesktopGL());
-  argparser::arg<bool> forceGooglePlayStoreUnverified(
-      p, "--force-google-play-store-unverified", "-fguv",
-      "Force telling the game that the license isn't verified, Google Play "
-      "Store version",
-      false);
-  argparser::arg<bool> forceAmazonAppStoreUnverified(
-      p, "--force-amazon-app-store-unverified", "-fauv",
-      "Force telling the game that the license isn't verified, Amazon App "
-      "Store version",
-      false);
-  argparser::arg<bool> texturePatch(
-      p, "--texture-patch", "-tp",
-      "Rewrite textures of the game for Minecraft 1.16.210 - 1.17.4X", false);
+    argparser::arg_parser p;
+    argparser::arg<bool> printVersion(p, "--version", "-v", "Prints version info");
+    argparser::arg<std::string> gameDir(p, "--game-dir", "-dg", "Directory with the game and assets");
+    argparser::arg<std::string> dataDir(p, "--data-dir", "-dd", "Directory to use for the data");
+    argparser::arg<std::string> cacheDir(p, "--cache-dir", "-dc", "Directory to use for cache");
+    argparser::arg<int> windowWidth(p, "--width", "-ww", "Window width", 720);
+    argparser::arg<int> windowHeight(p, "--height", "-wh", "Window height", 480);
+    argparser::arg<bool> disableFmod(p, "--disable-fmod", "-df", "Disables usage of the FMod audio library");
+    argparser::arg<bool> forceEgl(p, "--force-opengles", "-fes",
+                                  "Force creating an OpenGL ES surface instead "
+                                  "of using the glcorepatch hack",
+                                  !GLCorePatch::mustUseDesktopGL());
+    argparser::arg<bool> forceGooglePlayStoreUnverified(
+        p, "--force-google-play-store-unverified", "-fguv",
+        "Force telling the game that the license isn't verified, Google Play "
+        "Store version",
+        false);
+    argparser::arg<bool> forceAmazonAppStoreUnverified(
+        p, "--force-amazon-app-store-unverified", "-fauv",
+        "Force telling the game that the license isn't verified, Amazon App "
+        "Store version",
+        false);
+    argparser::arg<bool> texturePatch(p, "--texture-patch", "-tp",
+                                      "Rewrite textures of the game for Minecraft 1.16.210 - 1.17.4X", false);
 
-  if (!p.parse(argc, (const char **)argv))
-    return 1;
-  if (printVersion) {
-    printVersionInfo();
-    return 0;
-  }
-  options.windowWidth = windowWidth;
-  options.windowHeight = windowHeight;
-  options.graphicsApi =
-      forceEgl.get() ? GraphicsApi::OPENGL_ES2 : GraphicsApi::OPENGL;
+    if (!p.parse(argc, (const char **)argv))
+        return 1;
+    if (printVersion)
+    {
+        printVersionInfo();
+        return 0;
+    }
+    options.windowWidth = windowWidth;
+    options.windowHeight = windowHeight;
+    options.graphicsApi = forceEgl.get() ? GraphicsApi::OPENGL_ES2 : GraphicsApi::OPENGL;
 
-  FakeEGL::enableTexturePatch = texturePatch.get();
-  if (!gameDir.get().empty())
-    PathHelper::setGameDir(gameDir);
-  if (!dataDir.get().empty())
-    PathHelper::setDataDir(dataDir);
-  if (!cacheDir.get().empty())
-    PathHelper::setCacheDir(cacheDir);
+    FakeEGL::enableTexturePatch = texturePatch.get();
+    if (!gameDir.get().empty())
+        PathHelper::setGameDir(gameDir);
+    if (!dataDir.get().empty())
+        PathHelper::setDataDir(dataDir);
+    if (!cacheDir.get().empty())
+        PathHelper::setCacheDir(cacheDir);
 
-  Log::info("Launcher", "Version: client %s / manifest %s",
-            CLIENT_GIT_COMMIT_HASH, MANIFEST_GIT_COMMIT_HASH);
+    Log::info("Launcher", "Version: client %s / manifest %s", CLIENT_GIT_COMMIT_HASH, MANIFEST_GIT_COMMIT_HASH);
 #if defined(__i386__) || defined(__x86_64__)
-  {
-    CpuId cpuid;
-    Log::info("Launcher", "CPU: %s %s", cpuid.getManufacturer(),
-              cpuid.getBrandString());
-    Log::info("Launcher", "CPU supports SSSE3: %s",
-              cpuid.queryFeatureFlag(CpuId::FeatureFlag::SSSE3) ? "YES" : "NO");
-  }
+    {
+        CpuId cpuid;
+        Log::info("Launcher", "CPU: %s %s", cpuid.getManufacturer(), cpuid.getBrandString());
+        Log::info("Launcher", "CPU supports SSSE3: %s",
+                  cpuid.queryFeatureFlag(CpuId::FeatureFlag::SSSE3) ? "YES" : "NO");
+    }
 #endif
 
-  Log::trace("Launcher", "Loading hybris libraries");
-  linker::init();
-  // Fix saving to internal storage without write access to /data/*
-  // TODO research how this path is constructed
-  auto pid = getpid();
-  shim::from_android_data_dir = {
-      // Minecraft 1.16.210 or older
-      "/data/data/com.mojang.minecraftpe",
-      // Minecraft 1.16.210 or later, absolute path on linux (source build
-      // ubuntu 20.04)
-      std::string("/data/data") +
-          PathHelper::getParentDir(PathHelper::getAppDir()) + "/proc/" +
-          std::to_string(pid) + "/cmdline"};
-  if (argc >= 1 && argv != nullptr && argv[0] != nullptr &&
-      argv[0][0] != '\0') {
-    // Minecraft 1.16.210 or later, relative path on linux (source build
-    // ubuntu 20.04) or every path AppImage / flatpak
-    shim::from_android_data_dir.emplace_back(
-        argv[0][0] == '/' ? std::string("/data/data") + argv[0]
-                          : std::string("/data/data/") + argv[0]);
-  }
-  // Minecraft 1.16.210 or later, macOS
-  shim::from_android_data_dir.emplace_back("/data/data");
-  shim::to_android_data_dir = PathHelper::getPrimaryDataDirectory();
-  for (auto &&redir : shim::from_android_data_dir) {
-    Log::trace("REDIRECT", "%s to %s", redir.data(),
-               shim::to_android_data_dir.data());
-  }
-  StoreFactory::hasVerifiedGooglePlayStoreLicense =
-      !forceGooglePlayStoreUnverified.get();
-  StoreFactory::hasVerifiedAmazonAppStoreLicense =
-      !forceAmazonAppStoreUnverified.get();
-  auto libC = MinecraftUtils::getLibCSymbols();
-  ThreadMover::hookLibC(libC);
+    Log::trace("Launcher", "Loading hybris libraries");
+    linker::init();
+    // Fix saving to internal storage without write access to /data/*
+    // TODO research how this path is constructed
+    auto pid = getpid();
+    shim::from_android_data_dir = {// Minecraft 1.16.210 or older
+                                   "/data/data/com.mojang.minecraftpe",
+                                   // Minecraft 1.16.210 or later, absolute path on linux (source build
+                                   // ubuntu 20.04)
+                                   std::string("/data/data") + PathHelper::getParentDir(PathHelper::getAppDir()) +
+                                       "/proc/" + std::to_string(pid) + "/cmdline"};
+    if (argc >= 1 && argv != nullptr && argv[0] != nullptr && argv[0][0] != '\0')
+    {
+        // Minecraft 1.16.210 or later, relative path on linux (source build
+        // ubuntu 20.04) or every path AppImage / flatpak
+        shim::from_android_data_dir.emplace_back(argv[0][0] == '/' ? std::string("/data/data") + argv[0]
+                                                                   : std::string("/data/data/") + argv[0]);
+    }
+    // Minecraft 1.16.210 or later, macOS
+    shim::from_android_data_dir.emplace_back("/data/data");
+    shim::to_android_data_dir = PathHelper::getPrimaryDataDirectory();
+    for (auto &&redir : shim::from_android_data_dir)
+    {
+        Log::trace("REDIRECT", "%s to %s", redir.data(), shim::to_android_data_dir.data());
+    }
+    StoreFactory::hasVerifiedGooglePlayStoreLicense = !forceGooglePlayStoreUnverified.get();
+    StoreFactory::hasVerifiedAmazonAppStoreLicense = !forceAmazonAppStoreUnverified.get();
+    auto libC = MinecraftUtils::getLibCSymbols();
+    ThreadMover::hookLibC(libC);
 
 #ifdef USE_ARMHF_SUPPORT
-  linker::load_library("ld-android.so", {});
-  android_dlextinfo extinfo;
-  std::vector<mcpelauncher_hook_t> hooks;
-  for (auto &&entry : libC) {
-    hooks.emplace_back(mcpelauncher_hook_t{entry.first.data(), entry.second});
-  }
-  hooks.emplace_back(mcpelauncher_hook_t{nullptr, nullptr});
-  extinfo.flags = ANDROID_DLEXT_MCPELAUNCHER_HOOKS;
-  extinfo.mcpelauncher_hooks = hooks.data();
-  linker::dlopen_ext(
-      PathHelper::findDataFile("lib/" + std::string(PathHelper::getAbiDir()) +
-                               "/libc.so")
-          .c_str(),
-      0, &extinfo);
-  linker::dlopen(PathHelper::findDataFile(
-                     "lib/" + std::string(PathHelper::getAbiDir()) + "/libm.so")
-                     .c_str(),
-                 0);
+    linker::load_library("ld-android.so", {});
+    android_dlextinfo extinfo;
+    std::vector<mcpelauncher_hook_t> hooks;
+    for (auto &&entry : libC)
+    {
+        hooks.emplace_back(mcpelauncher_hook_t{entry.first.data(), entry.second});
+    }
+    hooks.emplace_back(mcpelauncher_hook_t{nullptr, nullptr});
+    extinfo.flags = ANDROID_DLEXT_MCPELAUNCHER_HOOKS;
+    extinfo.mcpelauncher_hooks = hooks.data();
+    linker::dlopen_ext(PathHelper::findDataFile("lib/" + std::string(PathHelper::getAbiDir()) + "/libc.so").c_str(), 0,
+                       &extinfo);
+    linker::dlopen(PathHelper::findDataFile("lib/" + std::string(PathHelper::getAbiDir()) + "/libm.so").c_str(), 0);
 #else
-  linker::load_library("libc.so", libC);
-  MinecraftUtils::loadLibM();
+    linker::load_library("libc.so", libC);
+    MinecraftUtils::loadLibM();
 #endif
-  MinecraftUtils::setupHybris();
-  try {
-    PathHelper::findGameFile(std::string("lib/") +
-                             MinecraftUtils::getLibraryAbi() +
-                             "/libminecraftpe.so");
-  } catch (std::exception &e) {
-    Log::error("LAUNCHER",
-               "Could not find the game, use the -dg flag to fix this error. "
-               "Original Error: %s",
-               e.what());
-    return 1;
-  }
-  linker::update_LD_LIBRARY_PATH(
-      PathHelper::findGameFile(std::string("lib/") +
-                               MinecraftUtils::getLibraryAbi())
-          .data());
-  if (!disableFmod) {
-    try {
-      MinecraftUtils::loadFMod();
-    } catch (std::exception &e) {
-      Log::warn("FMOD",
-                "Failed to load host libfmod: '%s', use experimental "
-                "pulseaudio backend if available",
-                e.what());
+    MinecraftUtils::setupHybris();
+    try
+    {
+        PathHelper::findGameFile(std::string("lib/") + MinecraftUtils::getLibraryAbi() + "/libminecraftpe.so");
     }
-  }
-  FakeEGL::setProcAddrFunction(
-      (void *(*)(const char *))windowManager->getProcAddrFunc());
-  FakeEGL::installLibrary();
+    catch (std::exception &e)
+    {
+        Log::error("LAUNCHER",
+                   "Could not find the game, use the -dg flag to fix this error. "
+                   "Original Error: %s",
+                   e.what());
+        return 1;
+    }
+    linker::update_LD_LIBRARY_PATH(
+        PathHelper::findGameFile(std::string("lib/") + MinecraftUtils::getLibraryAbi()).data());
+    if (!disableFmod)
+    {
+        try
+        {
+            MinecraftUtils::loadFMod();
+        }
+        catch (std::exception &e)
+        {
+            Log::warn("FMOD",
+                      "Failed to load host libfmod: '%s', use experimental "
+                      "pulseaudio backend if available",
+                      e.what());
+        }
+    }
+    FakeEGL::setProcAddrFunction((void *(*)(const char *))windowManager->getProcAddrFunc());
+    FakeEGL::installLibrary();
 
-  std::unordered_map<std::string, void *> android_syms;
-  struct ___data {
-    size_t arena;
+    std::unordered_map<std::string, void *> android_syms;
+    struct ___data
+    {
+        size_t arena;
 
-    size_t ordblks;
+        size_t ordblks;
 
-    size_t smblks;
+        size_t smblks;
 
-    size_t hblks;
+        size_t hblks;
 
-    size_t hblkhd;
+        size_t hblkhd;
 
-    size_t usmblks;
+        size_t usmblks;
 
-    size_t fsmblks;
+        size_t fsmblks;
 
-    size_t uordblks;
+        size_t uordblks;
 
-    size_t fordblks;
+        size_t fordblks;
 
-    size_t keepcost;
-  };
-  android_syms["mallinfo"] = (void *)+[](void *) -> ___data {
-    return {.ordblks = 8000000, .usmblks = 8000000, .fordblks = 8000000};
-  };
-  FakeAssetManager::initHybrisHooks(android_syms);
-  FakeInputQueue::initHybrisHooks(android_syms);
-  FakeLooper::initHybrisHooks(android_syms);
-  FakeWindow::initHybrisHooks(android_syms);
-  for (auto s = android_symbols; *s; s++) // stub missing symbols
-    android_syms.insert(
-        {*s, (void *)+[]() { Log::warn("Main", "Android stub called"); }});
-  linker::load_library("libandroid.so", android_syms);
-  MinecraftUtils::setupGLES2Symbols(fake_egl::eglGetProcAddress);
-  ModLoader modLoader;
-  modLoader.loadModsFromDirectory(
-      PathHelper::getPrimaryDataDirectory() + "mods/", true);
+        size_t keepcost;
+    };
+    android_syms["mallinfo"] =
+        (void *)+[](void *) -> ___data { return {.ordblks = 8000000, .usmblks = 8000000, .fordblks = 8000000}; };
+    FakeAssetManager::initHybrisHooks(android_syms);
+    FakeInputQueue::initHybrisHooks(android_syms);
+    FakeLooper::initHybrisHooks(android_syms);
+    FakeWindow::initHybrisHooks(android_syms);
+    for (auto s = android_symbols; *s; s++)  // stub missing symbols
+        android_syms.insert({*s, (void *)+[]() { Log::warn("Main", "Android stub called"); }});
+    linker::load_library("libandroid.so", android_syms);
+    MinecraftUtils::setupGLES2Symbols(fake_egl::eglGetProcAddress);
+    ModLoader modLoader;
+    modLoader.loadModsFromDirectory(PathHelper::getPrimaryDataDirectory() + "mods/", true);
 
-  Log::trace("Launcher", "Loading Minecraft library");
-  static void *handle = MinecraftUtils::loadMinecraftLib(
-      reinterpret_cast<void *>(&CorePatches::showMousePointer),
-      reinterpret_cast<void *>(&CorePatches::hideMousePointer));
-  if (!handle) {
-    Log::error("Launcher", "Failed to load Minecraft library, please reinstall "
-                           "or wait for an update to support the new release");
-    return 51;
-  }
-  Log::info("Launcher", "Loaded Minecraft library");
-  Log::debug("Launcher", "Minecraft is at offset 0x%" PRIXPTR,
-             (uintptr_t)MinecraftUtils::getLibraryBase(handle));
-  base = MinecraftUtils::getLibraryBase(handle);
+    Log::trace("Launcher", "Loading Minecraft library");
+    static void *handle = MinecraftUtils::loadMinecraftLib(reinterpret_cast<void *>(&CorePatches::showMousePointer),
+                                                           reinterpret_cast<void *>(&CorePatches::hideMousePointer));
+    if (!handle)
+    {
+        Log::error("Launcher",
+                   "Failed to load Minecraft library, please reinstall "
+                   "or wait for an update to support the new release");
+        return 51;
+    }
+    Log::info("Launcher", "Loaded Minecraft library");
+    Log::debug("Launcher", "Minecraft is at offset 0x%" PRIXPTR, (uintptr_t)MinecraftUtils::getLibraryBase(handle));
+    base = MinecraftUtils::getLibraryBase(handle);
 
-  modLoader.loadModsFromDirectory(PathHelper::getPrimaryDataDirectory() +
-                                  "mods/");
+    modLoader.loadModsFromDirectory(PathHelper::getPrimaryDataDirectory() + "mods/");
 
-  Log::info("Launcher", "Game version: %s",
-            MinecraftVersion::getString().c_str());
+    Log::info("Launcher", "Game version: %s", MinecraftVersion::getString().c_str());
 
-  Log::info("Launcher", "Applying patches");
-  SymbolsHelper::initSymbols(handle);
-  CorePatches::install(handle);
+    Log::info("Launcher", "Applying patches");
+    SymbolsHelper::initSymbols(handle);
+    CorePatches::install(handle);
 #ifdef __i386__
-  TexelAAPatch::install(handle);
-  HbuiPatch::install(handle);
-  SplitscreenPatch::install(handle);
-  ShaderErrorPatch::install(handle);
+    TexelAAPatch::install(handle);
+    HbuiPatch::install(handle);
+    SplitscreenPatch::install(handle);
+    ShaderErrorPatch::install(handle);
 #endif
-  if (options.graphicsApi == GraphicsApi::OPENGL) {
-    try {
-      GLCorePatch::install(handle);
-    } catch (const std::exception &ex) {
-      Log::error("GLCOREPATCH", "Failed to apply glcorepatch: %s", ex.what());
-      options.graphicsApi = GraphicsApi::OPENGL_ES2;
+    if (options.graphicsApi == GraphicsApi::OPENGL)
+    {
+        try
+        {
+            GLCorePatch::install(handle);
+        }
+        catch (const std::exception &ex)
+        {
+            Log::error("GLCOREPATCH", "Failed to apply glcorepatch: %s", ex.what());
+            options.graphicsApi = GraphicsApi::OPENGL_ES2;
+        }
     }
-  }
 
-  Log::info("Launcher", "Initializing JNI");
-  JniSupport support;
-  FakeLooper::setJniSupport(&support);
-  support.registerMinecraftNatives(
-      +[](const char *sym) { return linker::dlsym(handle, sym); });
-  std::thread startThread([&support]() {
-    support.startGame((ANativeActivity_createFunc *)linker::dlsym(
-                          handle, "ANativeActivity_onCreate"),
-                      linker::dlsym(handle, "stbi_load_from_memory"),
-                      linker::dlsym(handle, "stbi_image_free"));
-    linker::dlclose(handle);
-  });
-  startThread.detach();
+    Log::info("Launcher", "Initializing JNI");
+    JniSupport support;
+    FakeLooper::setJniSupport(&support);
+    support.registerMinecraftNatives(+[](const char *sym) { return linker::dlsym(handle, sym); });
+    std::thread startThread(
+        [&support]()
+        {
+            support.startGame((ANativeActivity_createFunc *)linker::dlsym(handle, "ANativeActivity_onCreate"),
+                              linker::dlsym(handle, "stbi_load_from_memory"), linker::dlsym(handle, "stbi_image_free"));
+            linker::dlclose(handle);
+        });
+    startThread.detach();
 
-  Log::info("Launcher", "Executing main thread");
-  ThreadMover::executeMainThread();
-  support.setLooperRunning(false);
+    Log::info("Launcher", "Executing main thread");
+    ThreadMover::executeMainThread();
+    support.setLooperRunning(false);
 
-  //    XboxLivePatches::workaroundShutdownFreeze(handle);
-  XboxLiveHelper::getInstance().shutdown();
-  // Workaround for XboxLive ShutdownFreeze
-  _Exit(0);
-  return 0;
+    //    XboxLivePatches::workaroundShutdownFreeze(handle);
+    XboxLiveHelper::getInstance().shutdown();
+    // Workaround for XboxLive ShutdownFreeze
+    _Exit(0);
+    return 0;
 }
 
-void printVersionInfo() {
-  printf("mcpelauncher-client %s / manifest %s\n", CLIENT_GIT_COMMIT_HASH,
-         MANIFEST_GIT_COMMIT_HASH);
+void printVersionInfo()
+{
+    printf("mcpelauncher-client %s / manifest %s\n", CLIENT_GIT_COMMIT_HASH, MANIFEST_GIT_COMMIT_HASH);
 #if defined(__i386__) || defined(__x86_64__)
-  CpuId cpuid;
-  printf("CPU: %s %s\n", cpuid.getManufacturer(), cpuid.getBrandString());
-  printf("SSSE3 support: %s\n",
-         cpuid.queryFeatureFlag(CpuId::FeatureFlag::SSSE3) ? "YES" : "NO");
+    CpuId cpuid;
+    printf("CPU: %s %s\n", cpuid.getManufacturer(), cpuid.getBrandString());
+    printf("SSSE3 support: %s\n", cpuid.queryFeatureFlag(CpuId::FeatureFlag::SSSE3) ? "YES" : "NO");
 #endif
-  auto windowManager = GameWindowManager::getManager();
-  GraphicsApi graphicsApi = GLCorePatch::mustUseDesktopGL()
-                                ? GraphicsApi::OPENGL
-                                : GraphicsApi::OPENGL_ES2;
-  auto window =
-      windowManager->createWindow("mcpelauncher", 32, 32, graphicsApi);
-  auto glGetString =
-      (const char *(*)(int))windowManager->getProcAddrFunc()("glGetString");
-  printf("GL Vendor: %s\n", glGetString(0x1F00 /* GL_VENDOR */));
-  printf("GL Renderer: %s\n", glGetString(0x1F01 /* GL_RENDERER */));
-  printf("GL Version: %s\n", glGetString(0x1F02 /* GL_VERSION */));
-  printf("MSA daemon path: %s\n", XboxLiveHelper::findMsa().c_str());
+    auto windowManager = GameWindowManager::getManager();
+    GraphicsApi graphicsApi = GLCorePatch::mustUseDesktopGL() ? GraphicsApi::OPENGL : GraphicsApi::OPENGL_ES2;
+    auto window = windowManager->createWindow("mcpelauncher", 32, 32, graphicsApi);
+    auto glGetString = (const char *(*)(int))windowManager->getProcAddrFunc()("glGetString");
+    printf("GL Vendor: %s\n", glGetString(0x1F00 /* GL_VENDOR */));
+    printf("GL Renderer: %s\n", glGetString(0x1F01 /* GL_RENDERER */));
+    printf("GL Version: %s\n", glGetString(0x1F02 /* GL_VERSION */));
+    printf("MSA daemon path: %s\n", XboxLiveHelper::findMsa().c_str());
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,8 +41,7 @@ LauncherOptions options;
 
 void printVersionInfo();
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     auto windowManager = GameWindowManager::getManager();
     CrashHandler::registerCrashHandler();
     MinecraftUtils::workaroundLocaleBug();
@@ -74,8 +73,7 @@ int main(int argc, char *argv[])
 
     if (!p.parse(argc, (const char **)argv))
         return 1;
-    if (printVersion)
-    {
+    if (printVersion) {
         printVersionInfo();
         return 0;
     }
@@ -112,8 +110,7 @@ int main(int argc, char *argv[])
                                    // ubuntu 20.04)
                                    std::string("/data/data") + PathHelper::getParentDir(PathHelper::getAppDir()) +
                                        "/proc/" + std::to_string(pid) + "/cmdline"};
-    if (argc >= 1 && argv != nullptr && argv[0] != nullptr && argv[0][0] != '\0')
-    {
+    if (argc >= 1 && argv != nullptr && argv[0] != nullptr && argv[0][0] != '\0') {
         // Minecraft 1.16.210 or later, relative path on linux (source build
         // ubuntu 20.04) or every path AppImage / flatpak
         shim::from_android_data_dir.emplace_back(argv[0][0] == '/' ? std::string("/data/data") + argv[0]
@@ -122,8 +119,7 @@ int main(int argc, char *argv[])
     // Minecraft 1.16.210 or later, macOS
     shim::from_android_data_dir.emplace_back("/data/data");
     shim::to_android_data_dir = PathHelper::getPrimaryDataDirectory();
-    for (auto &&redir : shim::from_android_data_dir)
-    {
+    for (auto &&redir : shim::from_android_data_dir) {
         Log::trace("REDIRECT", "%s to %s", redir.data(), shim::to_android_data_dir.data());
     }
     StoreFactory::hasVerifiedGooglePlayStoreLicense = !forceGooglePlayStoreUnverified.get();
@@ -135,8 +131,7 @@ int main(int argc, char *argv[])
     linker::load_library("ld-android.so", {});
     android_dlextinfo extinfo;
     std::vector<mcpelauncher_hook_t> hooks;
-    for (auto &&entry : libC)
-    {
+    for (auto &&entry : libC) {
         hooks.emplace_back(mcpelauncher_hook_t{entry.first.data(), entry.second});
     }
     hooks.emplace_back(mcpelauncher_hook_t{nullptr, nullptr});
@@ -150,12 +145,9 @@ int main(int argc, char *argv[])
     MinecraftUtils::loadLibM();
 #endif
     MinecraftUtils::setupHybris();
-    try
-    {
+    try {
         PathHelper::findGameFile(std::string("lib/") + MinecraftUtils::getLibraryAbi() + "/libminecraftpe.so");
-    }
-    catch (std::exception &e)
-    {
+    } catch (std::exception &e) {
         Log::error("LAUNCHER",
                    "Could not find the game, use the -dg flag to fix this error. "
                    "Original Error: %s",
@@ -164,14 +156,10 @@ int main(int argc, char *argv[])
     }
     linker::update_LD_LIBRARY_PATH(
         PathHelper::findGameFile(std::string("lib/") + MinecraftUtils::getLibraryAbi()).data());
-    if (!disableFmod)
-    {
-        try
-        {
+    if (!disableFmod) {
+        try {
             MinecraftUtils::loadFMod();
-        }
-        catch (std::exception &e)
-        {
+        } catch (std::exception &e) {
             Log::warn("FMOD",
                       "Failed to load host libfmod: '%s', use experimental "
                       "pulseaudio backend if available",
@@ -182,8 +170,7 @@ int main(int argc, char *argv[])
     FakeEGL::installLibrary();
 
     std::unordered_map<std::string, void *> android_syms;
-    struct ___data
-    {
+    struct ___data {
         size_t arena;
 
         size_t ordblks;
@@ -220,8 +207,7 @@ int main(int argc, char *argv[])
     Log::trace("Launcher", "Loading Minecraft library");
     static void *handle = MinecraftUtils::loadMinecraftLib(reinterpret_cast<void *>(&CorePatches::showMousePointer),
                                                            reinterpret_cast<void *>(&CorePatches::hideMousePointer));
-    if (!handle)
-    {
+    if (!handle) {
         Log::error("Launcher",
                    "Failed to load Minecraft library, please reinstall "
                    "or wait for an update to support the new release");
@@ -244,14 +230,10 @@ int main(int argc, char *argv[])
     SplitscreenPatch::install(handle);
     ShaderErrorPatch::install(handle);
 #endif
-    if (options.graphicsApi == GraphicsApi::OPENGL)
-    {
-        try
-        {
+    if (options.graphicsApi == GraphicsApi::OPENGL) {
+        try {
             GLCorePatch::install(handle);
-        }
-        catch (const std::exception &ex)
-        {
+        } catch (const std::exception &ex) {
             Log::error("GLCOREPATCH", "Failed to apply glcorepatch: %s", ex.what());
             options.graphicsApi = GraphicsApi::OPENGL_ES2;
         }
@@ -261,13 +243,11 @@ int main(int argc, char *argv[])
     JniSupport support;
     FakeLooper::setJniSupport(&support);
     support.registerMinecraftNatives(+[](const char *sym) { return linker::dlsym(handle, sym); });
-    std::thread startThread(
-        [&support]()
-        {
-            support.startGame((ANativeActivity_createFunc *)linker::dlsym(handle, "ANativeActivity_onCreate"),
-                              linker::dlsym(handle, "stbi_load_from_memory"), linker::dlsym(handle, "stbi_image_free"));
-            linker::dlclose(handle);
-        });
+    std::thread startThread([&support]() {
+        support.startGame((ANativeActivity_createFunc *)linker::dlsym(handle, "ANativeActivity_onCreate"),
+                          linker::dlsym(handle, "stbi_load_from_memory"), linker::dlsym(handle, "stbi_image_free"));
+        linker::dlclose(handle);
+    });
     startThread.detach();
 
     Log::info("Launcher", "Executing main thread");
@@ -281,8 +261,7 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-void printVersionInfo()
-{
+void printVersionInfo() {
     printf("mcpelauncher-client %s / manifest %s\n", CLIENT_GIT_COMMIT_HASH, MANIFEST_GIT_COMMIT_HASH);
 #if defined(__i386__) || defined(__x86_64__)
     CpuId cpuid;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,38 +1,38 @@
-#include <log.h>
-#include <dlfcn.h>
-#include <game_window_manager.h>
-#include <argparser.h>
-#include <mcpelauncher/minecraft_utils.h>
-#include <mcpelauncher/minecraft_version.h>
-#include <mcpelauncher/crash_handler.h>
-#include <mcpelauncher/path_helper.h>
-#include <mcpelauncher/mod_loader.h>
-#include "window_callbacks.h"
-#include "splitscreen_patch.h"
 #include "gl_core_patch.h"
-#include "xbox_live_helper.h"
-#include "shader_error_patch.h"
 #include "hbui_patch.h"
 #include "jni/jni_support.h"
 #include "jni/store.h"
+#include "shader_error_patch.h"
+#include "splitscreen_patch.h"
+#include "window_callbacks.h"
+#include "xbox_live_helper.h"
+#include <argparser.h>
+#include <dlfcn.h>
+#include <game_window_manager.h>
+#include <log.h>
+#include <mcpelauncher/crash_handler.h>
+#include <mcpelauncher/minecraft_utils.h>
+#include <mcpelauncher/minecraft_version.h>
+#include <mcpelauncher/mod_loader.h>
+#include <mcpelauncher/path_helper.h>
 #if defined(__i386__) || defined(__x86_64__)
 #include "cpuid.h"
 #include "texel_aa_patch.h"
 #include "xbox_shutdown_patch.h"
 #endif
-#include <build_info.h>
-#include <mcpelauncher/patch_utils.h>
-#include <libc_shim.h>
-#include <mcpelauncher/linker.h>
-#include <minecraft/imported/android_symbols.h>
-#include "main.h"
-#include "fake_looper.h"
-#include "fake_window.h"
+#include "core_patches.h"
 #include "fake_assetmanager.h"
 #include "fake_egl.h"
+#include "fake_looper.h"
+#include "fake_window.h"
+#include "main.h"
 #include "symbols.h"
-#include "core_patches.h"
 #include "thread_mover.h"
+#include <build_info.h>
+#include <libc_shim.h>
+#include <mcpelauncher/linker.h>
+#include <mcpelauncher/patch_utils.h>
+#include <minecraft/imported/android_symbols.h>
 // For getpid
 #include <unistd.h>
 
@@ -42,193 +42,280 @@ LauncherOptions options;
 void printVersionInfo();
 
 int main(int argc, char *argv[]) {
-    auto windowManager = GameWindowManager::getManager();
-    CrashHandler::registerCrashHandler();
-    MinecraftUtils::workaroundLocaleBug();
+  auto windowManager = GameWindowManager::getManager();
+  CrashHandler::registerCrashHandler();
+  MinecraftUtils::workaroundLocaleBug();
 
-    argparser::arg_parser p;
-    argparser::arg<bool> printVersion (p, "--version", "-v", "Prints version info");
-    argparser::arg<std::string> gameDir (p, "--game-dir", "-dg", "Directory with the game and assets");
-    argparser::arg<std::string> dataDir (p, "--data-dir", "-dd", "Directory to use for the data");
-    argparser::arg<std::string> cacheDir (p, "--cache-dir", "-dc", "Directory to use for cache");
-    argparser::arg<int> windowWidth (p, "--width", "-ww", "Window width", 720);
-    argparser::arg<int> windowHeight (p, "--height", "-wh", "Window height", 480);
-    argparser::arg<bool> disableFmod (p, "--disable-fmod", "-df", "Disables usage of the FMod audio library");
-    argparser::arg<bool> forceEgl (p, "--force-opengles", "-fes", "Force creating an OpenGL ES surface instead of using the glcorepatch hack", !GLCorePatch::mustUseDesktopGL());
-    argparser::arg<bool> forceGooglePlayStoreUnverified(p, "--force-google-play-store-unverified", "-fguv", "Force telling the game that the license isn't verified, Google Play Store version", false);
-    argparser::arg<bool> forceAmazonAppStoreUnverified(p, "--force-amazon-app-store-unverified", "-fauv", "Force telling the game that the license isn't verified, Amazon App Store version", false);
-    argparser::arg<bool> texturePatch(p, "--texture-patch", "-tp", "Rewrite textures of the game for Minecraft 1.16.210 - 1.17.4X", false);
+  argparser::arg_parser p;
+  argparser::arg<bool> printVersion(p, "--version", "-v",
+                                    "Prints version info");
+  argparser::arg<std::string> gameDir(p, "--game-dir", "-dg",
+                                      "Directory with the game and assets");
+  argparser::arg<std::string> dataDir(p, "--data-dir", "-dd",
+                                      "Directory to use for the data");
+  argparser::arg<std::string> cacheDir(p, "--cache-dir", "-dc",
+                                       "Directory to use for cache");
+  argparser::arg<int> windowWidth(p, "--width", "-ww", "Window width", 720);
+  argparser::arg<int> windowHeight(p, "--height", "-wh", "Window height", 480);
+  argparser::arg<bool> disableFmod(p, "--disable-fmod", "-df",
+                                   "Disables usage of the FMod audio library");
+  argparser::arg<bool> forceEgl(p, "--force-opengles", "-fes",
+                                "Force creating an OpenGL ES surface instead "
+                                "of using the glcorepatch hack",
+                                !GLCorePatch::mustUseDesktopGL());
+  argparser::arg<bool> forceGooglePlayStoreUnverified(
+      p, "--force-google-play-store-unverified", "-fguv",
+      "Force telling the game that the license isn't verified, Google Play "
+      "Store version",
+      false);
+  argparser::arg<bool> forceAmazonAppStoreUnverified(
+      p, "--force-amazon-app-store-unverified", "-fauv",
+      "Force telling the game that the license isn't verified, Amazon App "
+      "Store version",
+      false);
+  argparser::arg<bool> texturePatch(
+      p, "--texture-patch", "-tp",
+      "Rewrite textures of the game for Minecraft 1.16.210 - 1.17.4X", false);
 
-    if (!p.parse(argc, (const char**) argv))
-        return 1;
-    if (printVersion) {
-        printVersionInfo();
-        return 0;
-    }
-    options.windowWidth = windowWidth;
-    options.windowHeight = windowHeight;
-    options.graphicsApi = forceEgl.get() ? GraphicsApi::OPENGL_ES2 : GraphicsApi::OPENGL;
+  if (!p.parse(argc, (const char **)argv))
+    return 1;
+  if (printVersion) {
+    printVersionInfo();
+    return 0;
+  }
+  options.windowWidth = windowWidth;
+  options.windowHeight = windowHeight;
+  options.graphicsApi =
+      forceEgl.get() ? GraphicsApi::OPENGL_ES2 : GraphicsApi::OPENGL;
 
-    FakeEGL::enableTexturePatch = texturePatch.get();
-    if (!gameDir.get().empty())
-        PathHelper::setGameDir(gameDir);
-    if (!dataDir.get().empty())
-        PathHelper::setDataDir(dataDir);
-    if (!cacheDir.get().empty())
-        PathHelper::setCacheDir(cacheDir);
+  FakeEGL::enableTexturePatch = texturePatch.get();
+  if (!gameDir.get().empty())
+    PathHelper::setGameDir(gameDir);
+  if (!dataDir.get().empty())
+    PathHelper::setDataDir(dataDir);
+  if (!cacheDir.get().empty())
+    PathHelper::setCacheDir(cacheDir);
 
-    Log::info("Launcher", "Version: client %s / manifest %s", CLIENT_GIT_COMMIT_HASH, MANIFEST_GIT_COMMIT_HASH);
+  Log::info("Launcher", "Version: client %s / manifest %s",
+            CLIENT_GIT_COMMIT_HASH, MANIFEST_GIT_COMMIT_HASH);
 #if defined(__i386__) || defined(__x86_64__)
-    {
-        CpuId cpuid;
-        Log::info("Launcher", "CPU: %s %s", cpuid.getManufacturer(), cpuid.getBrandString());
-        Log::info("Launcher", "CPU supports SSSE3: %s",
-                cpuid.queryFeatureFlag(CpuId::FeatureFlag::SSSE3) ? "YES" : "NO");
-    }
+  {
+    CpuId cpuid;
+    Log::info("Launcher", "CPU: %s %s", cpuid.getManufacturer(),
+              cpuid.getBrandString());
+    Log::info("Launcher", "CPU supports SSSE3: %s",
+              cpuid.queryFeatureFlag(CpuId::FeatureFlag::SSSE3) ? "YES" : "NO");
+  }
 #endif
 
-    Log::trace("Launcher", "Loading hybris libraries");
-    linker::init();
-    // Fix saving to internal storage without write access to /data/*
-    // TODO research how this path is constructed
-    auto pid = getpid();
-    shim::from_android_data_dir = { 
-        // Minecraft 1.16.210 or older
-        "/data/data/com.mojang.minecraftpe", 
-        // Minecraft 1.16.210 or later, absolute path on linux (source build ubuntu 20.04)
-        std::string("/data/data") + PathHelper::getParentDir(PathHelper::getAppDir()) + "/proc/" + std::to_string(pid) + "/cmdline"
-    };
-    if(argc >= 1 && argv != nullptr && argv[0] != nullptr && argv[0][0] != '\0') {
-        // Minecraft 1.16.210 or later, relative path on linux (source build ubuntu 20.04) or every path AppImage / flatpak
-        shim::from_android_data_dir.emplace_back(argv[0][0] == '/' ? std::string("/data/data") + argv[0] : std::string("/data/data/") + argv[0]);
-    }
-    // Minecraft 1.16.210 or later, macOS
-    shim::from_android_data_dir.emplace_back("/data/data");
-    shim::to_android_data_dir = PathHelper::getPrimaryDataDirectory();
-    for(auto&& redir : shim::from_android_data_dir) {
-        Log::trace("REDIRECT", "%s to %s", redir.data(), shim::to_android_data_dir.data());
-    }
-    StoreFactory::hasVerifiedGooglePlayStoreLicense = !forceGooglePlayStoreUnverified.get();
-    StoreFactory::hasVerifiedAmazonAppStoreLicense = !forceAmazonAppStoreUnverified.get();
-    auto libC = MinecraftUtils::getLibCSymbols();
-    ThreadMover::hookLibC(libC);
+  Log::trace("Launcher", "Loading hybris libraries");
+  linker::init();
+  // Fix saving to internal storage without write access to /data/*
+  // TODO research how this path is constructed
+  auto pid = getpid();
+  shim::from_android_data_dir = {
+      // Minecraft 1.16.210 or older
+      "/data/data/com.mojang.minecraftpe",
+      // Minecraft 1.16.210 or later, absolute path on linux (source build
+      // ubuntu 20.04)
+      std::string("/data/data") +
+          PathHelper::getParentDir(PathHelper::getAppDir()) + "/proc/" +
+          std::to_string(pid) + "/cmdline"};
+  if (argc >= 1 && argv != nullptr && argv[0] != nullptr &&
+      argv[0][0] != '\0') {
+    // Minecraft 1.16.210 or later, relative path on linux (source build
+    // ubuntu 20.04) or every path AppImage / flatpak
+    shim::from_android_data_dir.emplace_back(
+        argv[0][0] == '/' ? std::string("/data/data") + argv[0]
+                          : std::string("/data/data/") + argv[0]);
+  }
+  // Minecraft 1.16.210 or later, macOS
+  shim::from_android_data_dir.emplace_back("/data/data");
+  shim::to_android_data_dir = PathHelper::getPrimaryDataDirectory();
+  for (auto &&redir : shim::from_android_data_dir) {
+    Log::trace("REDIRECT", "%s to %s", redir.data(),
+               shim::to_android_data_dir.data());
+  }
+  StoreFactory::hasVerifiedGooglePlayStoreLicense =
+      !forceGooglePlayStoreUnverified.get();
+  StoreFactory::hasVerifiedAmazonAppStoreLicense =
+      !forceAmazonAppStoreUnverified.get();
+  auto libC = MinecraftUtils::getLibCSymbols();
+  ThreadMover::hookLibC(libC);
 
 #ifdef USE_ARMHF_SUPPORT
-    linker::load_library("ld-android.so", {});
-    android_dlextinfo extinfo;
-    std::vector<mcpelauncher_hook_t> hooks;
-    for (auto && entry : libC) {
-        hooks.emplace_back(mcpelauncher_hook_t{ entry.first.data(), entry.second });
-    }
-    hooks.emplace_back(mcpelauncher_hook_t{ nullptr, nullptr });
-    extinfo.flags = ANDROID_DLEXT_MCPELAUNCHER_HOOKS;
-    extinfo.mcpelauncher_hooks = hooks.data();
-    linker::dlopen_ext(PathHelper::findDataFile("lib/" + std::string(PathHelper::getAbiDir()) + "/libc.so").c_str(), 0, &extinfo);
-    linker::dlopen(PathHelper::findDataFile("lib/" + std::string(PathHelper::getAbiDir()) + "/libm.so").c_str(), 0);
+  linker::load_library("ld-android.so", {});
+  android_dlextinfo extinfo;
+  std::vector<mcpelauncher_hook_t> hooks;
+  for (auto &&entry : libC) {
+    hooks.emplace_back(mcpelauncher_hook_t{entry.first.data(), entry.second});
+  }
+  hooks.emplace_back(mcpelauncher_hook_t{nullptr, nullptr});
+  extinfo.flags = ANDROID_DLEXT_MCPELAUNCHER_HOOKS;
+  extinfo.mcpelauncher_hooks = hooks.data();
+  linker::dlopen_ext(
+      PathHelper::findDataFile("lib/" + std::string(PathHelper::getAbiDir()) +
+                               "/libc.so")
+          .c_str(),
+      0, &extinfo);
+  linker::dlopen(PathHelper::findDataFile(
+                     "lib/" + std::string(PathHelper::getAbiDir()) + "/libm.so")
+                     .c_str(),
+                 0);
 #else
-    linker::load_library("libc.so", libC);
-    MinecraftUtils::loadLibM();
+  linker::load_library("libc.so", libC);
+  MinecraftUtils::loadLibM();
 #endif
-    MinecraftUtils::setupHybris();
+  MinecraftUtils::setupHybris();
+  try {
+    PathHelper::findGameFile(std::string("lib/") +
+                             MinecraftUtils::getLibraryAbi() +
+                             "/libminecraftpe.so");
+  } catch (std::exception &e) {
+    Log::error("LAUNCHER",
+               "Could not find the game, use the -dg flag to fix this error. "
+               "Original Error: %s",
+               e.what());
+    return 1;
+  }
+  linker::update_LD_LIBRARY_PATH(
+      PathHelper::findGameFile(std::string("lib/") +
+                               MinecraftUtils::getLibraryAbi())
+          .data());
+  if (!disableFmod) {
     try {
-        PathHelper::findGameFile(std::string("lib/") + MinecraftUtils::getLibraryAbi() + "/libminecraftpe.so");
-    } catch (std::exception& e) {
-        Log::error("LAUNCHER", "Could not find the game, use the -dg flag to fix this error. Original Error: %s", e.what());
-        return 1;
+      MinecraftUtils::loadFMod();
+    } catch (std::exception &e) {
+      Log::warn("FMOD",
+                "Failed to load host libfmod: '%s', use experimental "
+                "pulseaudio backend if available",
+                e.what());
     }
-    linker::update_LD_LIBRARY_PATH(PathHelper::findGameFile(std::string("lib/") + MinecraftUtils::getLibraryAbi()).data());
-    if (!disableFmod) {
-        try {
-            MinecraftUtils::loadFMod();
-        } catch (std::exception& e) {
-            Log::warn("FMOD", "Failed to load host libfmod: '%s', use experimental pulseaudio backend if available", e.what());
-        }
-    }
-    FakeEGL::setProcAddrFunction((void *(*)(const char*)) windowManager->getProcAddrFunc());
-    FakeEGL::installLibrary();
-    MinecraftUtils::setupGLES2Symbols(fake_egl::eglGetProcAddress);
+  }
+  FakeEGL::setProcAddrFunction(
+      (void *(*)(const char *))windowManager->getProcAddrFunc());
+  FakeEGL::installLibrary();
 
-    std::unordered_map<std::string, void*> android_syms;
-    FakeAssetManager::initHybrisHooks(android_syms);
-    FakeInputQueue::initHybrisHooks(android_syms);
-    FakeLooper::initHybrisHooks(android_syms);
-    FakeWindow::initHybrisHooks(android_syms);
-    for (auto s = android_symbols; *s; s++) // stub missing symbols
-        android_syms.insert({*s, (void *) +[]() { Log::warn("Main", "Android stub called"); }});
-    linker::load_library("libandroid.so", android_syms);
-    ModLoader modLoader;
-    modLoader.loadModsFromDirectory(PathHelper::getPrimaryDataDirectory() + "mods/", true);
+  std::unordered_map<std::string, void *> android_syms;
+  struct ___data {
+    size_t arena;
 
-    Log::trace("Launcher", "Loading Minecraft library");
-    static void* handle = MinecraftUtils::loadMinecraftLib(reinterpret_cast<void*>(&CorePatches::showMousePointer), reinterpret_cast<void*>(&CorePatches::hideMousePointer));
-    if (!handle) {
-      Log::error("Launcher", "Failed to load Minecraft library, please reinstall or wait for an update to support the new release");
-      return 51;
-    }
-    Log::info("Launcher", "Loaded Minecraft library");
-    Log::debug("Launcher", "Minecraft is at offset 0x%" PRIXPTR, (uintptr_t) MinecraftUtils::getLibraryBase(handle));
-    base = MinecraftUtils::getLibraryBase(handle);
+    size_t ordblks;
 
-    modLoader.loadModsFromDirectory(PathHelper::getPrimaryDataDirectory() + "mods/");
+    size_t smblks;
 
-    Log::info("Launcher", "Game version: %s", MinecraftVersion::getString().c_str());
+    size_t hblks;
 
-    Log::info("Launcher", "Applying patches");
-    SymbolsHelper::initSymbols(handle);
-    CorePatches::install(handle);
+    size_t hblkhd;
+
+    size_t usmblks;
+
+    size_t fsmblks;
+
+    size_t uordblks;
+
+    size_t fordblks;
+
+    size_t keepcost;
+  };
+  android_syms["mallinfo"] = (void *)+[](void *) -> ___data {
+    return {.ordblks = 8000000, .usmblks = 8000000, .fordblks = 8000000};
+  };
+  FakeAssetManager::initHybrisHooks(android_syms);
+  FakeInputQueue::initHybrisHooks(android_syms);
+  FakeLooper::initHybrisHooks(android_syms);
+  FakeWindow::initHybrisHooks(android_syms);
+  for (auto s = android_symbols; *s; s++) // stub missing symbols
+    android_syms.insert(
+        {*s, (void *)+[]() { Log::warn("Main", "Android stub called"); }});
+  linker::load_library("libandroid.so", android_syms);
+  MinecraftUtils::setupGLES2Symbols(fake_egl::eglGetProcAddress);
+  ModLoader modLoader;
+  modLoader.loadModsFromDirectory(
+      PathHelper::getPrimaryDataDirectory() + "mods/", true);
+
+  Log::trace("Launcher", "Loading Minecraft library");
+  static void *handle = MinecraftUtils::loadMinecraftLib(
+      reinterpret_cast<void *>(&CorePatches::showMousePointer),
+      reinterpret_cast<void *>(&CorePatches::hideMousePointer));
+  if (!handle) {
+    Log::error("Launcher", "Failed to load Minecraft library, please reinstall "
+                           "or wait for an update to support the new release");
+    return 51;
+  }
+  Log::info("Launcher", "Loaded Minecraft library");
+  Log::debug("Launcher", "Minecraft is at offset 0x%" PRIXPTR,
+             (uintptr_t)MinecraftUtils::getLibraryBase(handle));
+  base = MinecraftUtils::getLibraryBase(handle);
+
+  modLoader.loadModsFromDirectory(PathHelper::getPrimaryDataDirectory() +
+                                  "mods/");
+
+  Log::info("Launcher", "Game version: %s",
+            MinecraftVersion::getString().c_str());
+
+  Log::info("Launcher", "Applying patches");
+  SymbolsHelper::initSymbols(handle);
+  CorePatches::install(handle);
 #ifdef __i386__
-    TexelAAPatch::install(handle);
-    HbuiPatch::install(handle);
-    SplitscreenPatch::install(handle);
-    ShaderErrorPatch::install(handle);
+  TexelAAPatch::install(handle);
+  HbuiPatch::install(handle);
+  SplitscreenPatch::install(handle);
+  ShaderErrorPatch::install(handle);
 #endif
-    if (options.graphicsApi == GraphicsApi::OPENGL) {
-        try {
-            GLCorePatch::install(handle);
-        } catch (const std::exception& ex) {
-            Log::error("GLCOREPATCH", "Failed to apply glcorepatch: %s", ex.what());
-            options.graphicsApi = GraphicsApi::OPENGL_ES2;
-        }
+  if (options.graphicsApi == GraphicsApi::OPENGL) {
+    try {
+      GLCorePatch::install(handle);
+    } catch (const std::exception &ex) {
+      Log::error("GLCOREPATCH", "Failed to apply glcorepatch: %s", ex.what());
+      options.graphicsApi = GraphicsApi::OPENGL_ES2;
     }
+  }
 
-    Log::info("Launcher", "Initializing JNI");
-    JniSupport support;
-    FakeLooper::setJniSupport(&support);
-    support.registerMinecraftNatives(+[](const char *sym) {
-        return linker::dlsym(handle, sym);
-    });
-    std::thread startThread([&support]() {
-        support.startGame((ANativeActivity_createFunc *) linker::dlsym(handle, "ANativeActivity_onCreate"),
-            linker::dlsym(handle, "stbi_load_from_memory"),
-            linker::dlsym(handle, "stbi_image_free"));
-        linker::dlclose(handle);
-    });
-    startThread.detach();
+  Log::info("Launcher", "Initializing JNI");
+  JniSupport support;
+  FakeLooper::setJniSupport(&support);
+  support.registerMinecraftNatives(
+      +[](const char *sym) { return linker::dlsym(handle, sym); });
+  std::thread startThread([&support]() {
+    support.startGame((ANativeActivity_createFunc *)linker::dlsym(
+                          handle, "ANativeActivity_onCreate"),
+                      linker::dlsym(handle, "stbi_load_from_memory"),
+                      linker::dlsym(handle, "stbi_image_free"));
+    linker::dlclose(handle);
+  });
+  startThread.detach();
 
-    Log::info("Launcher", "Executing main thread");
-    ThreadMover::executeMainThread();
-    support.setLooperRunning(false);
+  Log::info("Launcher", "Executing main thread");
+  ThreadMover::executeMainThread();
+  support.setLooperRunning(false);
 
-//    XboxLivePatches::workaroundShutdownFreeze(handle);
-    XboxLiveHelper::getInstance().shutdown();
-    // Workaround for XboxLive ShutdownFreeze
-    _Exit(0);
-    return 0;
+  //    XboxLivePatches::workaroundShutdownFreeze(handle);
+  XboxLiveHelper::getInstance().shutdown();
+  // Workaround for XboxLive ShutdownFreeze
+  _Exit(0);
+  return 0;
 }
 
 void printVersionInfo() {
-    printf("mcpelauncher-client %s / manifest %s\n", CLIENT_GIT_COMMIT_HASH, MANIFEST_GIT_COMMIT_HASH);
+  printf("mcpelauncher-client %s / manifest %s\n", CLIENT_GIT_COMMIT_HASH,
+         MANIFEST_GIT_COMMIT_HASH);
 #if defined(__i386__) || defined(__x86_64__)
-    CpuId cpuid;
-    printf("CPU: %s %s\n", cpuid.getManufacturer(), cpuid.getBrandString());
-    printf("SSSE3 support: %s\n", cpuid.queryFeatureFlag(CpuId::FeatureFlag::SSSE3) ? "YES" : "NO");
+  CpuId cpuid;
+  printf("CPU: %s %s\n", cpuid.getManufacturer(), cpuid.getBrandString());
+  printf("SSSE3 support: %s\n",
+         cpuid.queryFeatureFlag(CpuId::FeatureFlag::SSSE3) ? "YES" : "NO");
 #endif
-    auto windowManager = GameWindowManager::getManager();
-    GraphicsApi graphicsApi = GLCorePatch::mustUseDesktopGL() ? GraphicsApi::OPENGL : GraphicsApi::OPENGL_ES2;
-    auto window = windowManager->createWindow("mcpelauncher", 32, 32, graphicsApi);
-    auto glGetString = (const char* (*)(int)) windowManager->getProcAddrFunc()("glGetString");
-    printf("GL Vendor: %s\n", glGetString(0x1F00 /* GL_VENDOR */));
-    printf("GL Renderer: %s\n", glGetString(0x1F01 /* GL_RENDERER */));
-    printf("GL Version: %s\n", glGetString(0x1F02 /* GL_VERSION */));
-    printf("MSA daemon path: %s\n", XboxLiveHelper::findMsa().c_str());
+  auto windowManager = GameWindowManager::getManager();
+  GraphicsApi graphicsApi = GLCorePatch::mustUseDesktopGL()
+                                ? GraphicsApi::OPENGL
+                                : GraphicsApi::OPENGL_ES2;
+  auto window =
+      windowManager->createWindow("mcpelauncher", 32, 32, graphicsApi);
+  auto glGetString =
+      (const char *(*)(int))windowManager->getProcAddrFunc()("glGetString");
+  printf("GL Vendor: %s\n", glGetString(0x1F00 /* GL_VENDOR */));
+  printf("GL Renderer: %s\n", glGetString(0x1F01 /* GL_RENDERER */));
+  printf("GL Version: %s\n", glGetString(0x1F02 /* GL_VERSION */));
+  printf("MSA daemon path: %s\n", XboxLiveHelper::findMsa().c_str());
 }

--- a/src/main.h
+++ b/src/main.h
@@ -2,8 +2,9 @@
 
 #include <game_window.h>
 
-struct LauncherOptions {
-  int windowWidth, windowHeight;
-  GraphicsApi graphicsApi;
+struct LauncherOptions
+{
+    int windowWidth, windowHeight;
+    GraphicsApi graphicsApi;
 };
 extern LauncherOptions options;

--- a/src/main.h
+++ b/src/main.h
@@ -2,8 +2,7 @@
 
 #include <game_window.h>
 
-struct LauncherOptions
-{
+struct LauncherOptions {
     int windowWidth, windowHeight;
     GraphicsApi graphicsApi;
 };

--- a/src/main.h
+++ b/src/main.h
@@ -3,7 +3,7 @@
 #include <game_window.h>
 
 struct LauncherOptions {
-    int windowWidth, windowHeight;
-    GraphicsApi graphicsApi;
+  int windowWidth, windowHeight;
+  GraphicsApi graphicsApi;
 };
 extern LauncherOptions options;

--- a/src/shader_error_patch.cpp
+++ b/src/shader_error_patch.cpp
@@ -3,67 +3,67 @@
 #include <log.h>
 #include <mcpelauncher/linker.h>
 
-void (*ShaderErrorPatch::glGetShaderiv)(unsigned int shader, int pname,
-                                        int *params);
-void (*ShaderErrorPatch::glGetShaderInfoLog)(unsigned int shader,
-                                             unsigned int maxLength,
-                                             unsigned int *length, char *log);
+void (*ShaderErrorPatch::glGetShaderiv)(unsigned int shader, int pname, int *params);
+void (*ShaderErrorPatch::glGetShaderInfoLog)(unsigned int shader, unsigned int maxLength, unsigned int *length,
+                                             char *log);
 void (*ShaderErrorPatch::glCompileShader)(unsigned int shader);
-void (*ShaderErrorPatch::glGetProgramiv)(unsigned int program, int pname,
-                                         int *params);
-void (*ShaderErrorPatch::glGetProgramInfoLog)(unsigned int program,
-                                              unsigned int maxLength,
-                                              unsigned int *length, char *log);
+void (*ShaderErrorPatch::glGetProgramiv)(unsigned int program, int pname, int *params);
+void (*ShaderErrorPatch::glGetProgramInfoLog)(unsigned int program, unsigned int maxLength, unsigned int *length,
+                                              char *log);
 void (*ShaderErrorPatch::glLinkProgram)(unsigned int program);
 
-void ShaderErrorPatch::install(void *handle) {
-  // TODO:
-  //    hybris_hook("glCompileShader", (void*) glCompileShaderHook);
-  //    hybris_hook("glLinkProgram", (void*) glLinkProgramHook);
+void ShaderErrorPatch::install(void *handle)
+{
+    // TODO:
+    //    hybris_hook("glCompileShader", (void*) glCompileShaderHook);
+    //    hybris_hook("glLinkProgram", (void*) glLinkProgramHook);
 }
 
-void ShaderErrorPatch::onGLContextCreated() {
-  auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
-  glCompileShader = (void (*)(unsigned int))getProcAddr("glCompileShader");
-  glLinkProgram = (void (*)(unsigned int))getProcAddr("glLinkProgram");
-  glGetShaderiv =
-      (void (*)(unsigned int, int, int *))getProcAddr("glGetShaderiv");
-  glGetShaderInfoLog = (void (*)(unsigned int, unsigned int, unsigned int *,
-                                 char *))getProcAddr("glGetShaderInfoLog");
-  glGetProgramiv =
-      (void (*)(unsigned int, int, int *))getProcAddr("glGetProgramiv");
-  glGetProgramInfoLog = (void (*)(unsigned int, unsigned int, unsigned int *,
-                                  char *))getProcAddr("glGetProgramInfoLog");
+void ShaderErrorPatch::onGLContextCreated()
+{
+    auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
+    glCompileShader = (void (*)(unsigned int))getProcAddr("glCompileShader");
+    glLinkProgram = (void (*)(unsigned int))getProcAddr("glLinkProgram");
+    glGetShaderiv = (void (*)(unsigned int, int, int *))getProcAddr("glGetShaderiv");
+    glGetShaderInfoLog =
+        (void (*)(unsigned int, unsigned int, unsigned int *, char *))getProcAddr("glGetShaderInfoLog");
+    glGetProgramiv = (void (*)(unsigned int, int, int *))getProcAddr("glGetProgramiv");
+    glGetProgramInfoLog =
+        (void (*)(unsigned int, unsigned int, unsigned int *, char *))getProcAddr("glGetProgramInfoLog");
 }
 
-void ShaderErrorPatch::glCompileShaderHook(unsigned int shader) {
-  glCompileShader(shader);
-  int status;
-  glGetShaderiv(shader, /* GL_COMPILE_STATUS */ 0x8B81, &status);
-  if (status != /* GL_TRUE */ 1) {
-    Log::error("Shader", "An error was detected when compiling a shader");
-    unsigned int infoLen;
-    glGetShaderiv(shader, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int *)&infoLen);
-    char *data = new char[infoLen];
-    glGetShaderInfoLog(shader, infoLen, &infoLen, data);
-    printf("%s\n",
-           data); // use printf because the logger may have a restricted length
-    fflush(stdout);
-  }
+void ShaderErrorPatch::glCompileShaderHook(unsigned int shader)
+{
+    glCompileShader(shader);
+    int status;
+    glGetShaderiv(shader, /* GL_COMPILE_STATUS */ 0x8B81, &status);
+    if (status != /* GL_TRUE */ 1)
+    {
+        Log::error("Shader", "An error was detected when compiling a shader");
+        unsigned int infoLen;
+        glGetShaderiv(shader, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int *)&infoLen);
+        char *data = new char[infoLen];
+        glGetShaderInfoLog(shader, infoLen, &infoLen, data);
+        printf("%s\n",
+               data);  // use printf because the logger may have a restricted length
+        fflush(stdout);
+    }
 }
 
-void ShaderErrorPatch::glLinkProgramHook(unsigned int program) {
-  glLinkProgram(program);
-  int status;
-  glGetProgramiv(program, /* GL_LINK_STATUS */ 0x8B82, &status);
-  if (status != /* GL_TRUE */ 1) {
-    Log::error("Shader", "An error was detected when linking a shader program");
-    unsigned int infoLen;
-    glGetProgramiv(program, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int *)&infoLen);
-    char *data = new char[infoLen];
-    glGetProgramInfoLog(program, infoLen, &infoLen, data);
-    printf("%s\n",
-           data); // use printf because the logger may have a restricted length
-    fflush(stdout);
-  }
+void ShaderErrorPatch::glLinkProgramHook(unsigned int program)
+{
+    glLinkProgram(program);
+    int status;
+    glGetProgramiv(program, /* GL_LINK_STATUS */ 0x8B82, &status);
+    if (status != /* GL_TRUE */ 1)
+    {
+        Log::error("Shader", "An error was detected when linking a shader program");
+        unsigned int infoLen;
+        glGetProgramiv(program, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int *)&infoLen);
+        char *data = new char[infoLen];
+        glGetProgramInfoLog(program, infoLen, &infoLen, data);
+        printf("%s\n",
+               data);  // use printf because the logger may have a restricted length
+        fflush(stdout);
+    }
 }

--- a/src/shader_error_patch.cpp
+++ b/src/shader_error_patch.cpp
@@ -12,15 +12,13 @@ void (*ShaderErrorPatch::glGetProgramInfoLog)(unsigned int program, unsigned int
                                               char *log);
 void (*ShaderErrorPatch::glLinkProgram)(unsigned int program);
 
-void ShaderErrorPatch::install(void *handle)
-{
+void ShaderErrorPatch::install(void *handle) {
     // TODO:
     //    hybris_hook("glCompileShader", (void*) glCompileShaderHook);
     //    hybris_hook("glLinkProgram", (void*) glLinkProgramHook);
 }
 
-void ShaderErrorPatch::onGLContextCreated()
-{
+void ShaderErrorPatch::onGLContextCreated() {
     auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
     glCompileShader = (void (*)(unsigned int))getProcAddr("glCompileShader");
     glLinkProgram = (void (*)(unsigned int))getProcAddr("glLinkProgram");
@@ -32,13 +30,11 @@ void ShaderErrorPatch::onGLContextCreated()
         (void (*)(unsigned int, unsigned int, unsigned int *, char *))getProcAddr("glGetProgramInfoLog");
 }
 
-void ShaderErrorPatch::glCompileShaderHook(unsigned int shader)
-{
+void ShaderErrorPatch::glCompileShaderHook(unsigned int shader) {
     glCompileShader(shader);
     int status;
     glGetShaderiv(shader, /* GL_COMPILE_STATUS */ 0x8B81, &status);
-    if (status != /* GL_TRUE */ 1)
-    {
+    if (status != /* GL_TRUE */ 1) {
         Log::error("Shader", "An error was detected when compiling a shader");
         unsigned int infoLen;
         glGetShaderiv(shader, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int *)&infoLen);
@@ -50,13 +46,11 @@ void ShaderErrorPatch::glCompileShaderHook(unsigned int shader)
     }
 }
 
-void ShaderErrorPatch::glLinkProgramHook(unsigned int program)
-{
+void ShaderErrorPatch::glLinkProgramHook(unsigned int program) {
     glLinkProgram(program);
     int status;
     glGetProgramiv(program, /* GL_LINK_STATUS */ 0x8B82, &status);
-    if (status != /* GL_TRUE */ 1)
-    {
+    if (status != /* GL_TRUE */ 1) {
         Log::error("Shader", "An error was detected when linking a shader program");
         unsigned int infoLen;
         glGetProgramiv(program, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int *)&infoLen);

--- a/src/shader_error_patch.cpp
+++ b/src/shader_error_patch.cpp
@@ -1,57 +1,69 @@
 #include "shader_error_patch.h"
-#include <mcpelauncher/linker.h>
 #include <game_window_manager.h>
 #include <log.h>
+#include <mcpelauncher/linker.h>
 
-void (*ShaderErrorPatch::glGetShaderiv)(unsigned int shader, int pname, int* params);
-void (*ShaderErrorPatch::glGetShaderInfoLog)(unsigned int shader, unsigned int maxLength, unsigned int* length, char* log);
+void (*ShaderErrorPatch::glGetShaderiv)(unsigned int shader, int pname,
+                                        int *params);
+void (*ShaderErrorPatch::glGetShaderInfoLog)(unsigned int shader,
+                                             unsigned int maxLength,
+                                             unsigned int *length, char *log);
 void (*ShaderErrorPatch::glCompileShader)(unsigned int shader);
-void (*ShaderErrorPatch::glGetProgramiv)(unsigned int program, int pname, int* params);
-void (*ShaderErrorPatch::glGetProgramInfoLog)(unsigned int program, unsigned int maxLength, unsigned int* length, char* log);
+void (*ShaderErrorPatch::glGetProgramiv)(unsigned int program, int pname,
+                                         int *params);
+void (*ShaderErrorPatch::glGetProgramInfoLog)(unsigned int program,
+                                              unsigned int maxLength,
+                                              unsigned int *length, char *log);
 void (*ShaderErrorPatch::glLinkProgram)(unsigned int program);
 
 void ShaderErrorPatch::install(void *handle) {
-    // TODO:
-//    hybris_hook("glCompileShader", (void*) glCompileShaderHook);
-//    hybris_hook("glLinkProgram", (void*) glLinkProgramHook);
+  // TODO:
+  //    hybris_hook("glCompileShader", (void*) glCompileShaderHook);
+  //    hybris_hook("glLinkProgram", (void*) glLinkProgramHook);
 }
 
 void ShaderErrorPatch::onGLContextCreated() {
-    auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
-    glCompileShader = (void (*)(unsigned int)) getProcAddr("glCompileShader");
-    glLinkProgram = (void (*)(unsigned int)) getProcAddr("glLinkProgram");
-    glGetShaderiv = (void (*)(unsigned int, int, int*)) getProcAddr("glGetShaderiv");
-    glGetShaderInfoLog = (void (*)(unsigned int, unsigned int, unsigned int*, char*)) getProcAddr("glGetShaderInfoLog");
-    glGetProgramiv = (void (*)(unsigned int, int, int*)) getProcAddr("glGetProgramiv");
-    glGetProgramInfoLog = (void (*)(unsigned int, unsigned int, unsigned int*, char*)) getProcAddr("glGetProgramInfoLog");
+  auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
+  glCompileShader = (void (*)(unsigned int))getProcAddr("glCompileShader");
+  glLinkProgram = (void (*)(unsigned int))getProcAddr("glLinkProgram");
+  glGetShaderiv =
+      (void (*)(unsigned int, int, int *))getProcAddr("glGetShaderiv");
+  glGetShaderInfoLog = (void (*)(unsigned int, unsigned int, unsigned int *,
+                                 char *))getProcAddr("glGetShaderInfoLog");
+  glGetProgramiv =
+      (void (*)(unsigned int, int, int *))getProcAddr("glGetProgramiv");
+  glGetProgramInfoLog = (void (*)(unsigned int, unsigned int, unsigned int *,
+                                  char *))getProcAddr("glGetProgramInfoLog");
 }
 
 void ShaderErrorPatch::glCompileShaderHook(unsigned int shader) {
-    glCompileShader(shader);
-    int status;
-    glGetShaderiv(shader, /* GL_COMPILE_STATUS */ 0x8B81, &status);
-    if (status != /* GL_TRUE */ 1) {
-        Log::error("Shader", "An error was detected when compiling a shader");
-        unsigned int infoLen;
-        glGetShaderiv(shader, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int*) &infoLen);
-        char* data = new char[infoLen];
-        glGetShaderInfoLog(shader, infoLen, &infoLen, data);
-        printf("%s\n", data); // use printf because the logger may have a restricted length
-        fflush(stdout);
-    }
+  glCompileShader(shader);
+  int status;
+  glGetShaderiv(shader, /* GL_COMPILE_STATUS */ 0x8B81, &status);
+  if (status != /* GL_TRUE */ 1) {
+    Log::error("Shader", "An error was detected when compiling a shader");
+    unsigned int infoLen;
+    glGetShaderiv(shader, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int *)&infoLen);
+    char *data = new char[infoLen];
+    glGetShaderInfoLog(shader, infoLen, &infoLen, data);
+    printf("%s\n",
+           data); // use printf because the logger may have a restricted length
+    fflush(stdout);
+  }
 }
 
 void ShaderErrorPatch::glLinkProgramHook(unsigned int program) {
-    glLinkProgram(program);
-    int status;
-    glGetProgramiv(program, /* GL_LINK_STATUS */ 0x8B82, &status);
-    if (status != /* GL_TRUE */ 1) {
-        Log::error("Shader", "An error was detected when linking a shader program");
-        unsigned int infoLen;
-        glGetProgramiv(program, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int*) &infoLen);
-        char* data = new char[infoLen];
-        glGetProgramInfoLog(program, infoLen, &infoLen, data);
-        printf("%s\n", data); // use printf because the logger may have a restricted length
-        fflush(stdout);
-    }
+  glLinkProgram(program);
+  int status;
+  glGetProgramiv(program, /* GL_LINK_STATUS */ 0x8B82, &status);
+  if (status != /* GL_TRUE */ 1) {
+    Log::error("Shader", "An error was detected when linking a shader program");
+    unsigned int infoLen;
+    glGetProgramiv(program, /* GL_INFO_LOG_LENGTH */ 0x8B84, (int *)&infoLen);
+    char *data = new char[infoLen];
+    glGetProgramInfoLog(program, infoLen, &infoLen, data);
+    printf("%s\n",
+           data); // use printf because the logger may have a restricted length
+    fflush(stdout);
+  }
 }

--- a/src/shader_error_patch.h
+++ b/src/shader_error_patch.h
@@ -5,21 +5,23 @@
 class ShaderErrorPatch {
 
 private:
-    static void (*glGetShaderiv)(unsigned int shader, int pname, int* params);
-    static void (*glGetShaderInfoLog)(unsigned int shader, unsigned int maxLength, unsigned int* length, char* log);
+  static void (*glGetShaderiv)(unsigned int shader, int pname, int *params);
+  static void (*glGetShaderInfoLog)(unsigned int shader, unsigned int maxLength,
+                                    unsigned int *length, char *log);
 
-    static void (*glCompileShader)(unsigned int shader);
-    static void glCompileShaderHook(unsigned int shader);
+  static void (*glCompileShader)(unsigned int shader);
+  static void glCompileShaderHook(unsigned int shader);
 
-    static void (*glGetProgramiv)(unsigned int program, int pname, int* params);
-    static void (*glGetProgramInfoLog)(unsigned int program, unsigned int maxLength, unsigned int* length, char* log);
+  static void (*glGetProgramiv)(unsigned int program, int pname, int *params);
+  static void (*glGetProgramInfoLog)(unsigned int program,
+                                     unsigned int maxLength,
+                                     unsigned int *length, char *log);
 
-    static void (*glLinkProgram)(unsigned int program);
-    static void glLinkProgramHook(unsigned int program);
+  static void (*glLinkProgram)(unsigned int program);
+  static void glLinkProgramHook(unsigned int program);
 
 public:
-    static void install(void* handle);
+  static void install(void *handle);
 
-    static void onGLContextCreated();
-
+  static void onGLContextCreated();
 };

--- a/src/shader_error_patch.h
+++ b/src/shader_error_patch.h
@@ -2,26 +2,23 @@
 
 #include <cstddef>
 
-class ShaderErrorPatch {
+class ShaderErrorPatch
+{
+   private:
+    static void (*glGetShaderiv)(unsigned int shader, int pname, int *params);
+    static void (*glGetShaderInfoLog)(unsigned int shader, unsigned int maxLength, unsigned int *length, char *log);
 
-private:
-  static void (*glGetShaderiv)(unsigned int shader, int pname, int *params);
-  static void (*glGetShaderInfoLog)(unsigned int shader, unsigned int maxLength,
-                                    unsigned int *length, char *log);
+    static void (*glCompileShader)(unsigned int shader);
+    static void glCompileShaderHook(unsigned int shader);
 
-  static void (*glCompileShader)(unsigned int shader);
-  static void glCompileShaderHook(unsigned int shader);
+    static void (*glGetProgramiv)(unsigned int program, int pname, int *params);
+    static void (*glGetProgramInfoLog)(unsigned int program, unsigned int maxLength, unsigned int *length, char *log);
 
-  static void (*glGetProgramiv)(unsigned int program, int pname, int *params);
-  static void (*glGetProgramInfoLog)(unsigned int program,
-                                     unsigned int maxLength,
-                                     unsigned int *length, char *log);
+    static void (*glLinkProgram)(unsigned int program);
+    static void glLinkProgramHook(unsigned int program);
 
-  static void (*glLinkProgram)(unsigned int program);
-  static void glLinkProgramHook(unsigned int program);
+   public:
+    static void install(void *handle);
 
-public:
-  static void install(void *handle);
-
-  static void onGLContextCreated();
+    static void onGLContextCreated();
 };

--- a/src/shader_error_patch.h
+++ b/src/shader_error_patch.h
@@ -2,8 +2,7 @@
 
 #include <cstddef>
 
-class ShaderErrorPatch
-{
+class ShaderErrorPatch {
    private:
     static void (*glGetShaderiv)(unsigned int shader, int pname, int *params);
     static void (*glGetShaderInfoLog)(unsigned int shader, unsigned int maxLength, unsigned int *length, char *log);

--- a/src/splitscreen_patch.cpp
+++ b/src/splitscreen_patch.cpp
@@ -8,22 +8,19 @@ void (*SplitscreenPatch::glScissor)(int x, int y, unsigned int w, unsigned int h
 
 void SplitscreenPatch::setScissorRect(void *, int x, int y, unsigned int w, unsigned int h) { glScissor(x, y, w, h); }
 
-void SplitscreenPatch::install(void *handle)
-{
+void SplitscreenPatch::install(void *handle) {
     void *ptr = linker::dlsym(handle,
                               "_ZN3mce13RenderContext26setViewportWithFul"
                               "lScissorERKNS_12ViewportInfoE");
     void *optr = (void *)((size_t)ptr + (0x85E - 0x740));
-    if (ptr == nullptr || *((unsigned char *)optr) != 0xE8)
-    {
+    if (ptr == nullptr || *((unsigned char *)optr) != 0xE8) {
         Log::error("SplitscreenPatch", "Not patching splitscreen - incompatible code");
         return;
     }
     PatchUtils::patchCallInstruction(optr, (void *)&setScissorRect, false);
 }
 
-void SplitscreenPatch::onGLContextCreated()
-{
+void SplitscreenPatch::onGLContextCreated() {
     auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
     glScissor = (void (*)(int, int, unsigned int, unsigned int))getProcAddr("glScissor");
 }

--- a/src/splitscreen_patch.cpp
+++ b/src/splitscreen_patch.cpp
@@ -4,28 +4,26 @@
 #include <mcpelauncher/linker.h>
 #include <mcpelauncher/patch_utils.h>
 
-void (*SplitscreenPatch::glScissor)(int x, int y, unsigned int w,
-                                    unsigned int h);
+void (*SplitscreenPatch::glScissor)(int x, int y, unsigned int w, unsigned int h);
 
-void SplitscreenPatch::setScissorRect(void *, int x, int y, unsigned int w,
-                                      unsigned int h) {
-  glScissor(x, y, w, h);
+void SplitscreenPatch::setScissorRect(void *, int x, int y, unsigned int w, unsigned int h) { glScissor(x, y, w, h); }
+
+void SplitscreenPatch::install(void *handle)
+{
+    void *ptr = linker::dlsym(handle,
+                              "_ZN3mce13RenderContext26setViewportWithFul"
+                              "lScissorERKNS_12ViewportInfoE");
+    void *optr = (void *)((size_t)ptr + (0x85E - 0x740));
+    if (ptr == nullptr || *((unsigned char *)optr) != 0xE8)
+    {
+        Log::error("SplitscreenPatch", "Not patching splitscreen - incompatible code");
+        return;
+    }
+    PatchUtils::patchCallInstruction(optr, (void *)&setScissorRect, false);
 }
 
-void SplitscreenPatch::install(void *handle) {
-  void *ptr = linker::dlsym(handle, "_ZN3mce13RenderContext26setViewportWithFul"
-                                    "lScissorERKNS_12ViewportInfoE");
-  void *optr = (void *)((size_t)ptr + (0x85E - 0x740));
-  if (ptr == nullptr || *((unsigned char *)optr) != 0xE8) {
-    Log::error("SplitscreenPatch",
-               "Not patching splitscreen - incompatible code");
-    return;
-  }
-  PatchUtils::patchCallInstruction(optr, (void *)&setScissorRect, false);
-}
-
-void SplitscreenPatch::onGLContextCreated() {
-  auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
-  glScissor =
-      (void (*)(int, int, unsigned int, unsigned int))getProcAddr("glScissor");
+void SplitscreenPatch::onGLContextCreated()
+{
+    auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
+    glScissor = (void (*)(int, int, unsigned int, unsigned int))getProcAddr("glScissor");
 }

--- a/src/splitscreen_patch.cpp
+++ b/src/splitscreen_patch.cpp
@@ -1,26 +1,31 @@
+#include "splitscreen_patch.h"
 #include <game_window_manager.h>
+#include <log.h>
 #include <mcpelauncher/linker.h>
 #include <mcpelauncher/patch_utils.h>
-#include <log.h>
-#include "splitscreen_patch.h"
 
-void (*SplitscreenPatch::glScissor)(int x, int y, unsigned int w, unsigned int h);
+void (*SplitscreenPatch::glScissor)(int x, int y, unsigned int w,
+                                    unsigned int h);
 
-void SplitscreenPatch::setScissorRect(void*, int x, int y, unsigned int w, unsigned int h) {
-    glScissor(x, y, w, h);
+void SplitscreenPatch::setScissorRect(void *, int x, int y, unsigned int w,
+                                      unsigned int h) {
+  glScissor(x, y, w, h);
 }
 
-void SplitscreenPatch::install(void* handle) {
-    void* ptr = linker::dlsym(handle, "_ZN3mce13RenderContext26setViewportWithFullScissorERKNS_12ViewportInfoE");
-    void* optr = (void*) ((size_t) ptr + (0x85E - 0x740));
-    if (ptr == nullptr || *((unsigned char*) optr) != 0xE8) {
-        Log::error("SplitscreenPatch", "Not patching splitscreen - incompatible code");
-        return;
-    }
-    PatchUtils::patchCallInstruction(optr, (void*) &setScissorRect, false);
+void SplitscreenPatch::install(void *handle) {
+  void *ptr = linker::dlsym(handle, "_ZN3mce13RenderContext26setViewportWithFul"
+                                    "lScissorERKNS_12ViewportInfoE");
+  void *optr = (void *)((size_t)ptr + (0x85E - 0x740));
+  if (ptr == nullptr || *((unsigned char *)optr) != 0xE8) {
+    Log::error("SplitscreenPatch",
+               "Not patching splitscreen - incompatible code");
+    return;
+  }
+  PatchUtils::patchCallInstruction(optr, (void *)&setScissorRect, false);
 }
 
 void SplitscreenPatch::onGLContextCreated() {
-    auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
-    glScissor = (void (*)(int, int, unsigned int, unsigned int)) getProcAddr("glScissor");
+  auto getProcAddr = GameWindowManager::getManager()->getProcAddrFunc();
+  glScissor =
+      (void (*)(int, int, unsigned int, unsigned int))getProcAddr("glScissor");
 }

--- a/src/splitscreen_patch.h
+++ b/src/splitscreen_patch.h
@@ -1,15 +1,14 @@
 #pragma once
 
-class SplitscreenPatch {
+class SplitscreenPatch
+{
+   private:
+    static void (*glScissor)(int x, int y, unsigned int w, unsigned int h);
 
-private:
-  static void (*glScissor)(int x, int y, unsigned int w, unsigned int h);
+    static void setScissorRect(void *, int x, int y, unsigned int w, unsigned int h);
 
-  static void setScissorRect(void *, int x, int y, unsigned int w,
-                             unsigned int h);
+   public:
+    static void install(void *handle);
 
-public:
-  static void install(void *handle);
-
-  static void onGLContextCreated();
+    static void onGLContextCreated();
 };

--- a/src/splitscreen_patch.h
+++ b/src/splitscreen_patch.h
@@ -3,13 +3,13 @@
 class SplitscreenPatch {
 
 private:
-    static void (*glScissor)(int x, int y, unsigned int w, unsigned int h);
+  static void (*glScissor)(int x, int y, unsigned int w, unsigned int h);
 
-    static void setScissorRect(void*, int x, int y, unsigned int w, unsigned int h);
+  static void setScissorRect(void *, int x, int y, unsigned int w,
+                             unsigned int h);
 
 public:
-    static void install(void* handle);
+  static void install(void *handle);
 
-    static void onGLContextCreated();
-
+  static void onGLContextCreated();
 };

--- a/src/splitscreen_patch.h
+++ b/src/splitscreen_patch.h
@@ -1,7 +1,6 @@
 #pragma once
 
-class SplitscreenPatch
-{
+class SplitscreenPatch {
    private:
     static void (*glScissor)(int x, int y, unsigned int w, unsigned int h);
 

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -7,13 +7,11 @@ int *Keyboard::_states;
 std::vector<Keyboard::InputEvent> *Keyboard::_inputs;
 int *Keyboard::_gameControllerId;
 
-void SymbolsHelper::initSymbols(void *handle) {
-  Mouse::feed = (void (*)(char, char, short, short, short, short))linker::dlsym(
-      handle, "_ZN5Mouse4feedEccssss");
+void SymbolsHelper::initSymbols(void *handle)
+{
+    Mouse::feed = (void (*)(char, char, short, short, short, short))linker::dlsym(handle, "_ZN5Mouse4feedEccssss");
 
-  Keyboard::_states = (int *)linker::dlsym(handle, "_ZN8Keyboard7_statesE");
-  Keyboard::_inputs = (std::vector<Keyboard::InputEvent> *)linker::dlsym(
-      handle, "_ZN8Keyboard7_inputsE");
-  Keyboard::_gameControllerId =
-      (int *)linker::dlsym(handle, "_ZN8Keyboard17_gameControllerIdE");
+    Keyboard::_states = (int *)linker::dlsym(handle, "_ZN8Keyboard7_statesE");
+    Keyboard::_inputs = (std::vector<Keyboard::InputEvent> *)linker::dlsym(handle, "_ZN8Keyboard7_inputsE");
+    Keyboard::_gameControllerId = (int *)linker::dlsym(handle, "_ZN8Keyboard17_gameControllerIdE");
 }

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -1,5 +1,5 @@
-#include <mcpelauncher/linker.h>
 #include "symbols.h"
+#include <mcpelauncher/linker.h>
 
 void (*Mouse::feed)(char, char, short, short, short, short);
 
@@ -8,9 +8,12 @@ std::vector<Keyboard::InputEvent> *Keyboard::_inputs;
 int *Keyboard::_gameControllerId;
 
 void SymbolsHelper::initSymbols(void *handle) {
-    Mouse::feed = (void (*)(char, char, short, short, short, short)) linker::dlsym(handle, "_ZN5Mouse4feedEccssss");
+  Mouse::feed = (void (*)(char, char, short, short, short, short))linker::dlsym(
+      handle, "_ZN5Mouse4feedEccssss");
 
-    Keyboard::_states = (int *) linker::dlsym(handle, "_ZN8Keyboard7_statesE");
-    Keyboard::_inputs = (std::vector<Keyboard::InputEvent> *) linker::dlsym(handle, "_ZN8Keyboard7_inputsE");
-    Keyboard::_gameControllerId = (int *) linker::dlsym(handle, "_ZN8Keyboard17_gameControllerIdE");
+  Keyboard::_states = (int *)linker::dlsym(handle, "_ZN8Keyboard7_statesE");
+  Keyboard::_inputs = (std::vector<Keyboard::InputEvent> *)linker::dlsym(
+      handle, "_ZN8Keyboard7_inputsE");
+  Keyboard::_gameControllerId =
+      (int *)linker::dlsym(handle, "_ZN8Keyboard17_gameControllerIdE");
 }

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -7,8 +7,7 @@ int *Keyboard::_states;
 std::vector<Keyboard::InputEvent> *Keyboard::_inputs;
 int *Keyboard::_gameControllerId;
 
-void SymbolsHelper::initSymbols(void *handle)
-{
+void SymbolsHelper::initSymbols(void *handle) {
     Mouse::feed = (void (*)(char, char, short, short, short, short))linker::dlsym(handle, "_ZN5Mouse4feedEccssss");
 
     Keyboard::_states = (int *)linker::dlsym(handle, "_ZN8Keyboard7_statesE");

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -3,21 +3,23 @@
 #include <vector>
 
 struct Mouse {
-    static void (*feed)(char, char, short, short, short, short);
+  static void (*feed)(char, char, short, short, short, short);
 };
 
 struct Keyboard {
-    struct InputEvent {
-        int event;
-        unsigned int key; // it's actually an unsigned char, but the asm code does suspicious stuff with the padding so use an int so it gets zeroed out
-        int controllerId;
-    };
+  struct InputEvent {
+    int event;
+    unsigned int
+        key; // it's actually an unsigned char, but the asm code does suspicious
+             // stuff with the padding so use an int so it gets zeroed out
+    int controllerId;
+  };
 
-    static int* _states;
-    static std::vector<Keyboard::InputEvent>* _inputs;
-    static int* _gameControllerId;
+  static int *_states;
+  static std::vector<Keyboard::InputEvent> *_inputs;
+  static int *_gameControllerId;
 };
 
 struct SymbolsHelper {
-    static void initSymbols(void *handle);
+  static void initSymbols(void *handle);
 };

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -2,15 +2,12 @@
 
 #include <vector>
 
-struct Mouse
-{
+struct Mouse {
     static void (*feed)(char, char, short, short, short, short);
 };
 
-struct Keyboard
-{
-    struct InputEvent
-    {
+struct Keyboard {
+    struct InputEvent {
         int event;
         unsigned int key;  // it's actually an unsigned char, but the asm code does suspicious
                            // stuff with the padding so use an int so it gets zeroed out
@@ -22,7 +19,6 @@ struct Keyboard
     static int *_gameControllerId;
 };
 
-struct SymbolsHelper
-{
+struct SymbolsHelper {
     static void initSymbols(void *handle);
 };

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -2,24 +2,27 @@
 
 #include <vector>
 
-struct Mouse {
-  static void (*feed)(char, char, short, short, short, short);
+struct Mouse
+{
+    static void (*feed)(char, char, short, short, short, short);
 };
 
-struct Keyboard {
-  struct InputEvent {
-    int event;
-    unsigned int
-        key; // it's actually an unsigned char, but the asm code does suspicious
-             // stuff with the padding so use an int so it gets zeroed out
-    int controllerId;
-  };
+struct Keyboard
+{
+    struct InputEvent
+    {
+        int event;
+        unsigned int key;  // it's actually an unsigned char, but the asm code does suspicious
+                           // stuff with the padding so use an int so it gets zeroed out
+        int controllerId;
+    };
 
-  static int *_states;
-  static std::vector<Keyboard::InputEvent> *_inputs;
-  static int *_gameControllerId;
+    static int *_states;
+    static std::vector<Keyboard::InputEvent> *_inputs;
+    static int *_gameControllerId;
 };
 
-struct SymbolsHelper {
-  static void initSymbols(void *handle);
+struct SymbolsHelper
+{
+    static void initSymbols(void *handle);
 };

--- a/src/texel_aa_patch.cpp
+++ b/src/texel_aa_patch.cpp
@@ -1,25 +1,29 @@
 #include "texel_aa_patch.h"
 
+#include <log.h>
 #include <mcpelauncher/linker.h>
 #include <memory.h>
-#include <log.h>
 
 void TexelAAPatch::install(void *handle) {
-    auto ptr = (unsigned char*) linker::dlsym(handle, "_ZN31GeneralSettingsScreenController28_registerControllerCallbacksEv");
-    if (ptr == nullptr)
+  auto ptr = (unsigned char *)linker::dlsym(
+      handle,
+      "_ZN31GeneralSettingsScreenController28_registerControllerCallbacksEv");
+  if (ptr == nullptr)
+    return;
+  int hash = 0x96F031FF;
+  for (int i = 0; i < 0x4000; i++) {
+    if ((int &)ptr[i + 4] == hash && ptr[i] == 0xC7 && ptr[i + 1] == 0x44 &&
+        ptr[i + 2] == 0x24) {
+      Log::trace("TexelAAPatch", "Found patch at @%x", i);
+      if (ptr[i + 0x24] != 0x8D && ptr[i + 0x24 + 1] != 0x83) {
+        Log::trace("TexelAAPatch",
+                   "LDR instruction invalid; patch incompatible");
         return;
-    int hash = 0x96F031FF;
-    for (int i = 0; i < 0x4000; i++) {
-        if ((int&) ptr[i + 4] == hash && ptr[i] == 0xC7 && ptr[i + 1] == 0x44 && ptr[i + 2] == 0x24) {
-            Log::trace("TexelAAPatch", "Found patch at @%x", i);
-            if (ptr[i + 0x24] != 0x8D && ptr[i + 0x24 + 1] != 0x83) {
-                Log::trace("TexelAAPatch", "LDR instruction invalid; patch incompatible");
-                return;
-            }
-            ptr[i + 0x24] = 0xB8; // mov eax, lamda_addr
-            (void*&) ptr[i + 0x24 + 1] = (void*) +[] { return true; };
-            ptr[i + 0x24 + 5] = 0x90; // nop
-            break;
-        }
+      }
+      ptr[i + 0x24] = 0xB8; // mov eax, lamda_addr
+      (void *&)ptr[i + 0x24 + 1] = (void *)+[] { return true; };
+      ptr[i + 0x24 + 5] = 0x90; // nop
+      break;
     }
+  }
 }

--- a/src/texel_aa_patch.cpp
+++ b/src/texel_aa_patch.cpp
@@ -4,20 +4,16 @@
 #include <mcpelauncher/linker.h>
 #include <memory.h>
 
-void TexelAAPatch::install(void *handle)
-{
+void TexelAAPatch::install(void *handle) {
     auto ptr =
         (unsigned char *)linker::dlsym(handle, "_ZN31GeneralSettingsScreenController28_registerControllerCallbacksEv");
     if (ptr == nullptr)
         return;
     int hash = 0x96F031FF;
-    for (int i = 0; i < 0x4000; i++)
-    {
-        if ((int &)ptr[i + 4] == hash && ptr[i] == 0xC7 && ptr[i + 1] == 0x44 && ptr[i + 2] == 0x24)
-        {
+    for (int i = 0; i < 0x4000; i++) {
+        if ((int &)ptr[i + 4] == hash && ptr[i] == 0xC7 && ptr[i + 1] == 0x44 && ptr[i + 2] == 0x24) {
             Log::trace("TexelAAPatch", "Found patch at @%x", i);
-            if (ptr[i + 0x24] != 0x8D && ptr[i + 0x24 + 1] != 0x83)
-            {
+            if (ptr[i + 0x24] != 0x8D && ptr[i + 0x24 + 1] != 0x83) {
                 Log::trace("TexelAAPatch", "LDR instruction invalid; patch incompatible");
                 return;
             }

--- a/src/texel_aa_patch.cpp
+++ b/src/texel_aa_patch.cpp
@@ -4,26 +4,27 @@
 #include <mcpelauncher/linker.h>
 #include <memory.h>
 
-void TexelAAPatch::install(void *handle) {
-  auto ptr = (unsigned char *)linker::dlsym(
-      handle,
-      "_ZN31GeneralSettingsScreenController28_registerControllerCallbacksEv");
-  if (ptr == nullptr)
-    return;
-  int hash = 0x96F031FF;
-  for (int i = 0; i < 0x4000; i++) {
-    if ((int &)ptr[i + 4] == hash && ptr[i] == 0xC7 && ptr[i + 1] == 0x44 &&
-        ptr[i + 2] == 0x24) {
-      Log::trace("TexelAAPatch", "Found patch at @%x", i);
-      if (ptr[i + 0x24] != 0x8D && ptr[i + 0x24 + 1] != 0x83) {
-        Log::trace("TexelAAPatch",
-                   "LDR instruction invalid; patch incompatible");
+void TexelAAPatch::install(void *handle)
+{
+    auto ptr =
+        (unsigned char *)linker::dlsym(handle, "_ZN31GeneralSettingsScreenController28_registerControllerCallbacksEv");
+    if (ptr == nullptr)
         return;
-      }
-      ptr[i + 0x24] = 0xB8; // mov eax, lamda_addr
-      (void *&)ptr[i + 0x24 + 1] = (void *)+[] { return true; };
-      ptr[i + 0x24 + 5] = 0x90; // nop
-      break;
+    int hash = 0x96F031FF;
+    for (int i = 0; i < 0x4000; i++)
+    {
+        if ((int &)ptr[i + 4] == hash && ptr[i] == 0xC7 && ptr[i + 1] == 0x44 && ptr[i + 2] == 0x24)
+        {
+            Log::trace("TexelAAPatch", "Found patch at @%x", i);
+            if (ptr[i + 0x24] != 0x8D && ptr[i + 0x24 + 1] != 0x83)
+            {
+                Log::trace("TexelAAPatch", "LDR instruction invalid; patch incompatible");
+                return;
+            }
+            ptr[i + 0x24] = 0xB8;  // mov eax, lamda_addr
+            (void *&)ptr[i + 0x24 + 1] = (void *)+[] { return true; };
+            ptr[i + 0x24 + 5] = 0x90;  // nop
+            break;
+        }
     }
-  }
 }

--- a/src/texel_aa_patch.h
+++ b/src/texel_aa_patch.h
@@ -3,6 +3,5 @@
 class TexelAAPatch {
 
 public:
-    static void install(void* handle);
-
+  static void install(void *handle);
 };

--- a/src/texel_aa_patch.h
+++ b/src/texel_aa_patch.h
@@ -1,7 +1,6 @@
 #pragma once
 
-class TexelAAPatch
-{
+class TexelAAPatch {
    public:
     static void install(void *handle);
 };

--- a/src/texel_aa_patch.h
+++ b/src/texel_aa_patch.h
@@ -1,7 +1,7 @@
 #pragma once
 
-class TexelAAPatch {
-
-public:
-  static void install(void *handle);
+class TexelAAPatch
+{
+   public:
+    static void install(void *handle);
 };

--- a/src/text_input_handler.cpp
+++ b/src/text_input_handler.cpp
@@ -2,94 +2,102 @@
 #include "utf8_util.h"
 
 void TextInputHandler::enable(std::string text, bool multiline) {
-    enabled = true;
-    this->multiline = multiline;
-    update(std::move(text));
+  enabled = true;
+  this->multiline = multiline;
+  update(std::move(text));
 }
 
 void TextInputHandler::update(std::string text) {
-    currentText = std::move(text);
-    currentTextPosition = currentText.size();
-    currentTextPositionUTF = UTF8Util::getLength(currentText.c_str(), currentTextPosition);
-    currentTextCopyPosition = currentTextPosition;
+  currentText = std::move(text);
+  currentTextPosition = currentText.size();
+  currentTextPositionUTF =
+      UTF8Util::getLength(currentText.c_str(), currentTextPosition);
+  currentTextCopyPosition = currentTextPosition;
 }
 
 void TextInputHandler::disable() {
-    currentText.clear();
-    currentTextPosition = 0;
-    currentTextPositionUTF = 0;
-    currentTextCopyPosition = 0;
-    enabled = false;
+  currentText.clear();
+  currentTextPosition = 0;
+  currentTextPositionUTF = 0;
+  currentTextCopyPosition = 0;
+  enabled = false;
 }
 
 void TextInputHandler::onTextInput(std::string const &text) {
-    if (!enabled) {
-        textUpdateCallback(text);
-        return;
-    }
-    if (text.size() == 1 && text[0] == 8) { // backspace
-        if (currentTextPositionUTF <= 0)
-            return;
-        currentTextPositionUTF--;
-        auto deleteStart = currentTextPosition - 1;
-        while (deleteStart > 0 && (currentText[deleteStart] & 0b11000000) == 0b10000000)
-            deleteStart--;
-        currentText.erase(currentText.begin() + deleteStart, currentText.begin() + currentTextPosition);
-        currentTextPosition = deleteStart;
-    } else if (text.size() == 1 && text[0] == 127) { // delete key
-        if (currentTextPosition >= currentText.size())
-            return;
-        auto deleteEnd = currentTextPosition + 1;
-        while (deleteEnd < currentText.size() && (currentText[deleteEnd] & 0b11000000) == 0b10000000)
-            deleteEnd++;
-        currentText.erase(currentText.begin() + currentTextPosition, currentText.begin() + deleteEnd);
-    } else {
-        currentText.insert(currentText.begin() + currentTextPosition, text.begin(), text.end());
-        currentTextPosition += text.size();
-        currentTextPositionUTF += UTF8Util::getLength(text.c_str(), text.size());
-    }
-    textUpdateCallback(currentText);
-    currentTextCopyPosition = currentTextPosition;
+  if (!enabled) {
+    textUpdateCallback(text);
+    return;
+  }
+  if (text.size() == 1 && text[0] == 8) { // backspace
+    if (currentTextPositionUTF <= 0)
+      return;
+    currentTextPositionUTF--;
+    auto deleteStart = currentTextPosition - 1;
+    while (deleteStart > 0 &&
+           (currentText[deleteStart] & 0b11000000) == 0b10000000)
+      deleteStart--;
+    currentText.erase(currentText.begin() + deleteStart,
+                      currentText.begin() + currentTextPosition);
+    currentTextPosition = deleteStart;
+  } else if (text.size() == 1 && text[0] == 127) { // delete key
+    if (currentTextPosition >= currentText.size())
+      return;
+    auto deleteEnd = currentTextPosition + 1;
+    while (deleteEnd < currentText.size() &&
+           (currentText[deleteEnd] & 0b11000000) == 0b10000000)
+      deleteEnd++;
+    currentText.erase(currentText.begin() + currentTextPosition,
+                      currentText.begin() + deleteEnd);
+  } else {
+    currentText.insert(currentText.begin() + currentTextPosition, text.begin(),
+                       text.end());
+    currentTextPosition += text.size();
+    currentTextPositionUTF += UTF8Util::getLength(text.c_str(), text.size());
+  }
+  textUpdateCallback(currentText);
+  currentTextCopyPosition = currentTextPosition;
 }
 
 void TextInputHandler::onKeyPressed(KeyCode key, KeyAction action) {
-    if (key == KeyCode::LEFT_SHIFT || key == KeyCode::RIGHT_SHIFT)
-        shiftPressed = (action != KeyAction::RELEASE);
+  if (key == KeyCode::LEFT_SHIFT || key == KeyCode::RIGHT_SHIFT)
+    shiftPressed = (action != KeyAction::RELEASE);
 
-    if (action != KeyAction::PRESS && action != KeyAction::REPEAT)
-        return;
-    if (key == KeyCode::RIGHT) {
-        if (currentTextPosition >= currentText.size())
-            return;
-        currentTextPosition++;
-        while (currentTextPosition < currentText.size() &&
-               (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
-            currentTextPosition++;
-        currentTextPositionUTF++;
-    } else if (key == KeyCode::LEFT) {
-        if (currentTextPosition <= 0)
-            return;
-        currentTextPosition--;
-        while (currentTextPosition > 0 && (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
-            currentTextPosition--;
-        currentTextPositionUTF--;
-    } else if (key == KeyCode::HOME) {
-        currentTextPosition = 0;
-        currentTextPositionUTF = 0;
-    } else if (key == KeyCode::END) {
-        currentTextPosition = currentText.size();
-        currentTextPositionUTF = UTF8Util::getLength(currentText.c_str(), currentTextPosition);
-    }
-    if (!shiftPressed)
-        currentTextCopyPosition = currentTextPosition;
+  if (action != KeyAction::PRESS && action != KeyAction::REPEAT)
+    return;
+  if (key == KeyCode::RIGHT) {
+    if (currentTextPosition >= currentText.size())
+      return;
+    currentTextPosition++;
+    while (currentTextPosition < currentText.size() &&
+           (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
+      currentTextPosition++;
+    currentTextPositionUTF++;
+  } else if (key == KeyCode::LEFT) {
+    if (currentTextPosition <= 0)
+      return;
+    currentTextPosition--;
+    while (currentTextPosition > 0 &&
+           (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
+      currentTextPosition--;
+    currentTextPositionUTF--;
+  } else if (key == KeyCode::HOME) {
+    currentTextPosition = 0;
+    currentTextPositionUTF = 0;
+  } else if (key == KeyCode::END) {
+    currentTextPosition = currentText.size();
+    currentTextPositionUTF =
+        UTF8Util::getLength(currentText.c_str(), currentTextPosition);
+  }
+  if (!shiftPressed)
+    currentTextCopyPosition = currentTextPosition;
 }
 
 std::string TextInputHandler::getCopyText() const {
-    if (currentTextCopyPosition != currentTextPosition) {
-        size_t start = std::min(currentTextPosition, currentTextCopyPosition);
-        size_t end = std::max(currentTextPosition, currentTextCopyPosition);
-        return currentText.substr(start, end - start);
-    } else {
-        return currentText;
-    }
+  if (currentTextCopyPosition != currentTextPosition) {
+    size_t start = std::min(currentTextPosition, currentTextCopyPosition);
+    size_t end = std::max(currentTextPosition, currentTextCopyPosition);
+    return currentText.substr(start, end - start);
+  } else {
+    return currentText;
+  }
 }

--- a/src/text_input_handler.cpp
+++ b/src/text_input_handler.cpp
@@ -1,23 +1,20 @@
 #include "text_input_handler.h"
 #include "utf8_util.h"
 
-void TextInputHandler::enable(std::string text, bool multiline)
-{
+void TextInputHandler::enable(std::string text, bool multiline) {
     enabled = true;
     this->multiline = multiline;
     update(std::move(text));
 }
 
-void TextInputHandler::update(std::string text)
-{
+void TextInputHandler::update(std::string text) {
     currentText = std::move(text);
     currentTextPosition = currentText.size();
     currentTextPositionUTF = UTF8Util::getLength(currentText.c_str(), currentTextPosition);
     currentTextCopyPosition = currentTextPosition;
 }
 
-void TextInputHandler::disable()
-{
+void TextInputHandler::disable() {
     currentText.clear();
     currentTextPosition = 0;
     currentTextPositionUTF = 0;
@@ -25,15 +22,12 @@ void TextInputHandler::disable()
     enabled = false;
 }
 
-void TextInputHandler::onTextInput(std::string const &text)
-{
-    if (!enabled)
-    {
+void TextInputHandler::onTextInput(std::string const &text) {
+    if (!enabled) {
         textUpdateCallback(text);
         return;
     }
-    if (text.size() == 1 && text[0] == 8)
-    {  // backspace
+    if (text.size() == 1 && text[0] == 8) {  // backspace
         if (currentTextPositionUTF <= 0)
             return;
         currentTextPositionUTF--;
@@ -41,17 +35,13 @@ void TextInputHandler::onTextInput(std::string const &text)
         while (deleteStart > 0 && (currentText[deleteStart] & 0b11000000) == 0b10000000) deleteStart--;
         currentText.erase(currentText.begin() + deleteStart, currentText.begin() + currentTextPosition);
         currentTextPosition = deleteStart;
-    }
-    else if (text.size() == 1 && text[0] == 127)
-    {  // delete key
+    } else if (text.size() == 1 && text[0] == 127) {  // delete key
         if (currentTextPosition >= currentText.size())
             return;
         auto deleteEnd = currentTextPosition + 1;
         while (deleteEnd < currentText.size() && (currentText[deleteEnd] & 0b11000000) == 0b10000000) deleteEnd++;
         currentText.erase(currentText.begin() + currentTextPosition, currentText.begin() + deleteEnd);
-    }
-    else
-    {
+    } else {
         currentText.insert(currentText.begin() + currentTextPosition, text.begin(), text.end());
         currentTextPosition += text.size();
         currentTextPositionUTF += UTF8Util::getLength(text.c_str(), text.size());
@@ -60,15 +50,13 @@ void TextInputHandler::onTextInput(std::string const &text)
     currentTextCopyPosition = currentTextPosition;
 }
 
-void TextInputHandler::onKeyPressed(KeyCode key, KeyAction action)
-{
+void TextInputHandler::onKeyPressed(KeyCode key, KeyAction action) {
     if (key == KeyCode::LEFT_SHIFT || key == KeyCode::RIGHT_SHIFT)
         shiftPressed = (action != KeyAction::RELEASE);
 
     if (action != KeyAction::PRESS && action != KeyAction::REPEAT)
         return;
-    if (key == KeyCode::RIGHT)
-    {
+    if (key == KeyCode::RIGHT) {
         if (currentTextPosition >= currentText.size())
             return;
         currentTextPosition++;
@@ -76,23 +64,17 @@ void TextInputHandler::onKeyPressed(KeyCode key, KeyAction action)
                (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
             currentTextPosition++;
         currentTextPositionUTF++;
-    }
-    else if (key == KeyCode::LEFT)
-    {
+    } else if (key == KeyCode::LEFT) {
         if (currentTextPosition <= 0)
             return;
         currentTextPosition--;
         while (currentTextPosition > 0 && (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
             currentTextPosition--;
         currentTextPositionUTF--;
-    }
-    else if (key == KeyCode::HOME)
-    {
+    } else if (key == KeyCode::HOME) {
         currentTextPosition = 0;
         currentTextPositionUTF = 0;
-    }
-    else if (key == KeyCode::END)
-    {
+    } else if (key == KeyCode::END) {
         currentTextPosition = currentText.size();
         currentTextPositionUTF = UTF8Util::getLength(currentText.c_str(), currentTextPosition);
     }
@@ -100,16 +82,12 @@ void TextInputHandler::onKeyPressed(KeyCode key, KeyAction action)
         currentTextCopyPosition = currentTextPosition;
 }
 
-std::string TextInputHandler::getCopyText() const
-{
-    if (currentTextCopyPosition != currentTextPosition)
-    {
+std::string TextInputHandler::getCopyText() const {
+    if (currentTextCopyPosition != currentTextPosition) {
         size_t start = std::min(currentTextPosition, currentTextCopyPosition);
         size_t end = std::max(currentTextPosition, currentTextCopyPosition);
         return currentText.substr(start, end - start);
-    }
-    else
-    {
+    } else {
         return currentText;
     }
 }

--- a/src/text_input_handler.cpp
+++ b/src/text_input_handler.cpp
@@ -1,103 +1,115 @@
 #include "text_input_handler.h"
 #include "utf8_util.h"
 
-void TextInputHandler::enable(std::string text, bool multiline) {
-  enabled = true;
-  this->multiline = multiline;
-  update(std::move(text));
+void TextInputHandler::enable(std::string text, bool multiline)
+{
+    enabled = true;
+    this->multiline = multiline;
+    update(std::move(text));
 }
 
-void TextInputHandler::update(std::string text) {
-  currentText = std::move(text);
-  currentTextPosition = currentText.size();
-  currentTextPositionUTF =
-      UTF8Util::getLength(currentText.c_str(), currentTextPosition);
-  currentTextCopyPosition = currentTextPosition;
-}
-
-void TextInputHandler::disable() {
-  currentText.clear();
-  currentTextPosition = 0;
-  currentTextPositionUTF = 0;
-  currentTextCopyPosition = 0;
-  enabled = false;
-}
-
-void TextInputHandler::onTextInput(std::string const &text) {
-  if (!enabled) {
-    textUpdateCallback(text);
-    return;
-  }
-  if (text.size() == 1 && text[0] == 8) { // backspace
-    if (currentTextPositionUTF <= 0)
-      return;
-    currentTextPositionUTF--;
-    auto deleteStart = currentTextPosition - 1;
-    while (deleteStart > 0 &&
-           (currentText[deleteStart] & 0b11000000) == 0b10000000)
-      deleteStart--;
-    currentText.erase(currentText.begin() + deleteStart,
-                      currentText.begin() + currentTextPosition);
-    currentTextPosition = deleteStart;
-  } else if (text.size() == 1 && text[0] == 127) { // delete key
-    if (currentTextPosition >= currentText.size())
-      return;
-    auto deleteEnd = currentTextPosition + 1;
-    while (deleteEnd < currentText.size() &&
-           (currentText[deleteEnd] & 0b11000000) == 0b10000000)
-      deleteEnd++;
-    currentText.erase(currentText.begin() + currentTextPosition,
-                      currentText.begin() + deleteEnd);
-  } else {
-    currentText.insert(currentText.begin() + currentTextPosition, text.begin(),
-                       text.end());
-    currentTextPosition += text.size();
-    currentTextPositionUTF += UTF8Util::getLength(text.c_str(), text.size());
-  }
-  textUpdateCallback(currentText);
-  currentTextCopyPosition = currentTextPosition;
-}
-
-void TextInputHandler::onKeyPressed(KeyCode key, KeyAction action) {
-  if (key == KeyCode::LEFT_SHIFT || key == KeyCode::RIGHT_SHIFT)
-    shiftPressed = (action != KeyAction::RELEASE);
-
-  if (action != KeyAction::PRESS && action != KeyAction::REPEAT)
-    return;
-  if (key == KeyCode::RIGHT) {
-    if (currentTextPosition >= currentText.size())
-      return;
-    currentTextPosition++;
-    while (currentTextPosition < currentText.size() &&
-           (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
-      currentTextPosition++;
-    currentTextPositionUTF++;
-  } else if (key == KeyCode::LEFT) {
-    if (currentTextPosition <= 0)
-      return;
-    currentTextPosition--;
-    while (currentTextPosition > 0 &&
-           (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
-      currentTextPosition--;
-    currentTextPositionUTF--;
-  } else if (key == KeyCode::HOME) {
-    currentTextPosition = 0;
-    currentTextPositionUTF = 0;
-  } else if (key == KeyCode::END) {
+void TextInputHandler::update(std::string text)
+{
+    currentText = std::move(text);
     currentTextPosition = currentText.size();
-    currentTextPositionUTF =
-        UTF8Util::getLength(currentText.c_str(), currentTextPosition);
-  }
-  if (!shiftPressed)
+    currentTextPositionUTF = UTF8Util::getLength(currentText.c_str(), currentTextPosition);
     currentTextCopyPosition = currentTextPosition;
 }
 
-std::string TextInputHandler::getCopyText() const {
-  if (currentTextCopyPosition != currentTextPosition) {
-    size_t start = std::min(currentTextPosition, currentTextCopyPosition);
-    size_t end = std::max(currentTextPosition, currentTextCopyPosition);
-    return currentText.substr(start, end - start);
-  } else {
-    return currentText;
-  }
+void TextInputHandler::disable()
+{
+    currentText.clear();
+    currentTextPosition = 0;
+    currentTextPositionUTF = 0;
+    currentTextCopyPosition = 0;
+    enabled = false;
+}
+
+void TextInputHandler::onTextInput(std::string const &text)
+{
+    if (!enabled)
+    {
+        textUpdateCallback(text);
+        return;
+    }
+    if (text.size() == 1 && text[0] == 8)
+    {  // backspace
+        if (currentTextPositionUTF <= 0)
+            return;
+        currentTextPositionUTF--;
+        auto deleteStart = currentTextPosition - 1;
+        while (deleteStart > 0 && (currentText[deleteStart] & 0b11000000) == 0b10000000) deleteStart--;
+        currentText.erase(currentText.begin() + deleteStart, currentText.begin() + currentTextPosition);
+        currentTextPosition = deleteStart;
+    }
+    else if (text.size() == 1 && text[0] == 127)
+    {  // delete key
+        if (currentTextPosition >= currentText.size())
+            return;
+        auto deleteEnd = currentTextPosition + 1;
+        while (deleteEnd < currentText.size() && (currentText[deleteEnd] & 0b11000000) == 0b10000000) deleteEnd++;
+        currentText.erase(currentText.begin() + currentTextPosition, currentText.begin() + deleteEnd);
+    }
+    else
+    {
+        currentText.insert(currentText.begin() + currentTextPosition, text.begin(), text.end());
+        currentTextPosition += text.size();
+        currentTextPositionUTF += UTF8Util::getLength(text.c_str(), text.size());
+    }
+    textUpdateCallback(currentText);
+    currentTextCopyPosition = currentTextPosition;
+}
+
+void TextInputHandler::onKeyPressed(KeyCode key, KeyAction action)
+{
+    if (key == KeyCode::LEFT_SHIFT || key == KeyCode::RIGHT_SHIFT)
+        shiftPressed = (action != KeyAction::RELEASE);
+
+    if (action != KeyAction::PRESS && action != KeyAction::REPEAT)
+        return;
+    if (key == KeyCode::RIGHT)
+    {
+        if (currentTextPosition >= currentText.size())
+            return;
+        currentTextPosition++;
+        while (currentTextPosition < currentText.size() &&
+               (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
+            currentTextPosition++;
+        currentTextPositionUTF++;
+    }
+    else if (key == KeyCode::LEFT)
+    {
+        if (currentTextPosition <= 0)
+            return;
+        currentTextPosition--;
+        while (currentTextPosition > 0 && (currentText[currentTextPosition] & 0b11000000) == 0b10000000)
+            currentTextPosition--;
+        currentTextPositionUTF--;
+    }
+    else if (key == KeyCode::HOME)
+    {
+        currentTextPosition = 0;
+        currentTextPositionUTF = 0;
+    }
+    else if (key == KeyCode::END)
+    {
+        currentTextPosition = currentText.size();
+        currentTextPositionUTF = UTF8Util::getLength(currentText.c_str(), currentTextPosition);
+    }
+    if (!shiftPressed)
+        currentTextCopyPosition = currentTextPosition;
+}
+
+std::string TextInputHandler::getCopyText() const
+{
+    if (currentTextCopyPosition != currentTextPosition)
+    {
+        size_t start = std::min(currentTextPosition, currentTextCopyPosition);
+        size_t end = std::max(currentTextPosition, currentTextCopyPosition);
+        return currentText.substr(start, end - start);
+    }
+    else
+    {
+        return currentText;
+    }
 }

--- a/src/text_input_handler.h
+++ b/src/text_input_handler.h
@@ -1,42 +1,41 @@
 #pragma once
 
-#include <functional>
 #include <game_window.h>
 #include <key_mapping.h>
+#include <functional>
 #include <string>
 
-struct TextInputHandler {
+struct TextInputHandler
+{
+   public:
+    using TextCallback = std::function<void(std::string)>;
 
-public:
-  using TextCallback = std::function<void(std::string)>;
+   private:
+    bool enabled = false, multiline = false, shiftPressed = false;
+    std::string currentText;
+    size_t currentTextPosition = 0;
+    size_t currentTextPositionUTF = 0;
+    size_t currentTextCopyPosition = 0;
+    TextCallback textUpdateCallback;
 
-private:
-  bool enabled = false, multiline = false, shiftPressed = false;
-  std::string currentText;
-  size_t currentTextPosition = 0;
-  size_t currentTextPositionUTF = 0;
-  size_t currentTextCopyPosition = 0;
-  TextCallback textUpdateCallback;
+   public:
+    explicit TextInputHandler(TextCallback cb) : textUpdateCallback(std::move(cb)) {}
 
-public:
-  explicit TextInputHandler(TextCallback cb)
-      : textUpdateCallback(std::move(cb)) {}
+    bool isEnabled() const { return enabled; }
 
-  bool isEnabled() const { return enabled; }
+    bool isMultiline() const { return multiline; }
 
-  bool isMultiline() const { return multiline; }
+    void enable(std::string text, bool multiline);
 
-  void enable(std::string text, bool multiline);
+    void update(std::string text);
 
-  void update(std::string text);
+    void disable();
 
-  void disable();
+    void onTextInput(std::string const &val);
 
-  void onTextInput(std::string const &val);
+    void onKeyPressed(KeyCode key, KeyAction action);
 
-  void onKeyPressed(KeyCode key, KeyAction action);
+    std::string getCopyText() const;
 
-  std::string getCopyText() const;
-
-  int getCursorPosition() const { return currentTextPositionUTF; }
+    int getCursorPosition() const { return currentTextPositionUTF; }
 };

--- a/src/text_input_handler.h
+++ b/src/text_input_handler.h
@@ -1,42 +1,42 @@
 #pragma once
 
-#include <string>
 #include <functional>
-#include <key_mapping.h>
 #include <game_window.h>
+#include <key_mapping.h>
+#include <string>
 
 struct TextInputHandler {
 
 public:
-    using TextCallback = std::function<void (std::string)>;
+  using TextCallback = std::function<void(std::string)>;
 
 private:
-    bool enabled = false, multiline = false, shiftPressed = false;
-    std::string currentText;
-    size_t currentTextPosition = 0;
-    size_t currentTextPositionUTF = 0;
-    size_t currentTextCopyPosition = 0;
-    TextCallback textUpdateCallback;
+  bool enabled = false, multiline = false, shiftPressed = false;
+  std::string currentText;
+  size_t currentTextPosition = 0;
+  size_t currentTextPositionUTF = 0;
+  size_t currentTextCopyPosition = 0;
+  TextCallback textUpdateCallback;
 
 public:
-    explicit TextInputHandler(TextCallback cb) : textUpdateCallback(std::move(cb)) {}
+  explicit TextInputHandler(TextCallback cb)
+      : textUpdateCallback(std::move(cb)) {}
 
-    bool isEnabled() const { return enabled; }
+  bool isEnabled() const { return enabled; }
 
-    bool isMultiline() const { return multiline; }
+  bool isMultiline() const { return multiline; }
 
-    void enable(std::string text, bool multiline);
+  void enable(std::string text, bool multiline);
 
-    void update(std::string text);
+  void update(std::string text);
 
-    void disable();
+  void disable();
 
-    void onTextInput(std::string const &val);
+  void onTextInput(std::string const &val);
 
-    void onKeyPressed(KeyCode key, KeyAction action);
+  void onKeyPressed(KeyCode key, KeyAction action);
 
-    std::string getCopyText() const;
+  std::string getCopyText() const;
 
-    int getCursorPosition() const { return currentTextPositionUTF; }
-
+  int getCursorPosition() const { return currentTextPositionUTF; }
 };

--- a/src/text_input_handler.h
+++ b/src/text_input_handler.h
@@ -5,8 +5,7 @@
 #include <functional>
 #include <string>
 
-struct TextInputHandler
-{
+struct TextInputHandler {
    public:
     using TextCallback = std::function<void(std::string)>;
 

--- a/src/thread_mover.cpp
+++ b/src/thread_mover.cpp
@@ -2,15 +2,12 @@
 
 ThreadMover ThreadMover::instance;
 
-void ThreadMover::hookLibC(std::unordered_map<std::string, void *> &syms)
-{
+void ThreadMover::hookLibC(std::unordered_map<std::string, void *> &syms) {
     using pthread_create_fn = int (*)(void *, const void *, void *(*)(void *), void *);
     static pthread_create_fn pthread_create_orig = (pthread_create_fn)syms["pthread_create"];
-    syms["pthread_create"] = (void *)+[](void *thread, const void *attr, void *(*start_routine)(void *), void *arg)
-    {
+    syms["pthread_create"] = (void *)+[](void *thread, const void *attr, void *(*start_routine)(void *), void *arg) {
         bool expected = false;
-        if (ThreadMover::instance.main_thread_started.compare_exchange_strong(expected, true))
-        {
+        if (ThreadMover::instance.main_thread_started.compare_exchange_strong(expected, true)) {
             ThreadMover::instance.main_thread_promise.set_value({start_routine, arg});
             return 0;
         }
@@ -18,8 +15,7 @@ void ThreadMover::hookLibC(std::unordered_map<std::string, void *> &syms)
     };
 }
 
-void ThreadMover::executeMainThread()
-{
+void ThreadMover::executeMainThread() {
     auto info = ThreadMover::instance.main_thread_promise.get_future().get();
     info.main_thread_fn(info.main_thread_arg);
 }

--- a/src/thread_mover.cpp
+++ b/src/thread_mover.cpp
@@ -3,19 +3,24 @@
 ThreadMover ThreadMover::instance;
 
 void ThreadMover::hookLibC(std::unordered_map<std::string, void *> &syms) {
-    using pthread_create_fn = int (*)(void *, const void *, void *(*) (void *), void *);
-    static pthread_create_fn pthread_create_orig = (pthread_create_fn) syms["pthread_create"];
-    syms["pthread_create"] = (void *) +[](void *thread, const void *attr, void *(*start_routine) (void *), void *arg) {
-        bool expected = false;
-        if (ThreadMover::instance.main_thread_started.compare_exchange_strong(expected, true)) {
-            ThreadMover::instance.main_thread_promise.set_value({start_routine, arg});
-            return 0;
-        }
-        return pthread_create_orig(thread, attr, start_routine, arg);
-    };
+  using pthread_create_fn =
+      int (*)(void *, const void *, void *(*)(void *), void *);
+  static pthread_create_fn pthread_create_orig =
+      (pthread_create_fn)syms["pthread_create"];
+  syms["pthread_create"] = (void *)+[](void *thread, const void *attr,
+                                       void *(*start_routine)(void *),
+                                       void *arg) {
+    bool expected = false;
+    if (ThreadMover::instance.main_thread_started.compare_exchange_strong(
+            expected, true)) {
+      ThreadMover::instance.main_thread_promise.set_value({start_routine, arg});
+      return 0;
+    }
+    return pthread_create_orig(thread, attr, start_routine, arg);
+  };
 }
 
 void ThreadMover::executeMainThread() {
-    auto info = ThreadMover::instance.main_thread_promise.get_future().get();
-    info.main_thread_fn(info.main_thread_arg);
+  auto info = ThreadMover::instance.main_thread_promise.get_future().get();
+  info.main_thread_fn(info.main_thread_arg);
 }

--- a/src/thread_mover.cpp
+++ b/src/thread_mover.cpp
@@ -2,25 +2,24 @@
 
 ThreadMover ThreadMover::instance;
 
-void ThreadMover::hookLibC(std::unordered_map<std::string, void *> &syms) {
-  using pthread_create_fn =
-      int (*)(void *, const void *, void *(*)(void *), void *);
-  static pthread_create_fn pthread_create_orig =
-      (pthread_create_fn)syms["pthread_create"];
-  syms["pthread_create"] = (void *)+[](void *thread, const void *attr,
-                                       void *(*start_routine)(void *),
-                                       void *arg) {
-    bool expected = false;
-    if (ThreadMover::instance.main_thread_started.compare_exchange_strong(
-            expected, true)) {
-      ThreadMover::instance.main_thread_promise.set_value({start_routine, arg});
-      return 0;
-    }
-    return pthread_create_orig(thread, attr, start_routine, arg);
-  };
+void ThreadMover::hookLibC(std::unordered_map<std::string, void *> &syms)
+{
+    using pthread_create_fn = int (*)(void *, const void *, void *(*)(void *), void *);
+    static pthread_create_fn pthread_create_orig = (pthread_create_fn)syms["pthread_create"];
+    syms["pthread_create"] = (void *)+[](void *thread, const void *attr, void *(*start_routine)(void *), void *arg)
+    {
+        bool expected = false;
+        if (ThreadMover::instance.main_thread_started.compare_exchange_strong(expected, true))
+        {
+            ThreadMover::instance.main_thread_promise.set_value({start_routine, arg});
+            return 0;
+        }
+        return pthread_create_orig(thread, attr, start_routine, arg);
+    };
 }
 
-void ThreadMover::executeMainThread() {
-  auto info = ThreadMover::instance.main_thread_promise.get_future().get();
-  info.main_thread_fn(info.main_thread_arg);
+void ThreadMover::executeMainThread()
+{
+    auto info = ThreadMover::instance.main_thread_promise.get_future().get();
+    info.main_thread_fn(info.main_thread_arg);
 }

--- a/src/thread_mover.h
+++ b/src/thread_mover.h
@@ -4,24 +4,25 @@
 #include <future>
 #include <unordered_map>
 
-class ThreadMover {
+class ThreadMover
+{
+   private:
+    static ThreadMover instance;
 
-private:
-  static ThreadMover instance;
+    std::atomic_bool main_thread_started = false;
 
-  std::atomic_bool main_thread_started = false;
+    struct main_thread_info
+    {
+        void *(*main_thread_fn)(void *);
+        void *main_thread_arg;
+    };
 
-  struct main_thread_info {
-    void *(*main_thread_fn)(void *);
-    void *main_thread_arg;
-  };
+    std::promise<main_thread_info> main_thread_promise;
 
-  std::promise<main_thread_info> main_thread_promise;
+    ThreadMover() = default;
 
-  ThreadMover() = default;
+   public:
+    static void hookLibC(std::unordered_map<std::string, void *> &syms);
 
-public:
-  static void hookLibC(std::unordered_map<std::string, void *> &syms);
-
-  static void executeMainThread();
+    static void executeMainThread();
 };

--- a/src/thread_mover.h
+++ b/src/thread_mover.h
@@ -4,15 +4,13 @@
 #include <future>
 #include <unordered_map>
 
-class ThreadMover
-{
+class ThreadMover {
    private:
     static ThreadMover instance;
 
     std::atomic_bool main_thread_started = false;
 
-    struct main_thread_info
-    {
+    struct main_thread_info {
         void *(*main_thread_fn)(void *);
         void *main_thread_arg;
     };

--- a/src/thread_mover.h
+++ b/src/thread_mover.h
@@ -1,28 +1,27 @@
 #pragma once
 
-#include <unordered_map>
 #include <atomic>
 #include <future>
+#include <unordered_map>
 
 class ThreadMover {
 
 private:
-    static ThreadMover instance;
+  static ThreadMover instance;
 
-    std::atomic_bool main_thread_started = false;
+  std::atomic_bool main_thread_started = false;
 
-    struct main_thread_info {
-        void *(*main_thread_fn)(void *);
-        void *main_thread_arg;
-    };
+  struct main_thread_info {
+    void *(*main_thread_fn)(void *);
+    void *main_thread_arg;
+  };
 
-    std::promise<main_thread_info> main_thread_promise;
+  std::promise<main_thread_info> main_thread_promise;
 
-    ThreadMover() = default;
+  ThreadMover() = default;
 
 public:
-    static void hookLibC(std::unordered_map<std::string, void*> &syms);
+  static void hookLibC(std::unordered_map<std::string, void *> &syms);
 
-    static void executeMainThread();
-
+  static void executeMainThread();
 };

--- a/src/utf8_util.h
+++ b/src/utf8_util.h
@@ -5,22 +5,21 @@
 class UTF8Util {
 
 public:
-    static int getCharByteSize(char c) {
-        if ((c & 0b11110000) == 0b11100000)
-            return 3;
-        else if ((c & 0b11100000) == 0b11000000)
-            return 2;
-        return 1;
-    }
+  static int getCharByteSize(char c) {
+    if ((c & 0b11110000) == 0b11100000)
+      return 3;
+    else if ((c & 0b11100000) == 0b11000000)
+      return 2;
+    return 1;
+  }
 
-    static size_t getLength(const char* str, size_t len) {
-        size_t ret = 0;
-        for (size_t i = 0; i < len; ) {
-            char c = str[i];
-            i += getCharByteSize(c);
-            ret++;
-        }
-        return ret;
+  static size_t getLength(const char *str, size_t len) {
+    size_t ret = 0;
+    for (size_t i = 0; i < len;) {
+      char c = str[i];
+      i += getCharByteSize(c);
+      ret++;
     }
-
+    return ret;
+  }
 };

--- a/src/utf8_util.h
+++ b/src/utf8_util.h
@@ -2,24 +2,27 @@
 
 #include <cstddef>
 
-class UTF8Util {
-
-public:
-  static int getCharByteSize(char c) {
-    if ((c & 0b11110000) == 0b11100000)
-      return 3;
-    else if ((c & 0b11100000) == 0b11000000)
-      return 2;
-    return 1;
-  }
-
-  static size_t getLength(const char *str, size_t len) {
-    size_t ret = 0;
-    for (size_t i = 0; i < len;) {
-      char c = str[i];
-      i += getCharByteSize(c);
-      ret++;
+class UTF8Util
+{
+   public:
+    static int getCharByteSize(char c)
+    {
+        if ((c & 0b11110000) == 0b11100000)
+            return 3;
+        else if ((c & 0b11100000) == 0b11000000)
+            return 2;
+        return 1;
     }
-    return ret;
-  }
+
+    static size_t getLength(const char *str, size_t len)
+    {
+        size_t ret = 0;
+        for (size_t i = 0; i < len;)
+        {
+            char c = str[i];
+            i += getCharByteSize(c);
+            ret++;
+        }
+        return ret;
+    }
 };

--- a/src/utf8_util.h
+++ b/src/utf8_util.h
@@ -2,11 +2,9 @@
 
 #include <cstddef>
 
-class UTF8Util
-{
+class UTF8Util {
    public:
-    static int getCharByteSize(char c)
-    {
+    static int getCharByteSize(char c) {
         if ((c & 0b11110000) == 0b11100000)
             return 3;
         else if ((c & 0b11100000) == 0b11000000)
@@ -14,11 +12,9 @@ class UTF8Util
         return 1;
     }
 
-    static size_t getLength(const char *str, size_t len)
-    {
+    static size_t getLength(const char *str, size_t len) {
         size_t ret = 0;
-        for (size_t i = 0; i < len;)
-        {
+        for (size_t i = 0; i < len;) {
             char c = str[i];
             i += getCharByteSize(c);
             ret++;

--- a/src/util.h
+++ b/src/util.h
@@ -3,18 +3,15 @@
 #include <algorithm>
 #include <string>
 
-static inline void ltrim(std::string &s)
-{
+static inline void ltrim(std::string &s) {
     s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
 }
 
-static inline void rtrim(std::string &s)
-{
+static inline void rtrim(std::string &s) {
     s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
-static inline void trim(std::string &s)
-{
+static inline void trim(std::string &s) {
     ltrim(s);
     rtrim(s);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,21 +1,21 @@
 #pragma once
 
-#include <string>
 #include <algorithm>
+#include <string>
 
 static inline void ltrim(std::string &s) {
-   s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
-       return !std::isspace(ch);
-   }));
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(),
+                                  [](int ch) { return !std::isspace(ch); }));
 }
 
 static inline void rtrim(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {
-        return !std::isspace(ch);
-    }).base(), s.end());
+  s.erase(std::find_if(s.rbegin(), s.rend(),
+                       [](int ch) { return !std::isspace(ch); })
+              .base(),
+          s.end());
 }
 
 static inline void trim(std::string &s) {
-    ltrim(s);
-    rtrim(s);
+  ltrim(s);
+  rtrim(s);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -3,19 +3,18 @@
 #include <algorithm>
 #include <string>
 
-static inline void ltrim(std::string &s) {
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(),
-                                  [](int ch) { return !std::isspace(ch); }));
+static inline void ltrim(std::string &s)
+{
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
 }
 
-static inline void rtrim(std::string &s) {
-  s.erase(std::find_if(s.rbegin(), s.rend(),
-                       [](int ch) { return !std::isspace(ch); })
-              .base(),
-          s.end());
+static inline void rtrim(std::string &s)
+{
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
-static inline void trim(std::string &s) {
-  ltrim(s);
-  rtrim(s);
+static inline void trim(std::string &s)
+{
+    ltrim(s);
+    rtrim(s);
 }

--- a/src/window_callbacks.cpp
+++ b/src/window_callbacks.cpp
@@ -1,334 +1,432 @@
 #include "window_callbacks.h"
 #include "symbols.h"
 
-#include <mcpelauncher/minecraft_version.h>
 #include <game_window_manager.h>
 #include <log.h>
+#include <mcpelauncher/minecraft_version.h>
 #include <mcpelauncher/path_helper.h>
 
-WindowCallbacks::WindowCallbacks(GameWindow &window, JniSupport &jniSupport, FakeInputQueue &inputQueue) :
-    window(window), jniSupport(jniSupport), inputQueue(inputQueue) {
-    useDirectMouseInput = true;
-    useDirectKeyboardInput = (Keyboard::_states && Keyboard::_inputs && Keyboard::_gameControllerId);
+WindowCallbacks::WindowCallbacks(GameWindow &window, JniSupport &jniSupport,
+                                 FakeInputQueue &inputQueue)
+    : window(window), jniSupport(jniSupport), inputQueue(inputQueue) {
+  useDirectMouseInput = true;
+  useDirectKeyboardInput = false;
 }
 
 void WindowCallbacks::registerCallbacks() {
-    using namespace std::placeholders;
-    window.setWindowSizeCallback(std::bind(&WindowCallbacks::onWindowSizeCallback, this, _1, _2));
-    window.setCloseCallback(std::bind(&WindowCallbacks::onClose, this));
+  using namespace std::placeholders;
+  window.setWindowSizeCallback(
+      std::bind(&WindowCallbacks::onWindowSizeCallback, this, _1, _2));
+  window.setCloseCallback(std::bind(&WindowCallbacks::onClose, this));
 
-    window.setMouseButtonCallback(std::bind(&WindowCallbacks::onMouseButton, this, _1, _2, _3, _4));
-    window.setMousePositionCallback(std::bind(&WindowCallbacks::onMousePosition, this, _1, _2));
-    window.setMouseRelativePositionCallback(std::bind(&WindowCallbacks::onMouseRelativePosition, this, _1, _2));
-    window.setMouseScrollCallback(std::bind(&WindowCallbacks::onMouseScroll, this, _1, _2, _3, _4));
-    window.setTouchStartCallback(std::bind(&WindowCallbacks::onTouchStart, this, _1, _2, _3));
-    window.setTouchUpdateCallback(std::bind(&WindowCallbacks::onTouchUpdate, this, _1, _2, _3));
-    window.setTouchEndCallback(std::bind(&WindowCallbacks::onTouchEnd, this, _1, _2, _3));
-    window.setKeyboardCallback(std::bind(&WindowCallbacks::onKeyboard, this, _1, _2));
-    window.setKeyboardTextCallback(std::bind(&WindowCallbacks::onKeyboardText, this, _1));
-    window.setPasteCallback(std::bind(&WindowCallbacks::onPaste, this, _1));
-    window.setGamepadStateCallback(std::bind(&WindowCallbacks::onGamepadState, this, _1, _2));
-    window.setGamepadButtonCallback(std::bind(&WindowCallbacks::onGamepadButton, this, _1, _2, _3));
-    window.setGamepadAxisCallback(std::bind(&WindowCallbacks::onGamepadAxis, this, _1, _2, _3));
+  window.setMouseButtonCallback(
+      std::bind(&WindowCallbacks::onMouseButton, this, _1, _2, _3, _4));
+  window.setMousePositionCallback(
+      std::bind(&WindowCallbacks::onMousePosition, this, _1, _2));
+  window.setMouseRelativePositionCallback(
+      std::bind(&WindowCallbacks::onMouseRelativePosition, this, _1, _2));
+  window.setMouseScrollCallback(
+      std::bind(&WindowCallbacks::onMouseScroll, this, _1, _2, _3, _4));
+  window.setTouchStartCallback(
+      std::bind(&WindowCallbacks::onTouchStart, this, _1, _2, _3));
+  window.setTouchUpdateCallback(
+      std::bind(&WindowCallbacks::onTouchUpdate, this, _1, _2, _3));
+  window.setTouchEndCallback(
+      std::bind(&WindowCallbacks::onTouchEnd, this, _1, _2, _3));
+  window.setKeyboardCallback(
+      std::bind(&WindowCallbacks::onKeyboard, this, _1, _2));
+  window.setKeyboardTextCallback(
+      std::bind(&WindowCallbacks::onKeyboardText, this, _1));
+  window.setPasteCallback(std::bind(&WindowCallbacks::onPaste, this, _1));
+  window.setGamepadStateCallback(
+      std::bind(&WindowCallbacks::onGamepadState, this, _1, _2));
+  window.setGamepadButtonCallback(
+      std::bind(&WindowCallbacks::onGamepadButton, this, _1, _2, _3));
+  window.setGamepadAxisCallback(
+      std::bind(&WindowCallbacks::onGamepadAxis, this, _1, _2, _3));
 }
 
 void WindowCallbacks::onWindowSizeCallback(int w, int h) {
-    jniSupport.onWindowResized(w, h);
+  jniSupport.onWindowResized(w, h);
 }
 
-void WindowCallbacks::onClose() {
-    jniSupport.onWindowClosed();
-}
+void WindowCallbacks::onClose() { jniSupport.onWindowClosed(); }
 
-bool WindowCallbacks::hasInputMode(WindowCallbacks::InputMode want, bool changeMode) {
-    auto now = std::chrono::high_resolution_clock::now();
-    if(inputMode == want || changeMode && ((int)want < (int)inputMode || (now - lastUpdated) > std::chrono::seconds(2))) {
-        if(inputMode != want) {
+bool WindowCallbacks::hasInputMode(WindowCallbacks::InputMode want,
+                                   bool changeMode) {
+  auto now = std::chrono::high_resolution_clock::now();
+  if (inputMode == want ||
+      changeMode && ((int)want < (int)inputMode ||
+                     (now - lastUpdated) > std::chrono::seconds(2))) {
+    if (inputMode != want) {
 #ifndef NDEBUG
-            printf("Input Mode changed to %d\n", (int)want);
+      printf("Input Mode changed to %d\n", (int)want);
 #endif
-            if(want == InputMode::Mouse) {
-                window.setCursorDisabled(false);
-            } else {
-                window.setCursorDisabled(true);
-            }
-        }
-        inputMode = want;
-        lastUpdated = now;
-        return true;
+      if (want == InputMode::Mouse) {
+        window.setCursorDisabled(false);
+      } else {
+        window.setCursorDisabled(true);
+      }
     }
-    return false;
+    inputMode = want;
+    lastUpdated = now;
+    return true;
+  }
+  return false;
 }
 
-void WindowCallbacks::onMouseButton(double x, double y, int btn, MouseButtonAction action) {
-    if(hasInputMode(InputMode::Mouse)) {
-        if (btn < 1)
-            return;
-        if (btn > 3) {
-            // Seems to get recognized same as regular Mousebuttons as Button4 or higher, but ignored from mouse
-            return onKeyboard((KeyCode) btn, action == MouseButtonAction::PRESS ? KeyAction::PRESS : KeyAction::RELEASE);
-        }
-        if (useDirectMouseInput)
-            Mouse::feed((char) btn, (char) (action == MouseButtonAction::PRESS ? 1 : 0), (short) x, (short) y, 0, 0);
-        else if (action == MouseButtonAction::PRESS)
-            inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, 0, x, y));
-        else if (action == MouseButtonAction::RELEASE)
-            inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, 0, x, y));
+void WindowCallbacks::onMouseButton(double x, double y, int btn,
+                                    MouseButtonAction action) {
+  if (hasInputMode(InputMode::Mouse)) {
+    if (btn < 1)
+      return;
+    if (btn > 3) {
+      // Seems to get recognized same as regular Mousebuttons as Button4 or
+      // higher, but ignored from mouse
+      return onKeyboard((KeyCode)btn, action == MouseButtonAction::PRESS
+                                          ? KeyAction::PRESS
+                                          : KeyAction::RELEASE);
     }
+    if (useDirectMouseInput)
+      Mouse::feed((char)btn, (char)(action == MouseButtonAction::PRESS ? 1 : 0),
+                  (short)x, (short)y, 0, 0);
+    else if (action == MouseButtonAction::PRESS)
+      inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, 0, x, y));
+    else if (action == MouseButtonAction::RELEASE)
+      inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, 0, x, y));
+  }
 }
 void WindowCallbacks::onMousePosition(double x, double y) {
-    if(hasInputMode(InputMode::Mouse)) {
-        if (useDirectMouseInput)
-            Mouse::feed(0, 0, (short) x, (short) y, 0, 0);
-        else
-            inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
-    }
+  if (hasInputMode(InputMode::Mouse)) {
+    if (useDirectMouseInput)
+      Mouse::feed(0, 0, (short)x, (short)y, 0, 0);
+    else
+      inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
+  }
 }
 void WindowCallbacks::onMouseRelativePosition(double x, double y) {
-    if(hasInputMode(InputMode::Mouse, std::abs(x) > 10 || std::abs(y) > 10)) {
-        if (useDirectMouseInput)
-            Mouse::feed(0, 0, 0, 0, (short) x, (short) y);
-        else
-            inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
-    }
+  if (hasInputMode(InputMode::Mouse, std::abs(x) > 10 || std::abs(y) > 10)) {
+    if (useDirectMouseInput)
+      Mouse::feed(0, 0, 0, 0, (short)x, (short)y);
+    else
+      inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
+  }
 }
 void WindowCallbacks::onMouseScroll(double x, double y, double dx, double dy) {
-    if(hasInputMode(InputMode::Mouse)) {
-        signed char cdy = (signed char)std::max(std::min(dy * 127.0, 127.0), -127.0);
-        if (useDirectMouseInput)
-            Mouse::feed(4, (char&)cdy, 0, 0, (short) x, (short) y);
-    }
+  if (hasInputMode(InputMode::Mouse)) {
+    signed char cdy =
+        (signed char)std::max(std::min(dy * 127.0, 127.0), -127.0);
+    if (useDirectMouseInput)
+      Mouse::feed(4, (char &)cdy, 0, 0, (short)x, (short)y);
+  }
 }
 void WindowCallbacks::onTouchStart(int id, double x, double y) {
-    if(hasInputMode(InputMode::Touch)) {
-        inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, id, x, y));
-    }
+  if (hasInputMode(InputMode::Touch)) {
+    inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, id, x, y));
+  }
 }
 void WindowCallbacks::onTouchUpdate(int id, double x, double y) {
-    if(hasInputMode(InputMode::Touch)) {
-        inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, id, x, y));
-    }
+  if (hasInputMode(InputMode::Touch)) {
+    inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, id, x, y));
+  }
 }
 void WindowCallbacks::onTouchEnd(int id, double x, double y) {
-    if(hasInputMode(InputMode::Touch)) {
-        inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, id, x, y));
-    }
+  if (hasInputMode(InputMode::Touch)) {
+    inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, id, x, y));
+  }
 }
 void WindowCallbacks::onKeyboard(KeyCode key, KeyAction action) {
-    if(hasInputMode(InputMode::Mouse)) {
-        // return onKeyboard((KeyCode) 4, KeyAction::PRESS);
-        // key = (KeyCode) 0x21;
-    #ifdef __APPLE__
-        if (key == KeyCode::LEFT_SUPER || key == KeyCode::RIGHT_SUPER)
-    #else
-        if (key == KeyCode::LEFT_CTRL || key == KeyCode::RIGHT_CTRL)
-    #endif
-            modCTRL = (action != KeyAction::RELEASE);
+  if (hasInputMode(InputMode::Mouse)) {
+    // return onKeyboard((KeyCode) 4, KeyAction::PRESS);
+    // key = (KeyCode) 0x21;
+#ifdef __APPLE__
+    if (key == KeyCode::LEFT_SUPER || key == KeyCode::RIGHT_SUPER)
+#else
+    if (key == KeyCode::LEFT_CTRL || key == KeyCode::RIGHT_CTRL)
+#endif
+      modCTRL = (action != KeyAction::RELEASE);
 
-        if (modCTRL && key == KeyCode::C) {
-            window.setClipboardText(jniSupport.getTextInputHandler().getCopyText());
-        } else {
-            jniSupport.getTextInputHandler().onKeyPressed(key, action);
-        }
-
-        if (key == KeyCode::FN11 && action == KeyAction::PRESS)
-            window.setFullscreen(fullscreen = !fullscreen);
-
-        if (useDirectKeyboardInput && (action == KeyAction::PRESS || action == KeyAction::RELEASE)) {
-            Keyboard::InputEvent evData {};
-            evData.key = (unsigned int) key & 0xff;
-            evData.event = (action == KeyAction::PRESS ? 1 : 0);
-            evData.controllerId = *Keyboard::_gameControllerId;
-            Keyboard::_inputs->push_back(evData);
-            Keyboard::_states[(int) key & 0xff] = evData.event;
-            return;
-        }
-
-        if (action == KeyAction::PRESS)
-            inputQueue.addEvent(FakeKeyEvent(AKEY_EVENT_ACTION_DOWN, mapMinecraftToAndroidKey(key)));
-        else if (action == KeyAction::RELEASE)
-            inputQueue.addEvent(FakeKeyEvent(AKEY_EVENT_ACTION_UP, mapMinecraftToAndroidKey(key)));
+    if (modCTRL && key == KeyCode::C) {
+      window.setClipboardText(jniSupport.getTextInputHandler().getCopyText());
+    } else {
+      jniSupport.getTextInputHandler().onKeyPressed(key, action);
     }
+
+    if (key == KeyCode::FN11 && action == KeyAction::PRESS)
+      window.setFullscreen(fullscreen = !fullscreen);
+
+    if (useDirectKeyboardInput &&
+        (action == KeyAction::PRESS || action == KeyAction::RELEASE)) {
+      Keyboard::InputEvent evData{};
+      evData.key = (unsigned int)key & 0xff;
+      evData.event = (action == KeyAction::PRESS ? 1 : 0);
+      evData.controllerId = *Keyboard::_gameControllerId;
+      Keyboard::_inputs->push_back(evData);
+      Keyboard::_states[(int)key & 0xff] = evData.event;
+      return;
+    }
+
+    if (action == KeyAction::PRESS)
+      inputQueue.addEvent(
+          FakeKeyEvent(AKEY_EVENT_ACTION_DOWN, mapMinecraftToAndroidKey(key)));
+    else if (action == KeyAction::RELEASE)
+      inputQueue.addEvent(
+          FakeKeyEvent(AKEY_EVENT_ACTION_UP, mapMinecraftToAndroidKey(key)));
+  }
 }
-void WindowCallbacks::onKeyboardText(std::string const& c) {
-    if (c == "\n" && !jniSupport.getTextInputHandler().isMultiline())
-        jniSupport.onReturnKeyPressed();
-    else
-        jniSupport.getTextInputHandler().onTextInput(c);
+void WindowCallbacks::onKeyboardText(std::string const &c) {
+  if (c == "\n" && !jniSupport.getTextInputHandler().isMultiline())
+    jniSupport.onReturnKeyPressed();
+  else
+    jniSupport.getTextInputHandler().onTextInput(c);
 }
-void WindowCallbacks::onPaste(std::string const& str) {
-    jniSupport.getTextInputHandler().onTextInput(str);
+void WindowCallbacks::onPaste(std::string const &str) {
+  jniSupport.getTextInputHandler().onTextInput(str);
 }
 void WindowCallbacks::onGamepadState(int gamepad, bool connected) {
-    Log::trace("WindowCallbacks", "Gamepad %s #%i", connected ? "connected" : "disconnected", gamepad);
-    if (connected)
-        gamepads.insert({gamepad, GamepadData()});
-    else
-        gamepads.erase(gamepad);
-    // This crashs the game 1.16.210+ during init, but works after loading, disable for now
-    // jniSupport.setGameControllerConnected(gamepad, connected);
+  Log::trace("WindowCallbacks", "Gamepad %s #%i",
+             connected ? "connected" : "disconnected", gamepad);
+  if (connected)
+    gamepads.insert({gamepad, GamepadData()});
+  else
+    gamepads.erase(gamepad);
+  // This crashs the game 1.16.210+ during init, but works after loading,
+  // disable for now jniSupport.setGameControllerConnected(gamepad, connected);
 }
 
 void WindowCallbacks::queueGamepadAxisInputIfNeeded(int gamepad) {
-    if (!needsQueueGamepadInput)
-        return;
-    inputQueue.addEvent(FakeMotionEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AMOTION_EVENT_ACTION_MOVE, 0, 0.f, 0.f,
-            [this, gamepad](int axis) {
-                auto gpi = gamepads.find(gamepad);
-                if (gpi == gamepads.end())
-                    return 0.f;
-                auto& gp = gpi->second;
-                if (axis == AMOTION_EVENT_AXIS_X) return gp.axis[(int) GamepadAxisId::LEFT_X];
-                if (axis == AMOTION_EVENT_AXIS_Y) return gp.axis[(int) GamepadAxisId::LEFT_Y];
-                if (axis == AMOTION_EVENT_AXIS_RX) return gp.axis[(int) GamepadAxisId::RIGHT_X];
-                if (axis == AMOTION_EVENT_AXIS_RY) return gp.axis[(int) GamepadAxisId::RIGHT_Y];
-                if (axis == AMOTION_EVENT_AXIS_BRAKE) return gp.axis[(int) GamepadAxisId::LEFT_TRIGGER];
-                if (axis == AMOTION_EVENT_AXIS_GAS) return gp.axis[(int) GamepadAxisId::RIGHT_TRIGGER];
-                if (axis == AMOTION_EVENT_AXIS_HAT_X) {
-                    if (gp.button[(int) GamepadButtonId::DPAD_LEFT])
-                        return -1.f;
-                    if (gp.button[(int) GamepadButtonId::DPAD_RIGHT])
-                        return 1.f;
-                    return 0.f;
-                }
-                if (axis == AMOTION_EVENT_AXIS_HAT_Y) {
-                    if (gp.button[(int) GamepadButtonId::DPAD_UP])
-                        return -1.f;
-                    if (gp.button[(int) GamepadButtonId::DPAD_DOWN])
-                        return 1.f;
-                    return 0.f;
-                }
-                return 0.f;
-            }));
-    needsQueueGamepadInput = false;
+  if (!needsQueueGamepadInput)
+    return;
+  inputQueue.addEvent(
+      FakeMotionEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AMOTION_EVENT_ACTION_MOVE,
+                      0, 0.f, 0.f, [this, gamepad](int axis) {
+                        auto gpi = gamepads.find(gamepad);
+                        if (gpi == gamepads.end())
+                          return 0.f;
+                        auto &gp = gpi->second;
+                        if (axis == AMOTION_EVENT_AXIS_X)
+                          return gp.axis[(int)GamepadAxisId::LEFT_X];
+                        if (axis == AMOTION_EVENT_AXIS_Y)
+                          return gp.axis[(int)GamepadAxisId::LEFT_Y];
+                        if (axis == AMOTION_EVENT_AXIS_RX)
+                          return gp.axis[(int)GamepadAxisId::RIGHT_X];
+                        if (axis == AMOTION_EVENT_AXIS_RY)
+                          return gp.axis[(int)GamepadAxisId::RIGHT_Y];
+                        if (axis == AMOTION_EVENT_AXIS_BRAKE)
+                          return gp.axis[(int)GamepadAxisId::LEFT_TRIGGER];
+                        if (axis == AMOTION_EVENT_AXIS_GAS)
+                          return gp.axis[(int)GamepadAxisId::RIGHT_TRIGGER];
+                        if (axis == AMOTION_EVENT_AXIS_HAT_X) {
+                          if (gp.button[(int)GamepadButtonId::DPAD_LEFT])
+                            return -1.f;
+                          if (gp.button[(int)GamepadButtonId::DPAD_RIGHT])
+                            return 1.f;
+                          return 0.f;
+                        }
+                        if (axis == AMOTION_EVENT_AXIS_HAT_Y) {
+                          if (gp.button[(int)GamepadButtonId::DPAD_UP])
+                            return -1.f;
+                          if (gp.button[(int)GamepadButtonId::DPAD_DOWN])
+                            return 1.f;
+                          return 0.f;
+                        }
+                        return 0.f;
+                      }));
+  needsQueueGamepadInput = false;
 }
 
-void WindowCallbacks::onGamepadButton(int gamepad, GamepadButtonId btn, bool pressed) {
-    if(hasInputMode(InputMode::Gamepad)) {
-        auto gpi = gamepads.find(gamepad);
-        if (gpi == gamepads.end())
-            return;
-        auto& gp = gpi->second;
-        if ((int) btn < 0 || (int) btn >= 15)
-            throw std::runtime_error("bad button id");
-        if (gp.button[(int) btn] == pressed)
-            return;
-        gp.button[(int) btn] = pressed;
+void WindowCallbacks::onGamepadButton(int gamepad, GamepadButtonId btn,
+                                      bool pressed) {
+  if (hasInputMode(InputMode::Gamepad)) {
+    auto gpi = gamepads.find(gamepad);
+    if (gpi == gamepads.end())
+      return;
+    auto &gp = gpi->second;
+    if ((int)btn < 0 || (int)btn >= 15)
+      throw std::runtime_error("bad button id");
+    if (gp.button[(int)btn] == pressed)
+      return;
+    gp.button[(int)btn] = pressed;
 
-        if (btn == GamepadButtonId::DPAD_UP || btn == GamepadButtonId::DPAD_DOWN || btn == GamepadButtonId::DPAD_LEFT || btn == GamepadButtonId::DPAD_RIGHT) {
-            queueGamepadAxisInputIfNeeded(gamepad);
-            return;
-        }
-
-        if (pressed)
-            inputQueue.addEvent(FakeKeyEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AKEY_EVENT_ACTION_DOWN, mapGamepadToAndroidKey(btn)));
-        else
-            inputQueue.addEvent(FakeKeyEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AKEY_EVENT_ACTION_UP, mapGamepadToAndroidKey(btn)));
+    if (btn == GamepadButtonId::DPAD_UP || btn == GamepadButtonId::DPAD_DOWN ||
+        btn == GamepadButtonId::DPAD_LEFT ||
+        btn == GamepadButtonId::DPAD_RIGHT) {
+      queueGamepadAxisInputIfNeeded(gamepad);
+      return;
     }
+
+    if (pressed)
+      inputQueue.addEvent(FakeKeyEvent(AINPUT_SOURCE_GAMEPAD, gamepad,
+                                       AKEY_EVENT_ACTION_DOWN,
+                                       mapGamepadToAndroidKey(btn)));
+    else
+      inputQueue.addEvent(FakeKeyEvent(AINPUT_SOURCE_GAMEPAD, gamepad,
+                                       AKEY_EVENT_ACTION_UP,
+                                       mapGamepadToAndroidKey(btn)));
+  }
 }
 
-void WindowCallbacks::onGamepadAxis(int gamepad, GamepadAxisId ax, float value) {
-    if(hasInputMode(InputMode::Gamepad, std::abs(value) > 0.4f )) {
-        auto gpi = gamepads.find(gamepad);
-        if (gpi == gamepads.end())
-            return;
-        auto& gp = gpi->second;
-        if ((int) ax < 0 || (int) ax >= 6)
-            throw std::runtime_error("bad axis id");
-        gp.axis[(int) ax] = value;
-        queueGamepadAxisInputIfNeeded(gamepad);
-    }
+void WindowCallbacks::onGamepadAxis(int gamepad, GamepadAxisId ax,
+                                    float value) {
+  if (hasInputMode(InputMode::Gamepad, std::abs(value) > 0.4f)) {
+    auto gpi = gamepads.find(gamepad);
+    if (gpi == gamepads.end())
+      return;
+    auto &gp = gpi->second;
+    if ((int)ax < 0 || (int)ax >= 6)
+      throw std::runtime_error("bad axis id");
+    gp.axis[(int)ax] = value;
+    queueGamepadAxisInputIfNeeded(gamepad);
+  }
 }
 
 void WindowCallbacks::loadGamepadMappings() {
-    auto windowManager = GameWindowManager::getManager();
-    std::vector<std::string> controllerDbPaths;
-    PathHelper::findAllDataFiles("gamecontrollerdb.txt", [&controllerDbPaths](std::string const &path) {
-        controllerDbPaths.push_back(path);
-    });
-    // Bugfix: allow users to change internal gamepad layouts
-    std::reverse(controllerDbPaths.begin(), controllerDbPaths.end());
-    for (std::string const& path : controllerDbPaths) {
-        Log::trace("Launcher", "Loading gamepad mappings: %s", path.c_str());
-        windowManager->addGamepadMappingFile(path);
-    }
+  auto windowManager = GameWindowManager::getManager();
+  std::vector<std::string> controllerDbPaths;
+  PathHelper::findAllDataFiles("gamecontrollerdb.txt",
+                               [&controllerDbPaths](std::string const &path) {
+                                 controllerDbPaths.push_back(path);
+                               });
+  // Bugfix: allow users to change internal gamepad layouts
+  std::reverse(controllerDbPaths.begin(), controllerDbPaths.end());
+  for (std::string const &path : controllerDbPaths) {
+    Log::trace("Launcher", "Loading gamepad mappings: %s", path.c_str());
+    windowManager->addGamepadMappingFile(path);
+  }
 }
 
 WindowCallbacks::GamepadData::GamepadData() {
-    for (int i = 0; i < 6; i++)
-        axis[i] = 0.f;
-    memset(button, 0, sizeof(button));
+  for (int i = 0; i < 6; i++)
+    axis[i] = 0.f;
+  memset(button, 0, sizeof(button));
 }
 
 int WindowCallbacks::mapMinecraftToAndroidKey(KeyCode code) {
-    if (code >= KeyCode::NUM_0 && code <= KeyCode::NUM_9)
-        return (int) code - (int) KeyCode::NUM_0 + AKEYCODE_0;
-    if (code >= KeyCode::A && code <= KeyCode::Z)
-        return (int) code - (int) KeyCode::A + AKEYCODE_A;
-    if (code >= KeyCode::FN1 && code <= KeyCode::FN12)
-        return (int) code - (int) KeyCode::FN1 + AKEYCODE_F1;
-    switch (code) {
-        case KeyCode::BACK: return AKEYCODE_BACK;
-        case KeyCode::BACKSPACE: return AKEYCODE_DEL;
-        case KeyCode::TAB: return AKEYCODE_TAB;
-        case KeyCode::ENTER: return AKEYCODE_ENTER;
-        case KeyCode::LEFT_SHIFT: return AKEYCODE_SHIFT_LEFT;
-        case KeyCode::RIGHT_SHIFT: return AKEYCODE_SHIFT_RIGHT;
-        case KeyCode::LEFT_CTRL: return AKEYCODE_CTRL_LEFT;
-        case KeyCode::RIGHT_CTRL: return AKEYCODE_CTRL_RIGHT;
-        case KeyCode::PAUSE: return AKEYCODE_BREAK;
-        case KeyCode::CAPS_LOCK: return AKEYCODE_CAPS_LOCK;
-        case KeyCode::ESCAPE: return AKEYCODE_ESCAPE;
-        case KeyCode::SPACE: return AKEYCODE_SPACE;
-        case KeyCode::PAGE_UP: return AKEYCODE_PAGE_UP;
-        case KeyCode::PAGE_DOWN: return AKEYCODE_PAGE_DOWN;
-        case KeyCode::END: return AKEYCODE_MOVE_END;
-        case KeyCode::HOME: return AKEYCODE_MOVE_HOME;
-        case KeyCode::LEFT: return AKEYCODE_DPAD_LEFT;
-        case KeyCode::UP: return AKEYCODE_DPAD_UP;
-        case KeyCode::RIGHT: return AKEYCODE_DPAD_RIGHT;
-        case KeyCode::DOWN: return AKEYCODE_DPAD_DOWN;
-        case KeyCode::INSERT: return AKEYCODE_INSERT;
-        case KeyCode::DELETE: return AKEYCODE_FORWARD_DEL;
-        case KeyCode::NUM_LOCK: return AKEYCODE_NUM_LOCK;
-        case KeyCode::SCROLL_LOCK: return AKEYCODE_SCROLL_LOCK;
-        case KeyCode::SEMICOLON: return AKEYCODE_SEMICOLON;
-        case KeyCode::EQUAL: return AKEYCODE_EQUALS;
-        case KeyCode::COMMA: return AKEYCODE_COMMA;
-        case KeyCode::MINUS: return AKEYCODE_MINUS;
-        case KeyCode::PERIOD: return AKEYCODE_PERIOD;
-        case KeyCode::SLASH: return AKEYCODE_SLASH;
-        case KeyCode::GRAVE: return AKEYCODE_GRAVE;
-        case KeyCode::LEFT_BRACKET: return AKEYCODE_LEFT_BRACKET;
-        case KeyCode::BACKSLASH: return AKEYCODE_BACKSLASH;
-        case KeyCode::RIGHT_BRACKET: return AKEYCODE_RIGHT_BRACKET;
-        case KeyCode::APOSTROPHE: return AKEYCODE_APOSTROPHE;
-        case KeyCode::MENU: return AKEYCODE_MENU;
-        case KeyCode::LEFT_SUPER: return AKEYCODE_META_LEFT;
-        case KeyCode::RIGHT_SUPER: return AKEYCODE_META_RIGHT;
-        case KeyCode::LEFT_ALT: return AKEYCODE_ALT_LEFT;
-        case KeyCode::RIGHT_ALT: return AKEYCODE_ALT_RIGHT;
-        default: return AKEYCODE_UNKNOWN;
-    }
+  if (code >= KeyCode::NUM_0 && code <= KeyCode::NUM_9)
+    return (int)code - (int)KeyCode::NUM_0 + AKEYCODE_0;
+  if (code >= KeyCode::A && code <= KeyCode::Z)
+    return (int)code - (int)KeyCode::A + AKEYCODE_A;
+  if (code >= KeyCode::FN1 && code <= KeyCode::FN12)
+    return (int)code - (int)KeyCode::FN1 + AKEYCODE_F1;
+  switch (code) {
+  case KeyCode::BACK:
+    return AKEYCODE_BACK;
+  case KeyCode::BACKSPACE:
+    return AKEYCODE_DEL;
+  case KeyCode::TAB:
+    return AKEYCODE_TAB;
+  case KeyCode::ENTER:
+    return AKEYCODE_ENTER;
+  case KeyCode::LEFT_SHIFT:
+    return AKEYCODE_SHIFT_LEFT;
+  case KeyCode::RIGHT_SHIFT:
+    return AKEYCODE_SHIFT_RIGHT;
+  case KeyCode::LEFT_CTRL:
+    return AKEYCODE_CTRL_LEFT;
+  case KeyCode::RIGHT_CTRL:
+    return AKEYCODE_CTRL_RIGHT;
+  case KeyCode::PAUSE:
+    return AKEYCODE_BREAK;
+  case KeyCode::CAPS_LOCK:
+    return AKEYCODE_CAPS_LOCK;
+  case KeyCode::ESCAPE:
+    return AKEYCODE_ESCAPE;
+  case KeyCode::SPACE:
+    return AKEYCODE_SPACE;
+  case KeyCode::PAGE_UP:
+    return AKEYCODE_PAGE_UP;
+  case KeyCode::PAGE_DOWN:
+    return AKEYCODE_PAGE_DOWN;
+  case KeyCode::END:
+    return AKEYCODE_MOVE_END;
+  case KeyCode::HOME:
+    return AKEYCODE_MOVE_HOME;
+  case KeyCode::LEFT:
+    return AKEYCODE_DPAD_LEFT;
+  case KeyCode::UP:
+    return AKEYCODE_DPAD_UP;
+  case KeyCode::RIGHT:
+    return AKEYCODE_DPAD_RIGHT;
+  case KeyCode::DOWN:
+    return AKEYCODE_DPAD_DOWN;
+  case KeyCode::INSERT:
+    return AKEYCODE_INSERT;
+  case KeyCode::DELETE:
+    return AKEYCODE_FORWARD_DEL;
+  case KeyCode::NUM_LOCK:
+    return AKEYCODE_NUM_LOCK;
+  case KeyCode::SCROLL_LOCK:
+    return AKEYCODE_SCROLL_LOCK;
+  case KeyCode::SEMICOLON:
+    return AKEYCODE_SEMICOLON;
+  case KeyCode::EQUAL:
+    return AKEYCODE_EQUALS;
+  case KeyCode::COMMA:
+    return AKEYCODE_COMMA;
+  case KeyCode::MINUS:
+    return AKEYCODE_MINUS;
+  case KeyCode::PERIOD:
+    return AKEYCODE_PERIOD;
+  case KeyCode::SLASH:
+    return AKEYCODE_SLASH;
+  case KeyCode::GRAVE:
+    return AKEYCODE_GRAVE;
+  case KeyCode::LEFT_BRACKET:
+    return AKEYCODE_LEFT_BRACKET;
+  case KeyCode::BACKSLASH:
+    return AKEYCODE_BACKSLASH;
+  case KeyCode::RIGHT_BRACKET:
+    return AKEYCODE_RIGHT_BRACKET;
+  case KeyCode::APOSTROPHE:
+    return AKEYCODE_APOSTROPHE;
+  case KeyCode::MENU:
+    return AKEYCODE_MENU;
+  case KeyCode::LEFT_SUPER:
+    return AKEYCODE_META_LEFT;
+  case KeyCode::RIGHT_SUPER:
+    return AKEYCODE_META_RIGHT;
+  case KeyCode::LEFT_ALT:
+    return AKEYCODE_ALT_LEFT;
+  case KeyCode::RIGHT_ALT:
+    return AKEYCODE_ALT_RIGHT;
+  default:
+    return AKEYCODE_UNKNOWN;
+  }
 }
 
 int WindowCallbacks::mapGamepadToAndroidKey(GamepadButtonId btn) {
-    switch (btn) {
-        case GamepadButtonId::A: return AKEYCODE_BUTTON_A;
-        case GamepadButtonId::B: return AKEYCODE_BUTTON_B;
-        case GamepadButtonId::X: return AKEYCODE_BUTTON_X;
-        case GamepadButtonId::Y: return AKEYCODE_BUTTON_Y;
-        case GamepadButtonId::LB: return AKEYCODE_BUTTON_L1;
-        case GamepadButtonId::RB: return AKEYCODE_BUTTON_R1;
-        case GamepadButtonId::BACK: return AKEYCODE_BUTTON_SELECT;
-        case GamepadButtonId::START: return AKEYCODE_BUTTON_START;
-        case GamepadButtonId::GUIDE: return AKEYCODE_BUTTON_MODE;
-        case GamepadButtonId::LEFT_STICK: return AKEYCODE_BUTTON_THUMBL;
-        case GamepadButtonId::RIGHT_STICK: return AKEYCODE_BUTTON_THUMBR;
-        case GamepadButtonId::DPAD_UP: return AKEYCODE_DPAD_UP;
-        case GamepadButtonId::DPAD_RIGHT: return AKEYCODE_DPAD_RIGHT;
-        case GamepadButtonId::DPAD_DOWN: return AKEYCODE_DPAD_DOWN;
-        case GamepadButtonId::DPAD_LEFT: return AKEYCODE_DPAD_LEFT;
-        default: return -1;
-    }
+  switch (btn) {
+  case GamepadButtonId::A:
+    return AKEYCODE_BUTTON_A;
+  case GamepadButtonId::B:
+    return AKEYCODE_BUTTON_B;
+  case GamepadButtonId::X:
+    return AKEYCODE_BUTTON_X;
+  case GamepadButtonId::Y:
+    return AKEYCODE_BUTTON_Y;
+  case GamepadButtonId::LB:
+    return AKEYCODE_BUTTON_L1;
+  case GamepadButtonId::RB:
+    return AKEYCODE_BUTTON_R1;
+  case GamepadButtonId::BACK:
+    return AKEYCODE_BUTTON_SELECT;
+  case GamepadButtonId::START:
+    return AKEYCODE_BUTTON_START;
+  case GamepadButtonId::GUIDE:
+    return AKEYCODE_BUTTON_MODE;
+  case GamepadButtonId::LEFT_STICK:
+    return AKEYCODE_BUTTON_THUMBL;
+  case GamepadButtonId::RIGHT_STICK:
+    return AKEYCODE_BUTTON_THUMBR;
+  case GamepadButtonId::DPAD_UP:
+    return AKEYCODE_DPAD_UP;
+  case GamepadButtonId::DPAD_RIGHT:
+    return AKEYCODE_DPAD_RIGHT;
+  case GamepadButtonId::DPAD_DOWN:
+    return AKEYCODE_DPAD_DOWN;
+  case GamepadButtonId::DPAD_LEFT:
+    return AKEYCODE_DPAD_LEFT;
+  default:
+    return -1;
+  }
 }

--- a/src/window_callbacks.cpp
+++ b/src/window_callbacks.cpp
@@ -7,14 +7,12 @@
 #include <mcpelauncher/path_helper.h>
 
 WindowCallbacks::WindowCallbacks(GameWindow &window, JniSupport &jniSupport, FakeInputQueue &inputQueue)
-    : window(window), jniSupport(jniSupport), inputQueue(inputQueue)
-{
+    : window(window), jniSupport(jniSupport), inputQueue(inputQueue) {
     useDirectMouseInput = true;
     useDirectKeyboardInput = false;
 }
 
-void WindowCallbacks::registerCallbacks()
-{
+void WindowCallbacks::registerCallbacks() {
     using namespace std::placeholders;
     window.setWindowSizeCallback(std::bind(&WindowCallbacks::onWindowSizeCallback, this, _1, _2));
     window.setCloseCallback(std::bind(&WindowCallbacks::onClose, this));
@@ -38,23 +36,17 @@ void WindowCallbacks::onWindowSizeCallback(int w, int h) { jniSupport.onWindowRe
 
 void WindowCallbacks::onClose() { jniSupport.onWindowClosed(); }
 
-bool WindowCallbacks::hasInputMode(WindowCallbacks::InputMode want, bool changeMode)
-{
+bool WindowCallbacks::hasInputMode(WindowCallbacks::InputMode want, bool changeMode) {
     auto now = std::chrono::high_resolution_clock::now();
     if (inputMode == want ||
-        changeMode && ((int)want < (int)inputMode || (now - lastUpdated) > std::chrono::seconds(2)))
-    {
-        if (inputMode != want)
-        {
+        changeMode && ((int)want < (int)inputMode || (now - lastUpdated) > std::chrono::seconds(2))) {
+        if (inputMode != want) {
 #ifndef NDEBUG
             printf("Input Mode changed to %d\n", (int)want);
 #endif
-            if (want == InputMode::Mouse)
-            {
+            if (want == InputMode::Mouse) {
                 window.setCursorDisabled(false);
-            }
-            else
-            {
+            } else {
                 window.setCursorDisabled(true);
             }
         }
@@ -65,14 +57,11 @@ bool WindowCallbacks::hasInputMode(WindowCallbacks::InputMode want, bool changeM
     return false;
 }
 
-void WindowCallbacks::onMouseButton(double x, double y, int btn, MouseButtonAction action)
-{
-    if (hasInputMode(InputMode::Mouse))
-    {
+void WindowCallbacks::onMouseButton(double x, double y, int btn, MouseButtonAction action) {
+    if (hasInputMode(InputMode::Mouse)) {
         if (btn < 1)
             return;
-        if (btn > 3)
-        {
+        if (btn > 3) {
             // Seems to get recognized same as regular Mousebuttons as Button4 or
             // higher, but ignored from mouse
             return onKeyboard((KeyCode)btn, action == MouseButtonAction::PRESS ? KeyAction::PRESS : KeyAction::RELEASE);
@@ -85,60 +74,46 @@ void WindowCallbacks::onMouseButton(double x, double y, int btn, MouseButtonActi
             inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, 0, x, y));
     }
 }
-void WindowCallbacks::onMousePosition(double x, double y)
-{
-    if (hasInputMode(InputMode::Mouse))
-    {
+void WindowCallbacks::onMousePosition(double x, double y) {
+    if (hasInputMode(InputMode::Mouse)) {
         if (useDirectMouseInput)
             Mouse::feed(0, 0, (short)x, (short)y, 0, 0);
         else
             inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
     }
 }
-void WindowCallbacks::onMouseRelativePosition(double x, double y)
-{
-    if (hasInputMode(InputMode::Mouse, std::abs(x) > 10 || std::abs(y) > 10))
-    {
+void WindowCallbacks::onMouseRelativePosition(double x, double y) {
+    if (hasInputMode(InputMode::Mouse, std::abs(x) > 10 || std::abs(y) > 10)) {
         if (useDirectMouseInput)
             Mouse::feed(0, 0, 0, 0, (short)x, (short)y);
         else
             inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
     }
 }
-void WindowCallbacks::onMouseScroll(double x, double y, double dx, double dy)
-{
-    if (hasInputMode(InputMode::Mouse))
-    {
+void WindowCallbacks::onMouseScroll(double x, double y, double dx, double dy) {
+    if (hasInputMode(InputMode::Mouse)) {
         signed char cdy = (signed char)std::max(std::min(dy * 127.0, 127.0), -127.0);
         if (useDirectMouseInput)
             Mouse::feed(4, (char &)cdy, 0, 0, (short)x, (short)y);
     }
 }
-void WindowCallbacks::onTouchStart(int id, double x, double y)
-{
-    if (hasInputMode(InputMode::Touch))
-    {
+void WindowCallbacks::onTouchStart(int id, double x, double y) {
+    if (hasInputMode(InputMode::Touch)) {
         inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, id, x, y));
     }
 }
-void WindowCallbacks::onTouchUpdate(int id, double x, double y)
-{
-    if (hasInputMode(InputMode::Touch))
-    {
+void WindowCallbacks::onTouchUpdate(int id, double x, double y) {
+    if (hasInputMode(InputMode::Touch)) {
         inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, id, x, y));
     }
 }
-void WindowCallbacks::onTouchEnd(int id, double x, double y)
-{
-    if (hasInputMode(InputMode::Touch))
-    {
+void WindowCallbacks::onTouchEnd(int id, double x, double y) {
+    if (hasInputMode(InputMode::Touch)) {
         inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, id, x, y));
     }
 }
-void WindowCallbacks::onKeyboard(KeyCode key, KeyAction action)
-{
-    if (hasInputMode(InputMode::Mouse))
-    {
+void WindowCallbacks::onKeyboard(KeyCode key, KeyAction action) {
+    if (hasInputMode(InputMode::Mouse)) {
         // return onKeyboard((KeyCode) 4, KeyAction::PRESS);
         // key = (KeyCode) 0x21;
 #ifdef __APPLE__
@@ -148,20 +123,16 @@ void WindowCallbacks::onKeyboard(KeyCode key, KeyAction action)
 #endif
             modCTRL = (action != KeyAction::RELEASE);
 
-        if (modCTRL && key == KeyCode::C)
-        {
+        if (modCTRL && key == KeyCode::C) {
             window.setClipboardText(jniSupport.getTextInputHandler().getCopyText());
-        }
-        else
-        {
+        } else {
             jniSupport.getTextInputHandler().onKeyPressed(key, action);
         }
 
         if (key == KeyCode::FN11 && action == KeyAction::PRESS)
             window.setFullscreen(fullscreen = !fullscreen);
 
-        if (useDirectKeyboardInput && (action == KeyAction::PRESS || action == KeyAction::RELEASE))
-        {
+        if (useDirectKeyboardInput && (action == KeyAction::PRESS || action == KeyAction::RELEASE)) {
             Keyboard::InputEvent evData{};
             evData.key = (unsigned int)key & 0xff;
             evData.event = (action == KeyAction::PRESS ? 1 : 0);
@@ -177,16 +148,14 @@ void WindowCallbacks::onKeyboard(KeyCode key, KeyAction action)
             inputQueue.addEvent(FakeKeyEvent(AKEY_EVENT_ACTION_UP, mapMinecraftToAndroidKey(key)));
     }
 }
-void WindowCallbacks::onKeyboardText(std::string const &c)
-{
+void WindowCallbacks::onKeyboardText(std::string const &c) {
     if (c == "\n" && !jniSupport.getTextInputHandler().isMultiline())
         jniSupport.onReturnKeyPressed();
     else
         jniSupport.getTextInputHandler().onTextInput(c);
 }
 void WindowCallbacks::onPaste(std::string const &str) { jniSupport.getTextInputHandler().onTextInput(str); }
-void WindowCallbacks::onGamepadState(int gamepad, bool connected)
-{
+void WindowCallbacks::onGamepadState(int gamepad, bool connected) {
     Log::trace("WindowCallbacks", "Gamepad %s #%i", connected ? "connected" : "disconnected", gamepad);
     if (connected)
         gamepads.insert({gamepad, GamepadData()});
@@ -196,13 +165,11 @@ void WindowCallbacks::onGamepadState(int gamepad, bool connected)
     // disable for now jniSupport.setGameControllerConnected(gamepad, connected);
 }
 
-void WindowCallbacks::queueGamepadAxisInputIfNeeded(int gamepad)
-{
+void WindowCallbacks::queueGamepadAxisInputIfNeeded(int gamepad) {
     if (!needsQueueGamepadInput)
         return;
     inputQueue.addEvent(FakeMotionEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AMOTION_EVENT_ACTION_MOVE, 0, 0.f, 0.f,
-                                        [this, gamepad](int axis)
-                                        {
+                                        [this, gamepad](int axis) {
                                             auto gpi = gamepads.find(gamepad);
                                             if (gpi == gamepads.end())
                                                 return 0.f;
@@ -219,16 +186,14 @@ void WindowCallbacks::queueGamepadAxisInputIfNeeded(int gamepad)
                                                 return gp.axis[(int)GamepadAxisId::LEFT_TRIGGER];
                                             if (axis == AMOTION_EVENT_AXIS_GAS)
                                                 return gp.axis[(int)GamepadAxisId::RIGHT_TRIGGER];
-                                            if (axis == AMOTION_EVENT_AXIS_HAT_X)
-                                            {
+                                            if (axis == AMOTION_EVENT_AXIS_HAT_X) {
                                                 if (gp.button[(int)GamepadButtonId::DPAD_LEFT])
                                                     return -1.f;
                                                 if (gp.button[(int)GamepadButtonId::DPAD_RIGHT])
                                                     return 1.f;
                                                 return 0.f;
                                             }
-                                            if (axis == AMOTION_EVENT_AXIS_HAT_Y)
-                                            {
+                                            if (axis == AMOTION_EVENT_AXIS_HAT_Y) {
                                                 if (gp.button[(int)GamepadButtonId::DPAD_UP])
                                                     return -1.f;
                                                 if (gp.button[(int)GamepadButtonId::DPAD_DOWN])
@@ -240,10 +205,8 @@ void WindowCallbacks::queueGamepadAxisInputIfNeeded(int gamepad)
     needsQueueGamepadInput = false;
 }
 
-void WindowCallbacks::onGamepadButton(int gamepad, GamepadButtonId btn, bool pressed)
-{
-    if (hasInputMode(InputMode::Gamepad))
-    {
+void WindowCallbacks::onGamepadButton(int gamepad, GamepadButtonId btn, bool pressed) {
+    if (hasInputMode(InputMode::Gamepad)) {
         auto gpi = gamepads.find(gamepad);
         if (gpi == gamepads.end())
             return;
@@ -255,8 +218,7 @@ void WindowCallbacks::onGamepadButton(int gamepad, GamepadButtonId btn, bool pre
         gp.button[(int)btn] = pressed;
 
         if (btn == GamepadButtonId::DPAD_UP || btn == GamepadButtonId::DPAD_DOWN || btn == GamepadButtonId::DPAD_LEFT ||
-            btn == GamepadButtonId::DPAD_RIGHT)
-        {
+            btn == GamepadButtonId::DPAD_RIGHT) {
             queueGamepadAxisInputIfNeeded(gamepad);
             return;
         }
@@ -270,10 +232,8 @@ void WindowCallbacks::onGamepadButton(int gamepad, GamepadButtonId btn, bool pre
     }
 }
 
-void WindowCallbacks::onGamepadAxis(int gamepad, GamepadAxisId ax, float value)
-{
-    if (hasInputMode(InputMode::Gamepad, std::abs(value) > 0.4f))
-    {
+void WindowCallbacks::onGamepadAxis(int gamepad, GamepadAxisId ax, float value) {
+    if (hasInputMode(InputMode::Gamepad, std::abs(value) > 0.4f)) {
         auto gpi = gamepads.find(gamepad);
         if (gpi == gamepads.end())
             return;
@@ -285,37 +245,32 @@ void WindowCallbacks::onGamepadAxis(int gamepad, GamepadAxisId ax, float value)
     }
 }
 
-void WindowCallbacks::loadGamepadMappings()
-{
+void WindowCallbacks::loadGamepadMappings() {
     auto windowManager = GameWindowManager::getManager();
     std::vector<std::string> controllerDbPaths;
     PathHelper::findAllDataFiles("gamecontrollerdb.txt",
                                  [&controllerDbPaths](std::string const &path) { controllerDbPaths.push_back(path); });
     // Bugfix: allow users to change internal gamepad layouts
     std::reverse(controllerDbPaths.begin(), controllerDbPaths.end());
-    for (std::string const &path : controllerDbPaths)
-    {
+    for (std::string const &path : controllerDbPaths) {
         Log::trace("Launcher", "Loading gamepad mappings: %s", path.c_str());
         windowManager->addGamepadMappingFile(path);
     }
 }
 
-WindowCallbacks::GamepadData::GamepadData()
-{
+WindowCallbacks::GamepadData::GamepadData() {
     for (int i = 0; i < 6; i++) axis[i] = 0.f;
     memset(button, 0, sizeof(button));
 }
 
-int WindowCallbacks::mapMinecraftToAndroidKey(KeyCode code)
-{
+int WindowCallbacks::mapMinecraftToAndroidKey(KeyCode code) {
     if (code >= KeyCode::NUM_0 && code <= KeyCode::NUM_9)
         return (int)code - (int)KeyCode::NUM_0 + AKEYCODE_0;
     if (code >= KeyCode::A && code <= KeyCode::Z)
         return (int)code - (int)KeyCode::A + AKEYCODE_A;
     if (code >= KeyCode::FN1 && code <= KeyCode::FN12)
         return (int)code - (int)KeyCode::FN1 + AKEYCODE_F1;
-    switch (code)
-    {
+    switch (code) {
     case KeyCode::BACK:
         return AKEYCODE_BACK;
     case KeyCode::BACKSPACE:
@@ -401,10 +356,8 @@ int WindowCallbacks::mapMinecraftToAndroidKey(KeyCode code)
     }
 }
 
-int WindowCallbacks::mapGamepadToAndroidKey(GamepadButtonId btn)
-{
-    switch (btn)
-    {
+int WindowCallbacks::mapGamepadToAndroidKey(GamepadButtonId btn) {
+    switch (btn) {
     case GamepadButtonId::A:
         return AKEYCODE_BUTTON_A;
     case GamepadButtonId::B:

--- a/src/window_callbacks.cpp
+++ b/src/window_callbacks.cpp
@@ -6,427 +6,436 @@
 #include <mcpelauncher/minecraft_version.h>
 #include <mcpelauncher/path_helper.h>
 
-WindowCallbacks::WindowCallbacks(GameWindow &window, JniSupport &jniSupport,
-                                 FakeInputQueue &inputQueue)
-    : window(window), jniSupport(jniSupport), inputQueue(inputQueue) {
-  useDirectMouseInput = true;
-  useDirectKeyboardInput = false;
+WindowCallbacks::WindowCallbacks(GameWindow &window, JniSupport &jniSupport, FakeInputQueue &inputQueue)
+    : window(window), jniSupport(jniSupport), inputQueue(inputQueue)
+{
+    useDirectMouseInput = true;
+    useDirectKeyboardInput = false;
 }
 
-void WindowCallbacks::registerCallbacks() {
-  using namespace std::placeholders;
-  window.setWindowSizeCallback(
-      std::bind(&WindowCallbacks::onWindowSizeCallback, this, _1, _2));
-  window.setCloseCallback(std::bind(&WindowCallbacks::onClose, this));
+void WindowCallbacks::registerCallbacks()
+{
+    using namespace std::placeholders;
+    window.setWindowSizeCallback(std::bind(&WindowCallbacks::onWindowSizeCallback, this, _1, _2));
+    window.setCloseCallback(std::bind(&WindowCallbacks::onClose, this));
 
-  window.setMouseButtonCallback(
-      std::bind(&WindowCallbacks::onMouseButton, this, _1, _2, _3, _4));
-  window.setMousePositionCallback(
-      std::bind(&WindowCallbacks::onMousePosition, this, _1, _2));
-  window.setMouseRelativePositionCallback(
-      std::bind(&WindowCallbacks::onMouseRelativePosition, this, _1, _2));
-  window.setMouseScrollCallback(
-      std::bind(&WindowCallbacks::onMouseScroll, this, _1, _2, _3, _4));
-  window.setTouchStartCallback(
-      std::bind(&WindowCallbacks::onTouchStart, this, _1, _2, _3));
-  window.setTouchUpdateCallback(
-      std::bind(&WindowCallbacks::onTouchUpdate, this, _1, _2, _3));
-  window.setTouchEndCallback(
-      std::bind(&WindowCallbacks::onTouchEnd, this, _1, _2, _3));
-  window.setKeyboardCallback(
-      std::bind(&WindowCallbacks::onKeyboard, this, _1, _2));
-  window.setKeyboardTextCallback(
-      std::bind(&WindowCallbacks::onKeyboardText, this, _1));
-  window.setPasteCallback(std::bind(&WindowCallbacks::onPaste, this, _1));
-  window.setGamepadStateCallback(
-      std::bind(&WindowCallbacks::onGamepadState, this, _1, _2));
-  window.setGamepadButtonCallback(
-      std::bind(&WindowCallbacks::onGamepadButton, this, _1, _2, _3));
-  window.setGamepadAxisCallback(
-      std::bind(&WindowCallbacks::onGamepadAxis, this, _1, _2, _3));
+    window.setMouseButtonCallback(std::bind(&WindowCallbacks::onMouseButton, this, _1, _2, _3, _4));
+    window.setMousePositionCallback(std::bind(&WindowCallbacks::onMousePosition, this, _1, _2));
+    window.setMouseRelativePositionCallback(std::bind(&WindowCallbacks::onMouseRelativePosition, this, _1, _2));
+    window.setMouseScrollCallback(std::bind(&WindowCallbacks::onMouseScroll, this, _1, _2, _3, _4));
+    window.setTouchStartCallback(std::bind(&WindowCallbacks::onTouchStart, this, _1, _2, _3));
+    window.setTouchUpdateCallback(std::bind(&WindowCallbacks::onTouchUpdate, this, _1, _2, _3));
+    window.setTouchEndCallback(std::bind(&WindowCallbacks::onTouchEnd, this, _1, _2, _3));
+    window.setKeyboardCallback(std::bind(&WindowCallbacks::onKeyboard, this, _1, _2));
+    window.setKeyboardTextCallback(std::bind(&WindowCallbacks::onKeyboardText, this, _1));
+    window.setPasteCallback(std::bind(&WindowCallbacks::onPaste, this, _1));
+    window.setGamepadStateCallback(std::bind(&WindowCallbacks::onGamepadState, this, _1, _2));
+    window.setGamepadButtonCallback(std::bind(&WindowCallbacks::onGamepadButton, this, _1, _2, _3));
+    window.setGamepadAxisCallback(std::bind(&WindowCallbacks::onGamepadAxis, this, _1, _2, _3));
 }
 
-void WindowCallbacks::onWindowSizeCallback(int w, int h) {
-  jniSupport.onWindowResized(w, h);
-}
+void WindowCallbacks::onWindowSizeCallback(int w, int h) { jniSupport.onWindowResized(w, h); }
 
 void WindowCallbacks::onClose() { jniSupport.onWindowClosed(); }
 
-bool WindowCallbacks::hasInputMode(WindowCallbacks::InputMode want,
-                                   bool changeMode) {
-  auto now = std::chrono::high_resolution_clock::now();
-  if (inputMode == want ||
-      changeMode && ((int)want < (int)inputMode ||
-                     (now - lastUpdated) > std::chrono::seconds(2))) {
-    if (inputMode != want) {
+bool WindowCallbacks::hasInputMode(WindowCallbacks::InputMode want, bool changeMode)
+{
+    auto now = std::chrono::high_resolution_clock::now();
+    if (inputMode == want ||
+        changeMode && ((int)want < (int)inputMode || (now - lastUpdated) > std::chrono::seconds(2)))
+    {
+        if (inputMode != want)
+        {
 #ifndef NDEBUG
-      printf("Input Mode changed to %d\n", (int)want);
+            printf("Input Mode changed to %d\n", (int)want);
 #endif
-      if (want == InputMode::Mouse) {
-        window.setCursorDisabled(false);
-      } else {
-        window.setCursorDisabled(true);
-      }
+            if (want == InputMode::Mouse)
+            {
+                window.setCursorDisabled(false);
+            }
+            else
+            {
+                window.setCursorDisabled(true);
+            }
+        }
+        inputMode = want;
+        lastUpdated = now;
+        return true;
     }
-    inputMode = want;
-    lastUpdated = now;
-    return true;
-  }
-  return false;
+    return false;
 }
 
-void WindowCallbacks::onMouseButton(double x, double y, int btn,
-                                    MouseButtonAction action) {
-  if (hasInputMode(InputMode::Mouse)) {
-    if (btn < 1)
-      return;
-    if (btn > 3) {
-      // Seems to get recognized same as regular Mousebuttons as Button4 or
-      // higher, but ignored from mouse
-      return onKeyboard((KeyCode)btn, action == MouseButtonAction::PRESS
-                                          ? KeyAction::PRESS
-                                          : KeyAction::RELEASE);
+void WindowCallbacks::onMouseButton(double x, double y, int btn, MouseButtonAction action)
+{
+    if (hasInputMode(InputMode::Mouse))
+    {
+        if (btn < 1)
+            return;
+        if (btn > 3)
+        {
+            // Seems to get recognized same as regular Mousebuttons as Button4 or
+            // higher, but ignored from mouse
+            return onKeyboard((KeyCode)btn, action == MouseButtonAction::PRESS ? KeyAction::PRESS : KeyAction::RELEASE);
+        }
+        if (useDirectMouseInput)
+            Mouse::feed((char)btn, (char)(action == MouseButtonAction::PRESS ? 1 : 0), (short)x, (short)y, 0, 0);
+        else if (action == MouseButtonAction::PRESS)
+            inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, 0, x, y));
+        else if (action == MouseButtonAction::RELEASE)
+            inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, 0, x, y));
     }
-    if (useDirectMouseInput)
-      Mouse::feed((char)btn, (char)(action == MouseButtonAction::PRESS ? 1 : 0),
-                  (short)x, (short)y, 0, 0);
-    else if (action == MouseButtonAction::PRESS)
-      inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, 0, x, y));
-    else if (action == MouseButtonAction::RELEASE)
-      inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, 0, x, y));
-  }
 }
-void WindowCallbacks::onMousePosition(double x, double y) {
-  if (hasInputMode(InputMode::Mouse)) {
-    if (useDirectMouseInput)
-      Mouse::feed(0, 0, (short)x, (short)y, 0, 0);
-    else
-      inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
-  }
+void WindowCallbacks::onMousePosition(double x, double y)
+{
+    if (hasInputMode(InputMode::Mouse))
+    {
+        if (useDirectMouseInput)
+            Mouse::feed(0, 0, (short)x, (short)y, 0, 0);
+        else
+            inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
+    }
 }
-void WindowCallbacks::onMouseRelativePosition(double x, double y) {
-  if (hasInputMode(InputMode::Mouse, std::abs(x) > 10 || std::abs(y) > 10)) {
-    if (useDirectMouseInput)
-      Mouse::feed(0, 0, 0, 0, (short)x, (short)y);
-    else
-      inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
-  }
+void WindowCallbacks::onMouseRelativePosition(double x, double y)
+{
+    if (hasInputMode(InputMode::Mouse, std::abs(x) > 10 || std::abs(y) > 10))
+    {
+        if (useDirectMouseInput)
+            Mouse::feed(0, 0, 0, 0, (short)x, (short)y);
+        else
+            inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, 0, x, y));
+    }
 }
-void WindowCallbacks::onMouseScroll(double x, double y, double dx, double dy) {
-  if (hasInputMode(InputMode::Mouse)) {
-    signed char cdy =
-        (signed char)std::max(std::min(dy * 127.0, 127.0), -127.0);
-    if (useDirectMouseInput)
-      Mouse::feed(4, (char &)cdy, 0, 0, (short)x, (short)y);
-  }
+void WindowCallbacks::onMouseScroll(double x, double y, double dx, double dy)
+{
+    if (hasInputMode(InputMode::Mouse))
+    {
+        signed char cdy = (signed char)std::max(std::min(dy * 127.0, 127.0), -127.0);
+        if (useDirectMouseInput)
+            Mouse::feed(4, (char &)cdy, 0, 0, (short)x, (short)y);
+    }
 }
-void WindowCallbacks::onTouchStart(int id, double x, double y) {
-  if (hasInputMode(InputMode::Touch)) {
-    inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, id, x, y));
-  }
+void WindowCallbacks::onTouchStart(int id, double x, double y)
+{
+    if (hasInputMode(InputMode::Touch))
+    {
+        inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_DOWN, id, x, y));
+    }
 }
-void WindowCallbacks::onTouchUpdate(int id, double x, double y) {
-  if (hasInputMode(InputMode::Touch)) {
-    inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, id, x, y));
-  }
+void WindowCallbacks::onTouchUpdate(int id, double x, double y)
+{
+    if (hasInputMode(InputMode::Touch))
+    {
+        inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_MOVE, id, x, y));
+    }
 }
-void WindowCallbacks::onTouchEnd(int id, double x, double y) {
-  if (hasInputMode(InputMode::Touch)) {
-    inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, id, x, y));
-  }
+void WindowCallbacks::onTouchEnd(int id, double x, double y)
+{
+    if (hasInputMode(InputMode::Touch))
+    {
+        inputQueue.addEvent(FakeMotionEvent(AMOTION_EVENT_ACTION_UP, id, x, y));
+    }
 }
-void WindowCallbacks::onKeyboard(KeyCode key, KeyAction action) {
-  if (hasInputMode(InputMode::Mouse)) {
-    // return onKeyboard((KeyCode) 4, KeyAction::PRESS);
-    // key = (KeyCode) 0x21;
+void WindowCallbacks::onKeyboard(KeyCode key, KeyAction action)
+{
+    if (hasInputMode(InputMode::Mouse))
+    {
+        // return onKeyboard((KeyCode) 4, KeyAction::PRESS);
+        // key = (KeyCode) 0x21;
 #ifdef __APPLE__
-    if (key == KeyCode::LEFT_SUPER || key == KeyCode::RIGHT_SUPER)
+        if (key == KeyCode::LEFT_SUPER || key == KeyCode::RIGHT_SUPER)
 #else
-    if (key == KeyCode::LEFT_CTRL || key == KeyCode::RIGHT_CTRL)
+        if (key == KeyCode::LEFT_CTRL || key == KeyCode::RIGHT_CTRL)
 #endif
-      modCTRL = (action != KeyAction::RELEASE);
+            modCTRL = (action != KeyAction::RELEASE);
 
-    if (modCTRL && key == KeyCode::C) {
-      window.setClipboardText(jniSupport.getTextInputHandler().getCopyText());
-    } else {
-      jniSupport.getTextInputHandler().onKeyPressed(key, action);
+        if (modCTRL && key == KeyCode::C)
+        {
+            window.setClipboardText(jniSupport.getTextInputHandler().getCopyText());
+        }
+        else
+        {
+            jniSupport.getTextInputHandler().onKeyPressed(key, action);
+        }
+
+        if (key == KeyCode::FN11 && action == KeyAction::PRESS)
+            window.setFullscreen(fullscreen = !fullscreen);
+
+        if (useDirectKeyboardInput && (action == KeyAction::PRESS || action == KeyAction::RELEASE))
+        {
+            Keyboard::InputEvent evData{};
+            evData.key = (unsigned int)key & 0xff;
+            evData.event = (action == KeyAction::PRESS ? 1 : 0);
+            evData.controllerId = *Keyboard::_gameControllerId;
+            Keyboard::_inputs->push_back(evData);
+            Keyboard::_states[(int)key & 0xff] = evData.event;
+            return;
+        }
+
+        if (action == KeyAction::PRESS)
+            inputQueue.addEvent(FakeKeyEvent(AKEY_EVENT_ACTION_DOWN, mapMinecraftToAndroidKey(key)));
+        else if (action == KeyAction::RELEASE)
+            inputQueue.addEvent(FakeKeyEvent(AKEY_EVENT_ACTION_UP, mapMinecraftToAndroidKey(key)));
     }
-
-    if (key == KeyCode::FN11 && action == KeyAction::PRESS)
-      window.setFullscreen(fullscreen = !fullscreen);
-
-    if (useDirectKeyboardInput &&
-        (action == KeyAction::PRESS || action == KeyAction::RELEASE)) {
-      Keyboard::InputEvent evData{};
-      evData.key = (unsigned int)key & 0xff;
-      evData.event = (action == KeyAction::PRESS ? 1 : 0);
-      evData.controllerId = *Keyboard::_gameControllerId;
-      Keyboard::_inputs->push_back(evData);
-      Keyboard::_states[(int)key & 0xff] = evData.event;
-      return;
-    }
-
-    if (action == KeyAction::PRESS)
-      inputQueue.addEvent(
-          FakeKeyEvent(AKEY_EVENT_ACTION_DOWN, mapMinecraftToAndroidKey(key)));
-    else if (action == KeyAction::RELEASE)
-      inputQueue.addEvent(
-          FakeKeyEvent(AKEY_EVENT_ACTION_UP, mapMinecraftToAndroidKey(key)));
-  }
 }
-void WindowCallbacks::onKeyboardText(std::string const &c) {
-  if (c == "\n" && !jniSupport.getTextInputHandler().isMultiline())
-    jniSupport.onReturnKeyPressed();
-  else
-    jniSupport.getTextInputHandler().onTextInput(c);
-}
-void WindowCallbacks::onPaste(std::string const &str) {
-  jniSupport.getTextInputHandler().onTextInput(str);
-}
-void WindowCallbacks::onGamepadState(int gamepad, bool connected) {
-  Log::trace("WindowCallbacks", "Gamepad %s #%i",
-             connected ? "connected" : "disconnected", gamepad);
-  if (connected)
-    gamepads.insert({gamepad, GamepadData()});
-  else
-    gamepads.erase(gamepad);
-  // This crashs the game 1.16.210+ during init, but works after loading,
-  // disable for now jniSupport.setGameControllerConnected(gamepad, connected);
-}
-
-void WindowCallbacks::queueGamepadAxisInputIfNeeded(int gamepad) {
-  if (!needsQueueGamepadInput)
-    return;
-  inputQueue.addEvent(
-      FakeMotionEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AMOTION_EVENT_ACTION_MOVE,
-                      0, 0.f, 0.f, [this, gamepad](int axis) {
-                        auto gpi = gamepads.find(gamepad);
-                        if (gpi == gamepads.end())
-                          return 0.f;
-                        auto &gp = gpi->second;
-                        if (axis == AMOTION_EVENT_AXIS_X)
-                          return gp.axis[(int)GamepadAxisId::LEFT_X];
-                        if (axis == AMOTION_EVENT_AXIS_Y)
-                          return gp.axis[(int)GamepadAxisId::LEFT_Y];
-                        if (axis == AMOTION_EVENT_AXIS_RX)
-                          return gp.axis[(int)GamepadAxisId::RIGHT_X];
-                        if (axis == AMOTION_EVENT_AXIS_RY)
-                          return gp.axis[(int)GamepadAxisId::RIGHT_Y];
-                        if (axis == AMOTION_EVENT_AXIS_BRAKE)
-                          return gp.axis[(int)GamepadAxisId::LEFT_TRIGGER];
-                        if (axis == AMOTION_EVENT_AXIS_GAS)
-                          return gp.axis[(int)GamepadAxisId::RIGHT_TRIGGER];
-                        if (axis == AMOTION_EVENT_AXIS_HAT_X) {
-                          if (gp.button[(int)GamepadButtonId::DPAD_LEFT])
-                            return -1.f;
-                          if (gp.button[(int)GamepadButtonId::DPAD_RIGHT])
-                            return 1.f;
-                          return 0.f;
-                        }
-                        if (axis == AMOTION_EVENT_AXIS_HAT_Y) {
-                          if (gp.button[(int)GamepadButtonId::DPAD_UP])
-                            return -1.f;
-                          if (gp.button[(int)GamepadButtonId::DPAD_DOWN])
-                            return 1.f;
-                          return 0.f;
-                        }
-                        return 0.f;
-                      }));
-  needsQueueGamepadInput = false;
-}
-
-void WindowCallbacks::onGamepadButton(int gamepad, GamepadButtonId btn,
-                                      bool pressed) {
-  if (hasInputMode(InputMode::Gamepad)) {
-    auto gpi = gamepads.find(gamepad);
-    if (gpi == gamepads.end())
-      return;
-    auto &gp = gpi->second;
-    if ((int)btn < 0 || (int)btn >= 15)
-      throw std::runtime_error("bad button id");
-    if (gp.button[(int)btn] == pressed)
-      return;
-    gp.button[(int)btn] = pressed;
-
-    if (btn == GamepadButtonId::DPAD_UP || btn == GamepadButtonId::DPAD_DOWN ||
-        btn == GamepadButtonId::DPAD_LEFT ||
-        btn == GamepadButtonId::DPAD_RIGHT) {
-      queueGamepadAxisInputIfNeeded(gamepad);
-      return;
-    }
-
-    if (pressed)
-      inputQueue.addEvent(FakeKeyEvent(AINPUT_SOURCE_GAMEPAD, gamepad,
-                                       AKEY_EVENT_ACTION_DOWN,
-                                       mapGamepadToAndroidKey(btn)));
+void WindowCallbacks::onKeyboardText(std::string const &c)
+{
+    if (c == "\n" && !jniSupport.getTextInputHandler().isMultiline())
+        jniSupport.onReturnKeyPressed();
     else
-      inputQueue.addEvent(FakeKeyEvent(AINPUT_SOURCE_GAMEPAD, gamepad,
-                                       AKEY_EVENT_ACTION_UP,
-                                       mapGamepadToAndroidKey(btn)));
-  }
+        jniSupport.getTextInputHandler().onTextInput(c);
+}
+void WindowCallbacks::onPaste(std::string const &str) { jniSupport.getTextInputHandler().onTextInput(str); }
+void WindowCallbacks::onGamepadState(int gamepad, bool connected)
+{
+    Log::trace("WindowCallbacks", "Gamepad %s #%i", connected ? "connected" : "disconnected", gamepad);
+    if (connected)
+        gamepads.insert({gamepad, GamepadData()});
+    else
+        gamepads.erase(gamepad);
+    // This crashs the game 1.16.210+ during init, but works after loading,
+    // disable for now jniSupport.setGameControllerConnected(gamepad, connected);
 }
 
-void WindowCallbacks::onGamepadAxis(int gamepad, GamepadAxisId ax,
-                                    float value) {
-  if (hasInputMode(InputMode::Gamepad, std::abs(value) > 0.4f)) {
-    auto gpi = gamepads.find(gamepad);
-    if (gpi == gamepads.end())
-      return;
-    auto &gp = gpi->second;
-    if ((int)ax < 0 || (int)ax >= 6)
-      throw std::runtime_error("bad axis id");
-    gp.axis[(int)ax] = value;
-    queueGamepadAxisInputIfNeeded(gamepad);
-  }
+void WindowCallbacks::queueGamepadAxisInputIfNeeded(int gamepad)
+{
+    if (!needsQueueGamepadInput)
+        return;
+    inputQueue.addEvent(FakeMotionEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AMOTION_EVENT_ACTION_MOVE, 0, 0.f, 0.f,
+                                        [this, gamepad](int axis)
+                                        {
+                                            auto gpi = gamepads.find(gamepad);
+                                            if (gpi == gamepads.end())
+                                                return 0.f;
+                                            auto &gp = gpi->second;
+                                            if (axis == AMOTION_EVENT_AXIS_X)
+                                                return gp.axis[(int)GamepadAxisId::LEFT_X];
+                                            if (axis == AMOTION_EVENT_AXIS_Y)
+                                                return gp.axis[(int)GamepadAxisId::LEFT_Y];
+                                            if (axis == AMOTION_EVENT_AXIS_RX)
+                                                return gp.axis[(int)GamepadAxisId::RIGHT_X];
+                                            if (axis == AMOTION_EVENT_AXIS_RY)
+                                                return gp.axis[(int)GamepadAxisId::RIGHT_Y];
+                                            if (axis == AMOTION_EVENT_AXIS_BRAKE)
+                                                return gp.axis[(int)GamepadAxisId::LEFT_TRIGGER];
+                                            if (axis == AMOTION_EVENT_AXIS_GAS)
+                                                return gp.axis[(int)GamepadAxisId::RIGHT_TRIGGER];
+                                            if (axis == AMOTION_EVENT_AXIS_HAT_X)
+                                            {
+                                                if (gp.button[(int)GamepadButtonId::DPAD_LEFT])
+                                                    return -1.f;
+                                                if (gp.button[(int)GamepadButtonId::DPAD_RIGHT])
+                                                    return 1.f;
+                                                return 0.f;
+                                            }
+                                            if (axis == AMOTION_EVENT_AXIS_HAT_Y)
+                                            {
+                                                if (gp.button[(int)GamepadButtonId::DPAD_UP])
+                                                    return -1.f;
+                                                if (gp.button[(int)GamepadButtonId::DPAD_DOWN])
+                                                    return 1.f;
+                                                return 0.f;
+                                            }
+                                            return 0.f;
+                                        }));
+    needsQueueGamepadInput = false;
 }
 
-void WindowCallbacks::loadGamepadMappings() {
-  auto windowManager = GameWindowManager::getManager();
-  std::vector<std::string> controllerDbPaths;
-  PathHelper::findAllDataFiles("gamecontrollerdb.txt",
-                               [&controllerDbPaths](std::string const &path) {
-                                 controllerDbPaths.push_back(path);
-                               });
-  // Bugfix: allow users to change internal gamepad layouts
-  std::reverse(controllerDbPaths.begin(), controllerDbPaths.end());
-  for (std::string const &path : controllerDbPaths) {
-    Log::trace("Launcher", "Loading gamepad mappings: %s", path.c_str());
-    windowManager->addGamepadMappingFile(path);
-  }
+void WindowCallbacks::onGamepadButton(int gamepad, GamepadButtonId btn, bool pressed)
+{
+    if (hasInputMode(InputMode::Gamepad))
+    {
+        auto gpi = gamepads.find(gamepad);
+        if (gpi == gamepads.end())
+            return;
+        auto &gp = gpi->second;
+        if ((int)btn < 0 || (int)btn >= 15)
+            throw std::runtime_error("bad button id");
+        if (gp.button[(int)btn] == pressed)
+            return;
+        gp.button[(int)btn] = pressed;
+
+        if (btn == GamepadButtonId::DPAD_UP || btn == GamepadButtonId::DPAD_DOWN || btn == GamepadButtonId::DPAD_LEFT ||
+            btn == GamepadButtonId::DPAD_RIGHT)
+        {
+            queueGamepadAxisInputIfNeeded(gamepad);
+            return;
+        }
+
+        if (pressed)
+            inputQueue.addEvent(
+                FakeKeyEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AKEY_EVENT_ACTION_DOWN, mapGamepadToAndroidKey(btn)));
+        else
+            inputQueue.addEvent(
+                FakeKeyEvent(AINPUT_SOURCE_GAMEPAD, gamepad, AKEY_EVENT_ACTION_UP, mapGamepadToAndroidKey(btn)));
+    }
 }
 
-WindowCallbacks::GamepadData::GamepadData() {
-  for (int i = 0; i < 6; i++)
-    axis[i] = 0.f;
-  memset(button, 0, sizeof(button));
+void WindowCallbacks::onGamepadAxis(int gamepad, GamepadAxisId ax, float value)
+{
+    if (hasInputMode(InputMode::Gamepad, std::abs(value) > 0.4f))
+    {
+        auto gpi = gamepads.find(gamepad);
+        if (gpi == gamepads.end())
+            return;
+        auto &gp = gpi->second;
+        if ((int)ax < 0 || (int)ax >= 6)
+            throw std::runtime_error("bad axis id");
+        gp.axis[(int)ax] = value;
+        queueGamepadAxisInputIfNeeded(gamepad);
+    }
 }
 
-int WindowCallbacks::mapMinecraftToAndroidKey(KeyCode code) {
-  if (code >= KeyCode::NUM_0 && code <= KeyCode::NUM_9)
-    return (int)code - (int)KeyCode::NUM_0 + AKEYCODE_0;
-  if (code >= KeyCode::A && code <= KeyCode::Z)
-    return (int)code - (int)KeyCode::A + AKEYCODE_A;
-  if (code >= KeyCode::FN1 && code <= KeyCode::FN12)
-    return (int)code - (int)KeyCode::FN1 + AKEYCODE_F1;
-  switch (code) {
-  case KeyCode::BACK:
-    return AKEYCODE_BACK;
-  case KeyCode::BACKSPACE:
-    return AKEYCODE_DEL;
-  case KeyCode::TAB:
-    return AKEYCODE_TAB;
-  case KeyCode::ENTER:
-    return AKEYCODE_ENTER;
-  case KeyCode::LEFT_SHIFT:
-    return AKEYCODE_SHIFT_LEFT;
-  case KeyCode::RIGHT_SHIFT:
-    return AKEYCODE_SHIFT_RIGHT;
-  case KeyCode::LEFT_CTRL:
-    return AKEYCODE_CTRL_LEFT;
-  case KeyCode::RIGHT_CTRL:
-    return AKEYCODE_CTRL_RIGHT;
-  case KeyCode::PAUSE:
-    return AKEYCODE_BREAK;
-  case KeyCode::CAPS_LOCK:
-    return AKEYCODE_CAPS_LOCK;
-  case KeyCode::ESCAPE:
-    return AKEYCODE_ESCAPE;
-  case KeyCode::SPACE:
-    return AKEYCODE_SPACE;
-  case KeyCode::PAGE_UP:
-    return AKEYCODE_PAGE_UP;
-  case KeyCode::PAGE_DOWN:
-    return AKEYCODE_PAGE_DOWN;
-  case KeyCode::END:
-    return AKEYCODE_MOVE_END;
-  case KeyCode::HOME:
-    return AKEYCODE_MOVE_HOME;
-  case KeyCode::LEFT:
-    return AKEYCODE_DPAD_LEFT;
-  case KeyCode::UP:
-    return AKEYCODE_DPAD_UP;
-  case KeyCode::RIGHT:
-    return AKEYCODE_DPAD_RIGHT;
-  case KeyCode::DOWN:
-    return AKEYCODE_DPAD_DOWN;
-  case KeyCode::INSERT:
-    return AKEYCODE_INSERT;
-  case KeyCode::DELETE:
-    return AKEYCODE_FORWARD_DEL;
-  case KeyCode::NUM_LOCK:
-    return AKEYCODE_NUM_LOCK;
-  case KeyCode::SCROLL_LOCK:
-    return AKEYCODE_SCROLL_LOCK;
-  case KeyCode::SEMICOLON:
-    return AKEYCODE_SEMICOLON;
-  case KeyCode::EQUAL:
-    return AKEYCODE_EQUALS;
-  case KeyCode::COMMA:
-    return AKEYCODE_COMMA;
-  case KeyCode::MINUS:
-    return AKEYCODE_MINUS;
-  case KeyCode::PERIOD:
-    return AKEYCODE_PERIOD;
-  case KeyCode::SLASH:
-    return AKEYCODE_SLASH;
-  case KeyCode::GRAVE:
-    return AKEYCODE_GRAVE;
-  case KeyCode::LEFT_BRACKET:
-    return AKEYCODE_LEFT_BRACKET;
-  case KeyCode::BACKSLASH:
-    return AKEYCODE_BACKSLASH;
-  case KeyCode::RIGHT_BRACKET:
-    return AKEYCODE_RIGHT_BRACKET;
-  case KeyCode::APOSTROPHE:
-    return AKEYCODE_APOSTROPHE;
-  case KeyCode::MENU:
-    return AKEYCODE_MENU;
-  case KeyCode::LEFT_SUPER:
-    return AKEYCODE_META_LEFT;
-  case KeyCode::RIGHT_SUPER:
-    return AKEYCODE_META_RIGHT;
-  case KeyCode::LEFT_ALT:
-    return AKEYCODE_ALT_LEFT;
-  case KeyCode::RIGHT_ALT:
-    return AKEYCODE_ALT_RIGHT;
-  default:
-    return AKEYCODE_UNKNOWN;
-  }
+void WindowCallbacks::loadGamepadMappings()
+{
+    auto windowManager = GameWindowManager::getManager();
+    std::vector<std::string> controllerDbPaths;
+    PathHelper::findAllDataFiles("gamecontrollerdb.txt",
+                                 [&controllerDbPaths](std::string const &path) { controllerDbPaths.push_back(path); });
+    // Bugfix: allow users to change internal gamepad layouts
+    std::reverse(controllerDbPaths.begin(), controllerDbPaths.end());
+    for (std::string const &path : controllerDbPaths)
+    {
+        Log::trace("Launcher", "Loading gamepad mappings: %s", path.c_str());
+        windowManager->addGamepadMappingFile(path);
+    }
 }
 
-int WindowCallbacks::mapGamepadToAndroidKey(GamepadButtonId btn) {
-  switch (btn) {
-  case GamepadButtonId::A:
-    return AKEYCODE_BUTTON_A;
-  case GamepadButtonId::B:
-    return AKEYCODE_BUTTON_B;
-  case GamepadButtonId::X:
-    return AKEYCODE_BUTTON_X;
-  case GamepadButtonId::Y:
-    return AKEYCODE_BUTTON_Y;
-  case GamepadButtonId::LB:
-    return AKEYCODE_BUTTON_L1;
-  case GamepadButtonId::RB:
-    return AKEYCODE_BUTTON_R1;
-  case GamepadButtonId::BACK:
-    return AKEYCODE_BUTTON_SELECT;
-  case GamepadButtonId::START:
-    return AKEYCODE_BUTTON_START;
-  case GamepadButtonId::GUIDE:
-    return AKEYCODE_BUTTON_MODE;
-  case GamepadButtonId::LEFT_STICK:
-    return AKEYCODE_BUTTON_THUMBL;
-  case GamepadButtonId::RIGHT_STICK:
-    return AKEYCODE_BUTTON_THUMBR;
-  case GamepadButtonId::DPAD_UP:
-    return AKEYCODE_DPAD_UP;
-  case GamepadButtonId::DPAD_RIGHT:
-    return AKEYCODE_DPAD_RIGHT;
-  case GamepadButtonId::DPAD_DOWN:
-    return AKEYCODE_DPAD_DOWN;
-  case GamepadButtonId::DPAD_LEFT:
-    return AKEYCODE_DPAD_LEFT;
-  default:
-    return -1;
-  }
+WindowCallbacks::GamepadData::GamepadData()
+{
+    for (int i = 0; i < 6; i++) axis[i] = 0.f;
+    memset(button, 0, sizeof(button));
+}
+
+int WindowCallbacks::mapMinecraftToAndroidKey(KeyCode code)
+{
+    if (code >= KeyCode::NUM_0 && code <= KeyCode::NUM_9)
+        return (int)code - (int)KeyCode::NUM_0 + AKEYCODE_0;
+    if (code >= KeyCode::A && code <= KeyCode::Z)
+        return (int)code - (int)KeyCode::A + AKEYCODE_A;
+    if (code >= KeyCode::FN1 && code <= KeyCode::FN12)
+        return (int)code - (int)KeyCode::FN1 + AKEYCODE_F1;
+    switch (code)
+    {
+    case KeyCode::BACK:
+        return AKEYCODE_BACK;
+    case KeyCode::BACKSPACE:
+        return AKEYCODE_DEL;
+    case KeyCode::TAB:
+        return AKEYCODE_TAB;
+    case KeyCode::ENTER:
+        return AKEYCODE_ENTER;
+    case KeyCode::LEFT_SHIFT:
+        return AKEYCODE_SHIFT_LEFT;
+    case KeyCode::RIGHT_SHIFT:
+        return AKEYCODE_SHIFT_RIGHT;
+    case KeyCode::LEFT_CTRL:
+        return AKEYCODE_CTRL_LEFT;
+    case KeyCode::RIGHT_CTRL:
+        return AKEYCODE_CTRL_RIGHT;
+    case KeyCode::PAUSE:
+        return AKEYCODE_BREAK;
+    case KeyCode::CAPS_LOCK:
+        return AKEYCODE_CAPS_LOCK;
+    case KeyCode::ESCAPE:
+        return AKEYCODE_ESCAPE;
+    case KeyCode::SPACE:
+        return AKEYCODE_SPACE;
+    case KeyCode::PAGE_UP:
+        return AKEYCODE_PAGE_UP;
+    case KeyCode::PAGE_DOWN:
+        return AKEYCODE_PAGE_DOWN;
+    case KeyCode::END:
+        return AKEYCODE_MOVE_END;
+    case KeyCode::HOME:
+        return AKEYCODE_MOVE_HOME;
+    case KeyCode::LEFT:
+        return AKEYCODE_DPAD_LEFT;
+    case KeyCode::UP:
+        return AKEYCODE_DPAD_UP;
+    case KeyCode::RIGHT:
+        return AKEYCODE_DPAD_RIGHT;
+    case KeyCode::DOWN:
+        return AKEYCODE_DPAD_DOWN;
+    case KeyCode::INSERT:
+        return AKEYCODE_INSERT;
+    case KeyCode::DELETE:
+        return AKEYCODE_FORWARD_DEL;
+    case KeyCode::NUM_LOCK:
+        return AKEYCODE_NUM_LOCK;
+    case KeyCode::SCROLL_LOCK:
+        return AKEYCODE_SCROLL_LOCK;
+    case KeyCode::SEMICOLON:
+        return AKEYCODE_SEMICOLON;
+    case KeyCode::EQUAL:
+        return AKEYCODE_EQUALS;
+    case KeyCode::COMMA:
+        return AKEYCODE_COMMA;
+    case KeyCode::MINUS:
+        return AKEYCODE_MINUS;
+    case KeyCode::PERIOD:
+        return AKEYCODE_PERIOD;
+    case KeyCode::SLASH:
+        return AKEYCODE_SLASH;
+    case KeyCode::GRAVE:
+        return AKEYCODE_GRAVE;
+    case KeyCode::LEFT_BRACKET:
+        return AKEYCODE_LEFT_BRACKET;
+    case KeyCode::BACKSLASH:
+        return AKEYCODE_BACKSLASH;
+    case KeyCode::RIGHT_BRACKET:
+        return AKEYCODE_RIGHT_BRACKET;
+    case KeyCode::APOSTROPHE:
+        return AKEYCODE_APOSTROPHE;
+    case KeyCode::MENU:
+        return AKEYCODE_MENU;
+    case KeyCode::LEFT_SUPER:
+        return AKEYCODE_META_LEFT;
+    case KeyCode::RIGHT_SUPER:
+        return AKEYCODE_META_RIGHT;
+    case KeyCode::LEFT_ALT:
+        return AKEYCODE_ALT_LEFT;
+    case KeyCode::RIGHT_ALT:
+        return AKEYCODE_ALT_RIGHT;
+    default:
+        return AKEYCODE_UNKNOWN;
+    }
+}
+
+int WindowCallbacks::mapGamepadToAndroidKey(GamepadButtonId btn)
+{
+    switch (btn)
+    {
+    case GamepadButtonId::A:
+        return AKEYCODE_BUTTON_A;
+    case GamepadButtonId::B:
+        return AKEYCODE_BUTTON_B;
+    case GamepadButtonId::X:
+        return AKEYCODE_BUTTON_X;
+    case GamepadButtonId::Y:
+        return AKEYCODE_BUTTON_Y;
+    case GamepadButtonId::LB:
+        return AKEYCODE_BUTTON_L1;
+    case GamepadButtonId::RB:
+        return AKEYCODE_BUTTON_R1;
+    case GamepadButtonId::BACK:
+        return AKEYCODE_BUTTON_SELECT;
+    case GamepadButtonId::START:
+        return AKEYCODE_BUTTON_START;
+    case GamepadButtonId::GUIDE:
+        return AKEYCODE_BUTTON_MODE;
+    case GamepadButtonId::LEFT_STICK:
+        return AKEYCODE_BUTTON_THUMBL;
+    case GamepadButtonId::RIGHT_STICK:
+        return AKEYCODE_BUTTON_THUMBR;
+    case GamepadButtonId::DPAD_UP:
+        return AKEYCODE_DPAD_UP;
+    case GamepadButtonId::DPAD_RIGHT:
+        return AKEYCODE_DPAD_RIGHT;
+    case GamepadButtonId::DPAD_DOWN:
+        return AKEYCODE_DPAD_DOWN;
+    case GamepadButtonId::DPAD_LEFT:
+        return AKEYCODE_DPAD_LEFT;
+    default:
+        return -1;
+    }
 }

--- a/src/window_callbacks.h
+++ b/src/window_callbacks.h
@@ -1,70 +1,70 @@
 #pragma once
 
+#include <game_window.h>
+#include <chrono>
+#include <unordered_map>
 #include "fake_inputqueue.h"
 #include "jni/jni_support.h"
-#include <chrono>
-#include <game_window.h>
-#include <unordered_map>
 
-class WindowCallbacks {
+class WindowCallbacks
+{
+   private:
+    struct GamepadData
+    {
+        float axis[6];
+        bool button[15];
 
-private:
-  struct GamepadData {
-    float axis[6];
-    bool button[15];
+        GamepadData();
+    };
 
-    GamepadData();
-  };
+    GameWindow &window;
+    JniSupport &jniSupport;
+    FakeInputQueue &inputQueue;
+    std::unordered_map<int, GamepadData> gamepads;
+    bool useDirectMouseInput, useDirectKeyboardInput;
+    bool modCTRL = false;
+    bool needsQueueGamepadInput = true;
+    bool fullscreen = false;
+    enum class InputMode
+    {
+        Touch,
+        Mouse,
+        Gamepad,
+        Unknown,
+    };
+    InputMode inputMode = InputMode::Unknown;
+    std::chrono::high_resolution_clock::time_point lastUpdated;
+    bool hasInputMode(InputMode want = InputMode::Unknown, bool changeMode = true);
 
-  GameWindow &window;
-  JniSupport &jniSupport;
-  FakeInputQueue &inputQueue;
-  std::unordered_map<int, GamepadData> gamepads;
-  bool useDirectMouseInput, useDirectKeyboardInput;
-  bool modCTRL = false;
-  bool needsQueueGamepadInput = true;
-  bool fullscreen = false;
-  enum class InputMode {
-    Touch,
-    Mouse,
-    Gamepad,
-    Unknown,
-  };
-  InputMode inputMode = InputMode::Unknown;
-  std::chrono::high_resolution_clock::time_point lastUpdated;
-  bool hasInputMode(InputMode want = InputMode::Unknown,
-                    bool changeMode = true);
+    void queueGamepadAxisInputIfNeeded(int gamepad);
 
-  void queueGamepadAxisInputIfNeeded(int gamepad);
+   public:
+    WindowCallbacks(GameWindow &window, JniSupport &jniSupport, FakeInputQueue &inputQueue);
 
-public:
-  WindowCallbacks(GameWindow &window, JniSupport &jniSupport,
-                  FakeInputQueue &inputQueue);
+    static void loadGamepadMappings();
 
-  static void loadGamepadMappings();
+    void registerCallbacks();
 
-  void registerCallbacks();
+    void markRequeueGamepadInput() { needsQueueGamepadInput = true; }
 
-  void markRequeueGamepadInput() { needsQueueGamepadInput = true; }
+    void onWindowSizeCallback(int w, int h);
 
-  void onWindowSizeCallback(int w, int h);
+    void onClose();
 
-  void onClose();
+    void onMouseButton(double x, double y, int btn, MouseButtonAction action);
+    void onMousePosition(double x, double y);
+    void onMouseRelativePosition(double x, double y);
+    void onMouseScroll(double x, double y, double dx, double dy);
+    void onTouchStart(int id, double x, double y);
+    void onTouchUpdate(int id, double x, double y);
+    void onTouchEnd(int id, double x, double y);
+    void onKeyboard(KeyCode key, KeyAction action);
+    void onKeyboardText(std::string const &c);
+    void onPaste(std::string const &str);
+    void onGamepadState(int gamepad, bool connected);
+    void onGamepadButton(int gamepad, GamepadButtonId btn, bool pressed);
+    void onGamepadAxis(int gamepad, GamepadAxisId ax, float value);
 
-  void onMouseButton(double x, double y, int btn, MouseButtonAction action);
-  void onMousePosition(double x, double y);
-  void onMouseRelativePosition(double x, double y);
-  void onMouseScroll(double x, double y, double dx, double dy);
-  void onTouchStart(int id, double x, double y);
-  void onTouchUpdate(int id, double x, double y);
-  void onTouchEnd(int id, double x, double y);
-  void onKeyboard(KeyCode key, KeyAction action);
-  void onKeyboardText(std::string const &c);
-  void onPaste(std::string const &str);
-  void onGamepadState(int gamepad, bool connected);
-  void onGamepadButton(int gamepad, GamepadButtonId btn, bool pressed);
-  void onGamepadAxis(int gamepad, GamepadAxisId ax, float value);
-
-  static int mapMinecraftToAndroidKey(KeyCode code);
-  static int mapGamepadToAndroidKey(GamepadButtonId btn);
+    static int mapMinecraftToAndroidKey(KeyCode code);
+    static int mapGamepadToAndroidKey(GamepadButtonId btn);
 };

--- a/src/window_callbacks.h
+++ b/src/window_callbacks.h
@@ -1,69 +1,70 @@
 #pragma once
 
+#include "fake_inputqueue.h"
+#include "jni/jni_support.h"
+#include <chrono>
 #include <game_window.h>
 #include <unordered_map>
-#include "jni/jni_support.h"
-#include "fake_inputqueue.h"
-#include <chrono>
 
 class WindowCallbacks {
 
 private:
-    struct GamepadData {
-        float axis[6];
-        bool button[15];
+  struct GamepadData {
+    float axis[6];
+    bool button[15];
 
-        GamepadData();
-    };
+    GamepadData();
+  };
 
-    GameWindow &window;
-    JniSupport &jniSupport;
-    FakeInputQueue &inputQueue;
-    std::unordered_map<int, GamepadData> gamepads;
-    bool useDirectMouseInput, useDirectKeyboardInput;
-    bool modCTRL = false;
-    bool needsQueueGamepadInput = true;
-    bool fullscreen = false;
-    enum class InputMode {
-        Touch,
-        Mouse,
-        Gamepad,
-        Unknown,
-    };
-    InputMode inputMode = InputMode::Unknown;
-    std::chrono::high_resolution_clock::time_point lastUpdated;
-    bool hasInputMode(InputMode want = InputMode::Unknown, bool changeMode = true);
+  GameWindow &window;
+  JniSupport &jniSupport;
+  FakeInputQueue &inputQueue;
+  std::unordered_map<int, GamepadData> gamepads;
+  bool useDirectMouseInput, useDirectKeyboardInput;
+  bool modCTRL = false;
+  bool needsQueueGamepadInput = true;
+  bool fullscreen = false;
+  enum class InputMode {
+    Touch,
+    Mouse,
+    Gamepad,
+    Unknown,
+  };
+  InputMode inputMode = InputMode::Unknown;
+  std::chrono::high_resolution_clock::time_point lastUpdated;
+  bool hasInputMode(InputMode want = InputMode::Unknown,
+                    bool changeMode = true);
 
-    void queueGamepadAxisInputIfNeeded(int gamepad);
+  void queueGamepadAxisInputIfNeeded(int gamepad);
 
 public:
-    WindowCallbacks(GameWindow &window, JniSupport &jniSupport, FakeInputQueue &inputQueue);
+  WindowCallbacks(GameWindow &window, JniSupport &jniSupport,
+                  FakeInputQueue &inputQueue);
 
-    static void loadGamepadMappings();
+  static void loadGamepadMappings();
 
-    void registerCallbacks();
+  void registerCallbacks();
 
-    void markRequeueGamepadInput() { needsQueueGamepadInput = true; }
+  void markRequeueGamepadInput() { needsQueueGamepadInput = true; }
 
-    void onWindowSizeCallback(int w, int h);
+  void onWindowSizeCallback(int w, int h);
 
-    void onClose();
+  void onClose();
 
-    void onMouseButton(double x, double y, int btn, MouseButtonAction action);
-    void onMousePosition(double x, double y);
-    void onMouseRelativePosition(double x, double y);
-    void onMouseScroll(double x, double y, double dx, double dy);
-    void onTouchStart(int id, double x, double y);
-    void onTouchUpdate(int id, double x, double y);
-    void onTouchEnd(int id, double x, double y);
-    void onKeyboard(KeyCode key, KeyAction action);
-    void onKeyboardText(std::string const& c);
-    void onPaste(std::string const& str);
-    void onGamepadState(int gamepad, bool connected);
-    void onGamepadButton(int gamepad, GamepadButtonId btn, bool pressed);
-    void onGamepadAxis(int gamepad, GamepadAxisId ax, float value);
+  void onMouseButton(double x, double y, int btn, MouseButtonAction action);
+  void onMousePosition(double x, double y);
+  void onMouseRelativePosition(double x, double y);
+  void onMouseScroll(double x, double y, double dx, double dy);
+  void onTouchStart(int id, double x, double y);
+  void onTouchUpdate(int id, double x, double y);
+  void onTouchEnd(int id, double x, double y);
+  void onKeyboard(KeyCode key, KeyAction action);
+  void onKeyboardText(std::string const &c);
+  void onPaste(std::string const &str);
+  void onGamepadState(int gamepad, bool connected);
+  void onGamepadButton(int gamepad, GamepadButtonId btn, bool pressed);
+  void onGamepadAxis(int gamepad, GamepadAxisId ax, float value);
 
-    static int mapMinecraftToAndroidKey(KeyCode code);
-    static int mapGamepadToAndroidKey(GamepadButtonId btn);
-
+  static int mapMinecraftToAndroidKey(KeyCode code);
+  static int mapGamepadToAndroidKey(GamepadButtonId btn);
 };

--- a/src/window_callbacks.h
+++ b/src/window_callbacks.h
@@ -6,11 +6,9 @@
 #include "fake_inputqueue.h"
 #include "jni/jni_support.h"
 
-class WindowCallbacks
-{
+class WindowCallbacks {
    private:
-    struct GamepadData
-    {
+    struct GamepadData {
         float axis[6];
         bool button[15];
 
@@ -25,8 +23,7 @@ class WindowCallbacks
     bool modCTRL = false;
     bool needsQueueGamepadInput = true;
     bool fullscreen = false;
-    enum class InputMode
-    {
+    enum class InputMode {
         Touch,
         Mouse,
         Gamepad,

--- a/src/xal_webview.h
+++ b/src/xal_webview.h
@@ -6,8 +6,7 @@
 class XalWebView {
 
 public:
-    virtual ~XalWebView() {}
+  virtual ~XalWebView() {}
 
-    virtual std::string show(std::string starturl, std::string endurlprefix) = 0;
-
+  virtual std::string show(std::string starturl, std::string endurlprefix) = 0;
 };

--- a/src/xal_webview.h
+++ b/src/xal_webview.h
@@ -3,10 +3,10 @@
 #include <string>
 #include <vector>
 
-class XalWebView {
+class XalWebView
+{
+   public:
+    virtual ~XalWebView() {}
 
-public:
-  virtual ~XalWebView() {}
-
-  virtual std::string show(std::string starturl, std::string endurlprefix) = 0;
+    virtual std::string show(std::string starturl, std::string endurlprefix) = 0;
 };

--- a/src/xal_webview.h
+++ b/src/xal_webview.h
@@ -3,8 +3,7 @@
 #include <string>
 #include <vector>
 
-class XalWebView
-{
+class XalWebView {
    public:
     virtual ~XalWebView() {}
 

--- a/src/xal_webview_cli.cpp
+++ b/src/xal_webview_cli.cpp
@@ -1,10 +1,13 @@
 #include "xal_webview_cli.h"
 #include <iostream>
 
-std::string XalWebViewCli::show(std::string starturl, std::string endurlprefix) {
-    std::cout << "Please open \"" << starturl << "\" in your Webbrowser and sign in\n";
-    std::cout << "Paste the final url starting with\"" << endurlprefix <<"\" to finish sign in:\n";
-    std::string result;
-    std::getline(std::cin, result);
-    return result;
+std::string XalWebViewCli::show(std::string starturl,
+                                std::string endurlprefix) {
+  std::cout << "Please open \"" << starturl
+            << "\" in your Webbrowser and sign in\n";
+  std::cout << "Paste the final url starting with\"" << endurlprefix
+            << "\" to finish sign in:\n";
+  std::string result;
+  std::getline(std::cin, result);
+  return result;
 }

--- a/src/xal_webview_cli.cpp
+++ b/src/xal_webview_cli.cpp
@@ -1,8 +1,7 @@
 #include "xal_webview_cli.h"
 #include <iostream>
 
-std::string XalWebViewCli::show(std::string starturl, std::string endurlprefix)
-{
+std::string XalWebViewCli::show(std::string starturl, std::string endurlprefix) {
     std::cout << "Please open \"" << starturl << "\" in your Webbrowser and sign in\n";
     std::cout << "Paste the final url starting with\"" << endurlprefix << "\" to finish sign in:\n";
     std::string result;

--- a/src/xal_webview_cli.cpp
+++ b/src/xal_webview_cli.cpp
@@ -1,13 +1,11 @@
 #include "xal_webview_cli.h"
 #include <iostream>
 
-std::string XalWebViewCli::show(std::string starturl,
-                                std::string endurlprefix) {
-  std::cout << "Please open \"" << starturl
-            << "\" in your Webbrowser and sign in\n";
-  std::cout << "Paste the final url starting with\"" << endurlprefix
-            << "\" to finish sign in:\n";
-  std::string result;
-  std::getline(std::cin, result);
-  return result;
+std::string XalWebViewCli::show(std::string starturl, std::string endurlprefix)
+{
+    std::cout << "Please open \"" << starturl << "\" in your Webbrowser and sign in\n";
+    std::cout << "Paste the final url starting with\"" << endurlprefix << "\" to finish sign in:\n";
+    std::string result;
+    std::getline(std::cin, result);
+    return result;
 }

--- a/src/xal_webview_cli.h
+++ b/src/xal_webview_cli.h
@@ -2,8 +2,7 @@
 
 #include "xal_webview.h"
 
-class XalWebViewCli : public XalWebView
-{
+class XalWebViewCli : public XalWebView {
    public:
     virtual std::string show(std::string starturl, std::string endurlprefix) override;
 };

--- a/src/xal_webview_cli.h
+++ b/src/xal_webview_cli.h
@@ -2,8 +2,8 @@
 
 #include "xal_webview.h"
 
-class XalWebViewCli : public XalWebView {
-public:
-  virtual std::string show(std::string starturl,
-                           std::string endurlprefix) override;
+class XalWebViewCli : public XalWebView
+{
+   public:
+    virtual std::string show(std::string starturl, std::string endurlprefix) override;
 };

--- a/src/xal_webview_cli.h
+++ b/src/xal_webview_cli.h
@@ -4,5 +4,6 @@
 
 class XalWebViewCli : public XalWebView {
 public:
-    virtual std::string show(std::string starturl, std::string endurlprefix) override;
+  virtual std::string show(std::string starturl,
+                           std::string endurlprefix) override;
 };

--- a/src/xal_webview_factory.cpp
+++ b/src/xal_webview_factory.cpp
@@ -4,19 +4,16 @@
 
 #if defined(XAL_WEBVIEW_USE_QT)
 #include "xal_webview_qt.h"
-std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView()
-{
+std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
     return std::unique_ptr<XalWebView>(new XalWebViewQt());
 }
 #elif defined(XAL_WEBVIEW_USE_CLI)
 #include "xal_webview_cli.h"
-std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView()
-{
+std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
     return std::unique_ptr<XalWebView>(new XalWebViewCli());
 }
 #else
-std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView()
-{
+std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
     throw std::runtime_error("No XalWebView implementation available");
 }
 #endif

--- a/src/xal_webview_factory.cpp
+++ b/src/xal_webview_factory.cpp
@@ -4,16 +4,19 @@
 
 #if defined(XAL_WEBVIEW_USE_QT)
 #include "xal_webview_qt.h"
-std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
-  return std::unique_ptr<XalWebView>(new XalWebViewQt());
+std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView()
+{
+    return std::unique_ptr<XalWebView>(new XalWebViewQt());
 }
 #elif defined(XAL_WEBVIEW_USE_CLI)
 #include "xal_webview_cli.h"
-std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
-  return std::unique_ptr<XalWebView>(new XalWebViewCli());
+std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView()
+{
+    return std::unique_ptr<XalWebView>(new XalWebViewCli());
 }
 #else
-std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
-  throw std::runtime_error("No XalWebView implementation available");
+std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView()
+{
+    throw std::runtime_error("No XalWebView implementation available");
 }
 #endif

--- a/src/xal_webview_factory.cpp
+++ b/src/xal_webview_factory.cpp
@@ -5,15 +5,15 @@
 #if defined(XAL_WEBVIEW_USE_QT)
 #include "xal_webview_qt.h"
 std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
-    return std::unique_ptr<XalWebView>(new XalWebViewQt());
+  return std::unique_ptr<XalWebView>(new XalWebViewQt());
 }
 #elif defined(XAL_WEBVIEW_USE_CLI)
 #include "xal_webview_cli.h"
 std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
-    return std::unique_ptr<XalWebView>(new XalWebViewCli());
+  return std::unique_ptr<XalWebView>(new XalWebViewCli());
 }
 #else
 std::unique_ptr<XalWebView> XalWebViewFactory::createXalWebView() {
-    throw std::runtime_error("No XalWebView implementation available");
+  throw std::runtime_error("No XalWebView implementation available");
 }
 #endif

--- a/src/xal_webview_factory.h
+++ b/src/xal_webview_factory.h
@@ -3,8 +3,7 @@
 #include <memory>
 #include "xal_webview.h"
 
-class XalWebViewFactory
-{
+class XalWebViewFactory {
    public:
     static std::unique_ptr<XalWebView> createXalWebView();
 };

--- a/src/xal_webview_factory.h
+++ b/src/xal_webview_factory.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <memory>
 #include "xal_webview.h"
+#include <memory>
 
 class XalWebViewFactory {
 
 public:
-
-    static std::unique_ptr<XalWebView> createXalWebView();
-
+  static std::unique_ptr<XalWebView> createXalWebView();
 };

--- a/src/xal_webview_factory.h
+++ b/src/xal_webview_factory.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "xal_webview.h"
 #include <memory>
+#include "xal_webview.h"
 
-class XalWebViewFactory {
-
-public:
-  static std::unique_ptr<XalWebView> createXalWebView();
+class XalWebViewFactory
+{
+   public:
+    static std::unique_ptr<XalWebView> createXalWebView();
 };

--- a/src/xal_webview_qt.cpp
+++ b/src/xal_webview_qt.cpp
@@ -11,8 +11,7 @@
 #include <stdexcept>
 #include "util.h"
 
-std::string XalWebViewQt::findWebView()
-{
+std::string XalWebViewQt::findWebView() {
     std::string path;
 #ifdef MCPELAUNCHER_WEBVIEW_PATH
     if (EnvPathUtil::findInPath("mcpelauncher-webview", path, MCPELAUNCHER_WEBVIEW_PATH,
@@ -24,8 +23,7 @@ std::string XalWebViewQt::findWebView()
     return std::string();
 }
 
-std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title, std::string description)
-{
+std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title, std::string description) {
     char ret[1024];
 
     int pipes[3][2];
@@ -39,8 +37,7 @@ std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title, s
     pipe(pipes[PIPE_STDERR]);
     pipe(pipes[PIPE_STDIN]);
     int pid;
-    if (!(pid = fork()))
-    {
+    if (!(pid = fork())) {
         auto argv = buildCommandLine(path, title, description);
         auto argvc = convertToC(argv);
         dup2(pipes[PIPE_STDOUT][PIPE_WRITE], STDOUT_FILENO);
@@ -55,9 +52,7 @@ std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title, s
         int r = execv(argvc[0], (char **)argvc.data());
         printf("Show: execv() error %i %s", r, strerror(errno));
         _exit(r);
-    }
-    else if (pid != -1)
-    {
+    } else if (pid != -1) {
         close(pipes[PIPE_STDIN][PIPE_WRITE]);
         close(pipes[PIPE_STDIN][PIPE_READ]);
 
@@ -78,29 +73,21 @@ std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title, s
         int status;
         waitpid(pid, &status, 0);
         status = WEXITSTATUS(status);
-        if (status == 0)
-        {
+        if (status == 0) {
             return outputStdOut;
-        }
-        else
-        {
+        } else {
             throw std::runtime_error("Process exited with status=" + std::to_string(status) + " stdout:`" +
                                      outputStdOut + "` stderr:`" + outputStdErr + "`");
         }
-    }
-    else
-    {
+    } else {
         throw std::runtime_error("Fork failed");
     }
 }
 
-std::string XalWebViewQt::show(std::string starturl, std::string endurlprefix)
-{
-    try
-    {
+std::string XalWebViewQt::show(std::string starturl, std::string endurlprefix) {
+    try {
         auto webview_path = findWebView();
-        if (webview_path.empty())
-        {
+        if (webview_path.empty()) {
             throw std::runtime_error("mcpelauncher-webview not found");
         }
         auto result = exec_get_stdout(webview_path, starturl, endurlprefix);
@@ -112,11 +99,9 @@ std::string XalWebViewQt::show(std::string starturl, std::string endurlprefix)
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0"
             "123456789-_.~!*'();:@&=+$,/?%#[] ";
         if ((result.rfind(endurlprefix, 0) != 0 || result.find_first_not_of(validUrlChars, 0) != std::string::npos) &&
-            !result.empty())
-        {
+            !result.empty()) {
             auto iurl = result.find(endurlprefix);
-            if (iurl != std::string::npos)
-            {
+            if (iurl != std::string::npos) {
                 auto eurl = result.find_first_not_of(validUrlChars, iurl);
                 auto url = result.substr(iurl, eurl);
                 GameWindowManager::getManager()->getErrorHandler()->onError(
@@ -135,9 +120,7 @@ std::string XalWebViewQt::show(std::string starturl, std::string endurlprefix)
                                      endurlprefix + "`");
         }
         return result;
-    }
-    catch (const std::exception &ex)
-    {
+    } catch (const std::exception &ex) {
         GameWindowManager::getManager()->getErrorHandler()->onError(
             "XalWebViewQt", std::string("Failed to open Xboxlive login Window. Please look into "
                                         "the gamelog for more Information: ") +
@@ -146,8 +129,7 @@ std::string XalWebViewQt::show(std::string starturl, std::string endurlprefix)
     }
 }
 
-std::vector<std::string> XalWebViewQt::buildCommandLine(std::string path, std::string title, std::string description)
-{
+std::vector<std::string> XalWebViewQt::buildCommandLine(std::string path, std::string title, std::string description) {
     std::vector<std::string> cmd;
     cmd.emplace_back(path);
     cmd.emplace_back(title);
@@ -155,8 +137,7 @@ std::vector<std::string> XalWebViewQt::buildCommandLine(std::string path, std::s
     return std::move(cmd);
 }
 
-std::vector<const char *> XalWebViewQt::convertToC(std::vector<std::string> const &v)
-{
+std::vector<const char *> XalWebViewQt::convertToC(std::vector<std::string> const &v) {
     std::vector<const char *> ret;
     for (auto const &i : v) ret.push_back(i.c_str());
     ret.push_back(nullptr);

--- a/src/xal_webview_qt.cpp
+++ b/src/xal_webview_qt.cpp
@@ -1,155 +1,164 @@
 #include "xal_webview_qt.h"
-#include "util.h"
 #include <EnvPathUtil.h>
-#include <array>
-#include <cstring>
 #include <errno.h>
 #include <game_window_manager.h>
-#include <memory>
-#include <stdexcept>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <array>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include "util.h"
 
-std::string XalWebViewQt::findWebView() {
-  std::string path;
+std::string XalWebViewQt::findWebView()
+{
+    std::string path;
 #ifdef MCPELAUNCHER_WEBVIEW_PATH
-  if (EnvPathUtil::findInPath("mcpelauncher-webview", path,
-                              MCPELAUNCHER_WEBVIEW_PATH,
-                              EnvPathUtil::getAppDir().c_str()))
-    return path;
+    if (EnvPathUtil::findInPath("mcpelauncher-webview", path, MCPELAUNCHER_WEBVIEW_PATH,
+                                EnvPathUtil::getAppDir().c_str()))
+        return path;
 #endif
-  if (EnvPathUtil::findInPath("mcpelauncher-webview", path))
-    return path;
-  return std::string();
+    if (EnvPathUtil::findInPath("mcpelauncher-webview", path))
+        return path;
+    return std::string();
 }
 
-std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title,
-                                          std::string description) {
-  char ret[1024];
+std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title, std::string description)
+{
+    char ret[1024];
 
-  int pipes[3][2];
-  static const int PIPE_STDOUT = 0;
-  static const int PIPE_STDERR = 1;
-  static const int PIPE_STDIN = 2;
-  static const int PIPE_READ = 0;
-  static const int PIPE_WRITE = 1;
+    int pipes[3][2];
+    static const int PIPE_STDOUT = 0;
+    static const int PIPE_STDERR = 1;
+    static const int PIPE_STDIN = 2;
+    static const int PIPE_READ = 0;
+    static const int PIPE_WRITE = 1;
 
-  pipe(pipes[PIPE_STDOUT]);
-  pipe(pipes[PIPE_STDERR]);
-  pipe(pipes[PIPE_STDIN]);
-  int pid;
-  if (!(pid = fork())) {
-    auto argv = buildCommandLine(path, title, description);
-    auto argvc = convertToC(argv);
-    dup2(pipes[PIPE_STDOUT][PIPE_WRITE], STDOUT_FILENO);
-    dup2(pipes[PIPE_STDERR][PIPE_WRITE], STDERR_FILENO);
-    dup2(pipes[PIPE_STDIN][PIPE_READ], STDIN_FILENO);
-    close(pipes[PIPE_STDIN][PIPE_WRITE]);
-    close(pipes[PIPE_STDOUT][PIPE_WRITE]);
-    close(pipes[PIPE_STDERR][PIPE_WRITE]);
-    close(pipes[PIPE_STDIN][PIPE_READ]);
-    close(pipes[PIPE_STDOUT][PIPE_READ]);
-    close(pipes[PIPE_STDERR][PIPE_READ]);
-    int r = execv(argvc[0], (char **)argvc.data());
-    printf("Show: execv() error %i %s", r, strerror(errno));
-    _exit(r);
-  } else if (pid != -1) {
-    close(pipes[PIPE_STDIN][PIPE_WRITE]);
-    close(pipes[PIPE_STDIN][PIPE_READ]);
-
-    close(pipes[PIPE_STDOUT][PIPE_WRITE]);
-    close(pipes[PIPE_STDERR][PIPE_WRITE]);
-
-    std::string outputStdOut;
-    std::string outputStdErr;
-    ssize_t r;
-    if ((r = read(pipes[PIPE_STDOUT][PIPE_READ], ret, 1024)) > 0)
-      outputStdOut += std::string(ret, (size_t)r);
-    if ((r = read(pipes[PIPE_STDERR][PIPE_READ], ret, 1024)) > 0)
-      outputStdErr += std::string(ret, (size_t)r);
-
-    close(pipes[PIPE_STDOUT][PIPE_READ]);
-    close(pipes[PIPE_STDERR][PIPE_READ]);
-
-    int status;
-    waitpid(pid, &status, 0);
-    status = WEXITSTATUS(status);
-    if (status == 0) {
-      return outputStdOut;
-    } else {
-      throw std::runtime_error(
-          "Process exited with status=" + std::to_string(status) + " stdout:`" +
-          outputStdOut + "` stderr:`" + outputStdErr + "`");
+    pipe(pipes[PIPE_STDOUT]);
+    pipe(pipes[PIPE_STDERR]);
+    pipe(pipes[PIPE_STDIN]);
+    int pid;
+    if (!(pid = fork()))
+    {
+        auto argv = buildCommandLine(path, title, description);
+        auto argvc = convertToC(argv);
+        dup2(pipes[PIPE_STDOUT][PIPE_WRITE], STDOUT_FILENO);
+        dup2(pipes[PIPE_STDERR][PIPE_WRITE], STDERR_FILENO);
+        dup2(pipes[PIPE_STDIN][PIPE_READ], STDIN_FILENO);
+        close(pipes[PIPE_STDIN][PIPE_WRITE]);
+        close(pipes[PIPE_STDOUT][PIPE_WRITE]);
+        close(pipes[PIPE_STDERR][PIPE_WRITE]);
+        close(pipes[PIPE_STDIN][PIPE_READ]);
+        close(pipes[PIPE_STDOUT][PIPE_READ]);
+        close(pipes[PIPE_STDERR][PIPE_READ]);
+        int r = execv(argvc[0], (char **)argvc.data());
+        printf("Show: execv() error %i %s", r, strerror(errno));
+        _exit(r);
     }
-  } else {
-    throw std::runtime_error("Fork failed");
-  }
+    else if (pid != -1)
+    {
+        close(pipes[PIPE_STDIN][PIPE_WRITE]);
+        close(pipes[PIPE_STDIN][PIPE_READ]);
+
+        close(pipes[PIPE_STDOUT][PIPE_WRITE]);
+        close(pipes[PIPE_STDERR][PIPE_WRITE]);
+
+        std::string outputStdOut;
+        std::string outputStdErr;
+        ssize_t r;
+        if ((r = read(pipes[PIPE_STDOUT][PIPE_READ], ret, 1024)) > 0)
+            outputStdOut += std::string(ret, (size_t)r);
+        if ((r = read(pipes[PIPE_STDERR][PIPE_READ], ret, 1024)) > 0)
+            outputStdErr += std::string(ret, (size_t)r);
+
+        close(pipes[PIPE_STDOUT][PIPE_READ]);
+        close(pipes[PIPE_STDERR][PIPE_READ]);
+
+        int status;
+        waitpid(pid, &status, 0);
+        status = WEXITSTATUS(status);
+        if (status == 0)
+        {
+            return outputStdOut;
+        }
+        else
+        {
+            throw std::runtime_error("Process exited with status=" + std::to_string(status) + " stdout:`" +
+                                     outputStdOut + "` stderr:`" + outputStdErr + "`");
+        }
+    }
+    else
+    {
+        throw std::runtime_error("Fork failed");
+    }
 }
 
-std::string XalWebViewQt::show(std::string starturl, std::string endurlprefix) {
-  try {
-    auto webview_path = findWebView();
-    if (webview_path.empty()) {
-      throw std::runtime_error("mcpelauncher-webview not found");
+std::string XalWebViewQt::show(std::string starturl, std::string endurlprefix)
+{
+    try
+    {
+        auto webview_path = findWebView();
+        if (webview_path.empty())
+        {
+            throw std::runtime_error("mcpelauncher-webview not found");
+        }
+        auto result = exec_get_stdout(webview_path, starturl, endurlprefix);
+        trim(result);
+        // valid character list took from
+        // https://developers.google.com/maps/documentation/urls/url-encoding#special-characters
+        // added space, because it isn't url encoded on account creation
+        auto validUrlChars =
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0"
+            "123456789-_.~!*'();:@&=+$,/?%#[] ";
+        if ((result.rfind(endurlprefix, 0) != 0 || result.find_first_not_of(validUrlChars, 0) != std::string::npos) &&
+            !result.empty())
+        {
+            auto iurl = result.find(endurlprefix);
+            if (iurl != std::string::npos)
+            {
+                auto eurl = result.find_first_not_of(validUrlChars, iurl);
+                auto url = result.substr(iurl, eurl);
+                GameWindowManager::getManager()->getErrorHandler()->onError(
+                    "XalWebViewQt",
+                    "The Launcher might failed to open the Xboxlive login Window "
+                    "successfully, please report if Minecraft tells you that sign in "
+                    "failed. Please look into the gamelog for more Information: "
+                    "Process returned stdout:`" +
+                        result + "`, but expected an url starting with:`" + endurlprefix + "`. Try returning `" + url +
+                        "` as endurl. We track this issue here "
+                        "https://github.com/minecraft-linux/mcpelauncher-manifest/"
+                        "issues/444");
+                return url;
+            }
+            throw std::runtime_error("Process returned stdout:`" + result + "`, but expected an url starting with:`" +
+                                     endurlprefix + "`");
+        }
+        return result;
     }
-    auto result = exec_get_stdout(webview_path, starturl, endurlprefix);
-    trim(result);
-    // valid character list took from
-    // https://developers.google.com/maps/documentation/urls/url-encoding#special-characters
-    // added space, because it isn't url encoded on account creation
-    auto validUrlChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0"
-                         "123456789-_.~!*'();:@&=+$,/?%#[] ";
-    if ((result.rfind(endurlprefix, 0) != 0 ||
-         result.find_first_not_of(validUrlChars, 0) != std::string::npos) &&
-        !result.empty()) {
-      auto iurl = result.find(endurlprefix);
-      if (iurl != std::string::npos) {
-        auto eurl = result.find_first_not_of(validUrlChars, iurl);
-        auto url = result.substr(iurl, eurl);
+    catch (const std::exception &ex)
+    {
         GameWindowManager::getManager()->getErrorHandler()->onError(
-            "XalWebViewQt",
-            "The Launcher might failed to open the Xboxlive login Window "
-            "successfully, please report if Minecraft tells you that sign in "
-            "failed. Please look into the gamelog for more Information: "
-            "Process returned stdout:`" +
-                result + "`, but expected an url starting with:`" +
-                endurlprefix + "`. Try returning `" + url +
-                "` as endurl. We track this issue here "
-                "https://github.com/minecraft-linux/mcpelauncher-manifest/"
-                "issues/444");
-        return url;
-      }
-      throw std::runtime_error("Process returned stdout:`" + result +
-                               "`, but expected an url starting with:`" +
-                               endurlprefix + "`");
+            "XalWebViewQt", std::string("Failed to open Xboxlive login Window. Please look into "
+                                        "the gamelog for more Information: ") +
+                                ex.what());
+        return "";
     }
-    return result;
-  } catch (const std::exception &ex) {
-    GameWindowManager::getManager()->getErrorHandler()->onError(
-        "XalWebViewQt",
-        std::string("Failed to open Xboxlive login Window. Please look into "
-                    "the gamelog for more Information: ") +
-            ex.what());
-    return "";
-  }
 }
 
-std::vector<std::string>
-XalWebViewQt::buildCommandLine(std::string path, std::string title,
-                               std::string description) {
-  std::vector<std::string> cmd;
-  cmd.emplace_back(path);
-  cmd.emplace_back(title);
-  cmd.emplace_back(description);
-  return std::move(cmd);
+std::vector<std::string> XalWebViewQt::buildCommandLine(std::string path, std::string title, std::string description)
+{
+    std::vector<std::string> cmd;
+    cmd.emplace_back(path);
+    cmd.emplace_back(title);
+    cmd.emplace_back(description);
+    return std::move(cmd);
 }
 
-std::vector<const char *>
-XalWebViewQt::convertToC(std::vector<std::string> const &v) {
-  std::vector<const char *> ret;
-  for (auto const &i : v)
-    ret.push_back(i.c_str());
-  ret.push_back(nullptr);
-  return std::move(ret);
+std::vector<const char *> XalWebViewQt::convertToC(std::vector<std::string> const &v)
+{
+    std::vector<const char *> ret;
+    for (auto const &i : v) ret.push_back(i.c_str());
+    ret.push_back(nullptr);
+    return std::move(ret);
 }

--- a/src/xal_webview_qt.cpp
+++ b/src/xal_webview_qt.cpp
@@ -1,127 +1,155 @@
 #include "xal_webview_qt.h"
+#include "util.h"
 #include <EnvPathUtil.h>
 #include <array>
-#include <memory>
-#include <stdexcept>
-#include <unistd.h>
-#include <sys/wait.h>
-#include <sys/stat.h>
 #include <cstring>
 #include <errno.h>
 #include <game_window_manager.h>
-#include "util.h"
+#include <memory>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 std::string XalWebViewQt::findWebView() {
-    std::string path;
+  std::string path;
 #ifdef MCPELAUNCHER_WEBVIEW_PATH
-    if (EnvPathUtil::findInPath("mcpelauncher-webview", path, MCPELAUNCHER_WEBVIEW_PATH, EnvPathUtil::getAppDir().c_str()))
-        return path;
+  if (EnvPathUtil::findInPath("mcpelauncher-webview", path,
+                              MCPELAUNCHER_WEBVIEW_PATH,
+                              EnvPathUtil::getAppDir().c_str()))
+    return path;
 #endif
-    if (EnvPathUtil::findInPath("mcpelauncher-webview", path))
-        return path;
-    return std::string();
+  if (EnvPathUtil::findInPath("mcpelauncher-webview", path))
+    return path;
+  return std::string();
 }
 
-std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title, std::string description) {
-    char ret[1024];
+std::string XalWebViewQt::exec_get_stdout(std::string path, std::string title,
+                                          std::string description) {
+  char ret[1024];
 
-    int pipes[3][2];
-    static const int PIPE_STDOUT = 0;
-    static const int PIPE_STDERR = 1;
-    static const int PIPE_STDIN = 2;
-    static const int PIPE_READ = 0;
-    static const int PIPE_WRITE = 1;
+  int pipes[3][2];
+  static const int PIPE_STDOUT = 0;
+  static const int PIPE_STDERR = 1;
+  static const int PIPE_STDIN = 2;
+  static const int PIPE_READ = 0;
+  static const int PIPE_WRITE = 1;
 
-    pipe(pipes[PIPE_STDOUT]);
-    pipe(pipes[PIPE_STDERR]);
-    pipe(pipes[PIPE_STDIN]);
-    int pid;
-    if (!(pid = fork())) {
-        auto argv = buildCommandLine(path, title, description);
-        auto argvc = convertToC(argv);
-        dup2(pipes[PIPE_STDOUT][PIPE_WRITE], STDOUT_FILENO);
-        dup2(pipes[PIPE_STDERR][PIPE_WRITE], STDERR_FILENO);
-        dup2(pipes[PIPE_STDIN][PIPE_READ], STDIN_FILENO);
-        close(pipes[PIPE_STDIN][PIPE_WRITE]);
-        close(pipes[PIPE_STDOUT][PIPE_WRITE]);
-        close(pipes[PIPE_STDERR][PIPE_WRITE]);
-        close(pipes[PIPE_STDIN][PIPE_READ]);
-        close(pipes[PIPE_STDOUT][PIPE_READ]);
-        close(pipes[PIPE_STDERR][PIPE_READ]);
-        int r = execv(argvc[0], (char**) argvc.data());
-        printf("Show: execv() error %i %s", r, strerror(errno));
-        _exit(r);
-    } else if (pid != -1) {
-        close(pipes[PIPE_STDIN][PIPE_WRITE]);
-        close(pipes[PIPE_STDIN][PIPE_READ]);
+  pipe(pipes[PIPE_STDOUT]);
+  pipe(pipes[PIPE_STDERR]);
+  pipe(pipes[PIPE_STDIN]);
+  int pid;
+  if (!(pid = fork())) {
+    auto argv = buildCommandLine(path, title, description);
+    auto argvc = convertToC(argv);
+    dup2(pipes[PIPE_STDOUT][PIPE_WRITE], STDOUT_FILENO);
+    dup2(pipes[PIPE_STDERR][PIPE_WRITE], STDERR_FILENO);
+    dup2(pipes[PIPE_STDIN][PIPE_READ], STDIN_FILENO);
+    close(pipes[PIPE_STDIN][PIPE_WRITE]);
+    close(pipes[PIPE_STDOUT][PIPE_WRITE]);
+    close(pipes[PIPE_STDERR][PIPE_WRITE]);
+    close(pipes[PIPE_STDIN][PIPE_READ]);
+    close(pipes[PIPE_STDOUT][PIPE_READ]);
+    close(pipes[PIPE_STDERR][PIPE_READ]);
+    int r = execv(argvc[0], (char **)argvc.data());
+    printf("Show: execv() error %i %s", r, strerror(errno));
+    _exit(r);
+  } else if (pid != -1) {
+    close(pipes[PIPE_STDIN][PIPE_WRITE]);
+    close(pipes[PIPE_STDIN][PIPE_READ]);
 
-        close(pipes[PIPE_STDOUT][PIPE_WRITE]);
-        close(pipes[PIPE_STDERR][PIPE_WRITE]);
+    close(pipes[PIPE_STDOUT][PIPE_WRITE]);
+    close(pipes[PIPE_STDERR][PIPE_WRITE]);
 
-        std::string outputStdOut;
-        std::string outputStdErr;
-        ssize_t r;
-        if ((r = read(pipes[PIPE_STDOUT][PIPE_READ], ret, 1024)) > 0)
-            outputStdOut += std::string(ret, (size_t) r);
-        if ((r = read(pipes[PIPE_STDERR][PIPE_READ], ret, 1024)) > 0)
-            outputStdErr += std::string(ret, (size_t) r);
+    std::string outputStdOut;
+    std::string outputStdErr;
+    ssize_t r;
+    if ((r = read(pipes[PIPE_STDOUT][PIPE_READ], ret, 1024)) > 0)
+      outputStdOut += std::string(ret, (size_t)r);
+    if ((r = read(pipes[PIPE_STDERR][PIPE_READ], ret, 1024)) > 0)
+      outputStdErr += std::string(ret, (size_t)r);
 
-        close(pipes[PIPE_STDOUT][PIPE_READ]);
-        close(pipes[PIPE_STDERR][PIPE_READ]);
+    close(pipes[PIPE_STDOUT][PIPE_READ]);
+    close(pipes[PIPE_STDERR][PIPE_READ]);
 
-        int status;
-        waitpid(pid, &status, 0);
-        status = WEXITSTATUS(status);
-        if (status == 0) {
-            return outputStdOut;
-        } else {
-            throw std::runtime_error("Process exited with status=" + std::to_string(status) + " stdout:`" + outputStdOut + "` stderr:`" + outputStdErr + "`");
-        }
+    int status;
+    waitpid(pid, &status, 0);
+    status = WEXITSTATUS(status);
+    if (status == 0) {
+      return outputStdOut;
     } else {
-        throw std::runtime_error("Fork failed");
+      throw std::runtime_error(
+          "Process exited with status=" + std::to_string(status) + " stdout:`" +
+          outputStdOut + "` stderr:`" + outputStdErr + "`");
     }
+  } else {
+    throw std::runtime_error("Fork failed");
+  }
 }
 
 std::string XalWebViewQt::show(std::string starturl, std::string endurlprefix) {
-    try {
-        auto webview_path = findWebView();
-        if (webview_path.empty()) {
-            throw std::runtime_error("mcpelauncher-webview not found");
-        }
-        auto result = exec_get_stdout(webview_path, starturl, endurlprefix);
-        trim(result);
-        // valid character list took from https://developers.google.com/maps/documentation/urls/url-encoding#special-characters
-        // added space, because it isn't url encoded on account creation
-        auto validUrlChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~!*'();:@&=+$,/?%#[] ";
-        if ((result.rfind(endurlprefix, 0) != 0 || result.find_first_not_of(validUrlChars, 0) != std::string::npos) && !result.empty()) {
-            auto iurl = result.find(endurlprefix);
-            if (iurl != std::string::npos) {
-                auto eurl = result.find_first_not_of(validUrlChars, iurl);
-                auto url = result.substr(iurl, eurl);
-                GameWindowManager::getManager()->getErrorHandler()->onError("XalWebViewQt", "The Launcher might failed to open the Xboxlive login Window successfully, please report if Minecraft tells you that sign in failed. Please look into the gamelog for more Information: Process returned stdout:`" + result + "`, but expected an url starting with:`" + endurlprefix + "`. Try returning `" + url + "` as endurl. We track this issue here https://github.com/minecraft-linux/mcpelauncher-manifest/issues/444");
-                return url;
-            }
-            throw std::runtime_error("Process returned stdout:`" + result + "`, but expected an url starting with:`" + endurlprefix + "`");
-        }
-        return result;
-    } catch (const std::exception& ex) {
-        GameWindowManager::getManager()->getErrorHandler()->onError("XalWebViewQt", std::string("Failed to open Xboxlive login Window. Please look into the gamelog for more Information: ") + ex.what());
-        return "";
+  try {
+    auto webview_path = findWebView();
+    if (webview_path.empty()) {
+      throw std::runtime_error("mcpelauncher-webview not found");
     }
+    auto result = exec_get_stdout(webview_path, starturl, endurlprefix);
+    trim(result);
+    // valid character list took from
+    // https://developers.google.com/maps/documentation/urls/url-encoding#special-characters
+    // added space, because it isn't url encoded on account creation
+    auto validUrlChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0"
+                         "123456789-_.~!*'();:@&=+$,/?%#[] ";
+    if ((result.rfind(endurlprefix, 0) != 0 ||
+         result.find_first_not_of(validUrlChars, 0) != std::string::npos) &&
+        !result.empty()) {
+      auto iurl = result.find(endurlprefix);
+      if (iurl != std::string::npos) {
+        auto eurl = result.find_first_not_of(validUrlChars, iurl);
+        auto url = result.substr(iurl, eurl);
+        GameWindowManager::getManager()->getErrorHandler()->onError(
+            "XalWebViewQt",
+            "The Launcher might failed to open the Xboxlive login Window "
+            "successfully, please report if Minecraft tells you that sign in "
+            "failed. Please look into the gamelog for more Information: "
+            "Process returned stdout:`" +
+                result + "`, but expected an url starting with:`" +
+                endurlprefix + "`. Try returning `" + url +
+                "` as endurl. We track this issue here "
+                "https://github.com/minecraft-linux/mcpelauncher-manifest/"
+                "issues/444");
+        return url;
+      }
+      throw std::runtime_error("Process returned stdout:`" + result +
+                               "`, but expected an url starting with:`" +
+                               endurlprefix + "`");
+    }
+    return result;
+  } catch (const std::exception &ex) {
+    GameWindowManager::getManager()->getErrorHandler()->onError(
+        "XalWebViewQt",
+        std::string("Failed to open Xboxlive login Window. Please look into "
+                    "the gamelog for more Information: ") +
+            ex.what());
+    return "";
+  }
 }
 
-std::vector<std::string> XalWebViewQt::buildCommandLine(std::string path, std::string title, std::string description) {
-    std::vector<std::string> cmd;
-    cmd.emplace_back(path);
-    cmd.emplace_back(title);
-    cmd.emplace_back(description);
-    return std::move(cmd);
+std::vector<std::string>
+XalWebViewQt::buildCommandLine(std::string path, std::string title,
+                               std::string description) {
+  std::vector<std::string> cmd;
+  cmd.emplace_back(path);
+  cmd.emplace_back(title);
+  cmd.emplace_back(description);
+  return std::move(cmd);
 }
 
-std::vector<const char*> XalWebViewQt::convertToC(std::vector<std::string> const& v) {
-    std::vector<const char*> ret;
-    for (auto const& i : v)
-        ret.push_back(i.c_str());
-    ret.push_back(nullptr);
-    return std::move(ret);
+std::vector<const char *>
+XalWebViewQt::convertToC(std::vector<std::string> const &v) {
+  std::vector<const char *> ret;
+  for (auto const &i : v)
+    ret.push_back(i.c_str());
+  ret.push_back(nullptr);
+  return std::move(ret);
 }

--- a/src/xal_webview_qt.h
+++ b/src/xal_webview_qt.h
@@ -4,8 +4,7 @@
 #include <vector>
 #include "xal_webview.h"
 
-class XalWebViewQt : public XalWebView
-{
+class XalWebViewQt : public XalWebView {
     std::string findWebView();
     std::string exec_get_stdout(std::string path, std::string title, std::string description);
     std::vector<std::string> buildCommandLine(std::string path, std::string title, std::string description);

--- a/src/xal_webview_qt.h
+++ b/src/xal_webview_qt.h
@@ -5,10 +5,14 @@
 #include <vector>
 
 class XalWebViewQt : public XalWebView {
-    std::string findWebView();
-    std::string exec_get_stdout(std::string path, std::string title, std::string description);
-    std::vector<std::string> buildCommandLine(std::string path, std::string title, std::string description);
-    std::vector<const char *> convertToC(const std::vector<std::string> &v);
+  std::string findWebView();
+  std::string exec_get_stdout(std::string path, std::string title,
+                              std::string description);
+  std::vector<std::string> buildCommandLine(std::string path, std::string title,
+                                            std::string description);
+  std::vector<const char *> convertToC(const std::vector<std::string> &v);
+
 public:
-    virtual std::string show(std::string starturl, std::string endurlprefix) override;
+  virtual std::string show(std::string starturl,
+                           std::string endurlprefix) override;
 };

--- a/src/xal_webview_qt.h
+++ b/src/xal_webview_qt.h
@@ -1,18 +1,16 @@
 #pragma once
 
-#include "xal_webview.h"
 #include <string>
 #include <vector>
+#include "xal_webview.h"
 
-class XalWebViewQt : public XalWebView {
-  std::string findWebView();
-  std::string exec_get_stdout(std::string path, std::string title,
-                              std::string description);
-  std::vector<std::string> buildCommandLine(std::string path, std::string title,
-                                            std::string description);
-  std::vector<const char *> convertToC(const std::vector<std::string> &v);
+class XalWebViewQt : public XalWebView
+{
+    std::string findWebView();
+    std::string exec_get_stdout(std::string path, std::string title, std::string description);
+    std::vector<std::string> buildCommandLine(std::string path, std::string title, std::string description);
+    std::vector<const char *> convertToC(const std::vector<std::string> &v);
 
-public:
-  virtual std::string show(std::string starturl,
-                           std::string endurlprefix) override;
+   public:
+    virtual std::string show(std::string starturl, std::string endurlprefix) override;
 };

--- a/src/xbox_live_helper.cpp
+++ b/src/xbox_live_helper.cpp
@@ -1,10 +1,10 @@
 #include "xbox_live_helper.h"
-#include "jni/xbox_live.h"
 #include <FileUtil.h>
 #include <log.h>
 #include <mcpelauncher/minecraft_version.h>
 #include <mcpelauncher/path_helper.h>
 #include <msa/client/compact_token.h>
+#include "jni/xbox_live.h"
 
 using namespace simpleipc;
 
@@ -14,177 +14,174 @@ std::string const XboxLiveHelper::MSA_CLIENT_ID =
     "android-app://com.mojang.minecraftpe.H62DKCBHJP6WXXIV7RBFOGOL4NAK4E6Y";
 std::string const XboxLiveHelper::MSA_COBRAND_ID = "90023";
 
-std::string XboxLiveHelper::findMsa() {
-  std::string path;
+std::string XboxLiveHelper::findMsa()
+{
+    std::string path;
 #ifdef MSA_DAEMON_PATH
-  if (EnvPathUtil::findInPath("msa-daemon", path, MSA_DAEMON_PATH,
-                              EnvPathUtil::getAppDir().c_str()))
-    return path;
+    if (EnvPathUtil::findInPath("msa-daemon", path, MSA_DAEMON_PATH, EnvPathUtil::getAppDir().c_str()))
+        return path;
 #endif
-  if (EnvPathUtil::findInPath("msa-daemon", path))
-    return path;
-  return std::string();
+    if (EnvPathUtil::findInPath("msa-daemon", path))
+        return path;
+    return std::string();
 }
 
-XboxLiveHelper::XboxLiveHelper()
-    : launcher(findMsa()), triedToCreateClient(false) {}
+XboxLiveHelper::XboxLiveHelper() : launcher(findMsa()), triedToCreateClient(false) {}
 
-msa::client::ServiceClient *XboxLiveHelper::getMsaClientOrNull() {
-  std::lock_guard<std::mutex> lock(clientMutex);
-  if (triedToCreateClient)
+msa::client::ServiceClient *XboxLiveHelper::getMsaClientOrNull()
+{
+    std::lock_guard<std::mutex> lock(clientMutex);
+    if (triedToCreateClient)
+        return client.get();
+    triedToCreateClient = true;
+    try
+    {
+        client = std::unique_ptr<msa::client::ServiceClient>(new msa::client::ServiceClient(launcher));
+    }
+    catch (std::exception &exception)
+    {
+        Log::error("XboxLiveHelper", "Failed to connect to the daemon: %s", exception.what());
+    }
     return client.get();
-  triedToCreateClient = true;
-  try {
-    client = std::unique_ptr<msa::client::ServiceClient>(
-        new msa::client::ServiceClient(launcher));
-  } catch (std::exception &exception) {
-    Log::error("XboxLiveHelper", "Failed to connect to the daemon: %s",
-               exception.what());
-  }
-  return client.get();
 }
 
-msa::client::ServiceClient &XboxLiveHelper::getMsaClient() {
-  auto client = getMsaClientOrNull();
-  if (!client)
-    throw std::runtime_error("Could not connect to the daemon");
-  return *client;
+msa::client::ServiceClient &XboxLiveHelper::getMsaClient()
+{
+    auto client = getMsaClientOrNull();
+    if (!client)
+        throw std::runtime_error("Could not connect to the daemon");
+    return *client;
 }
 
 void XboxLiveHelper::invokeMsaAuthFlow(
-    std::function<void(std::string const &cid, std::string const &binaryToken)>
-        success_cb,
-    std::function<void(simpleipc::rpc_error_code, std::string const &)>
-        error_cb) {
-  auto client = getMsaClientOrNull();
-  if (!client) {
-    error_cb(simpleipc::rpc_error_codes::connection_closed,
-             "Could not connect to the daemon");
-    return;
-  }
-  client->pickAccount(MSA_CLIENT_ID, MSA_COBRAND_ID)
-      .call([this, success_cb, error_cb](rpc_result<std::string> res) {
-        if (!res.success()) {
-          error_cb(res.error_code(), res.error_text());
-          return;
-        }
+    std::function<void(std::string const &cid, std::string const &binaryToken)> success_cb,
+    std::function<void(simpleipc::rpc_error_code, std::string const &)> error_cb)
+{
+    auto client = getMsaClientOrNull();
+    if (!client)
+    {
+        error_cb(simpleipc::rpc_error_codes::connection_closed, "Could not connect to the daemon");
+        return;
+    }
+    client->pickAccount(MSA_CLIENT_ID, MSA_COBRAND_ID)
+        .call(
+            [this, success_cb, error_cb](rpc_result<std::string> res)
+            {
+                if (!res.success())
+                {
+                    error_cb(res.error_code(), res.error_text());
+                    return;
+                }
 
-        requestXblToken(res.data(), false, success_cb, error_cb);
-      });
+                requestXblToken(res.data(), false, success_cb, error_cb);
+            });
 }
 
-simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>>
-XboxLiveHelper::requestXblToken(std::string const &cid, bool silent) {
-  return getMsaClient().requestToken(cid, {"user.auth.xboxlive.com", "mbi_ssl"},
-                                     MSA_CLIENT_ID, silent);
+simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>> XboxLiveHelper::requestXblToken(std::string const &cid,
+                                                                                                 bool silent)
+{
+    return getMsaClient().requestToken(cid, {"user.auth.xboxlive.com", "mbi_ssl"}, MSA_CLIENT_ID, silent);
 }
 
 void XboxLiveHelper::requestXblToken(
     std::string const &cid, bool silent,
-    std::function<void(std::string const &cid, std::string const &binaryToken)>
-        success_cb,
-    std::function<void(simpleipc::rpc_error_code, std::string const &)>
-        error_cb) {
-  if (!getMsaClientOrNull()) {
-    error_cb(simpleipc::rpc_error_codes::connection_closed,
-             "Could not connect to the daemon");
-    return;
-  }
-  requestXblToken(cid, silent)
-      .call([cid, success_cb,
-             error_cb](rpc_result<std::shared_ptr<msa::client::Token>> res) {
-        if (res.success() && res.data() &&
-            res.data()->getType() == msa::client::TokenType::Compact) {
-          auto token =
-              msa::client::token_pointer_cast<msa::client::CompactToken>(
-                  res.data());
-          success_cb(cid, token->getBinaryToken());
-        } else {
-          if (res.success())
-            error_cb(simpleipc::rpc_error_codes::internal_error,
-                     "Invalid token received from the MSA daemon");
-          else
-            error_cb(res.error_code(), res.error_text());
-        }
-      });
+    std::function<void(std::string const &cid, std::string const &binaryToken)> success_cb,
+    std::function<void(simpleipc::rpc_error_code, std::string const &)> error_cb)
+{
+    if (!getMsaClientOrNull())
+    {
+        error_cb(simpleipc::rpc_error_codes::connection_closed, "Could not connect to the daemon");
+        return;
+    }
+    requestXblToken(cid, silent)
+        .call(
+            [cid, success_cb, error_cb](rpc_result<std::shared_ptr<msa::client::Token>> res)
+            {
+                if (res.success() && res.data() && res.data()->getType() == msa::client::TokenType::Compact)
+                {
+                    auto token = msa::client::token_pointer_cast<msa::client::CompactToken>(res.data());
+                    success_cb(cid, token->getBinaryToken());
+                }
+                else
+                {
+                    if (res.success())
+                        error_cb(simpleipc::rpc_error_codes::internal_error,
+                                 "Invalid token received from the MSA daemon");
+                    else
+                        error_cb(res.error_code(), res.error_text());
+                }
+            });
 }
 
-void XboxLiveHelper::initCll(std::string const &cid) {
-  std::lock_guard<std::mutex> lock(cllMutex);
-  if (!cid.empty())
-    cllAuthStep.setAccount(cid);
-  if (cll)
-    return;
-  std::string iKey = "P-XBL-T" + std::to_string(0); // TODO: Get tid properly
-  auto cllEvents = PathHelper::getPrimaryDataDirectory() + "cll_events";
-  auto cacheDir = PathHelper::getCacheDirectory() + "cll";
-  FileUtil::mkdirRecursive(cllEvents);
-  FileUtil::mkdirRecursive(cacheDir);
-  cll = std::unique_ptr<cll::EventManager>(
-      new cll::EventManager(iKey, cllEvents, cacheDir));
-  cll->addUploadStep(cllAuthStep);
-  cll->setApp("A:com.mojang.minecraftpe", MinecraftVersion::getString());
-  cll->start();
+void XboxLiveHelper::initCll(std::string const &cid)
+{
+    std::lock_guard<std::mutex> lock(cllMutex);
+    if (!cid.empty())
+        cllAuthStep.setAccount(cid);
+    if (cll)
+        return;
+    std::string iKey = "P-XBL-T" + std::to_string(0);  // TODO: Get tid properly
+    auto cllEvents = PathHelper::getPrimaryDataDirectory() + "cll_events";
+    auto cacheDir = PathHelper::getCacheDirectory() + "cll";
+    FileUtil::mkdirRecursive(cllEvents);
+    FileUtil::mkdirRecursive(cacheDir);
+    cll = std::unique_ptr<cll::EventManager>(new cll::EventManager(iKey, cllEvents, cacheDir));
+    cll->addUploadStep(cllAuthStep);
+    cll->setApp("A:com.mojang.minecraftpe", MinecraftVersion::getString());
+    cll->start();
 }
 
-std::string XboxLiveHelper::getCllMsaToken(std::string const &cid) {
-  auto client = getMsaClientOrNull();
-  if (!client)
-    return std::string();
-  auto token = client
-                   ->requestToken(cid, {"vortex.data.microsoft.com", "mbi_ssl"},
-                                  MSA_CLIENT_ID, true)
-                   .call();
-  if (!token.success() || !token.data() ||
-      token.data()->getType() != msa::client::TokenType::Compact)
-    return std::string();
-  return msa::client::token_pointer_cast<msa::client::CompactToken>(
-             token.data())
-      ->getBinaryToken();
+std::string XboxLiveHelper::getCllMsaToken(std::string const &cid)
+{
+    auto client = getMsaClientOrNull();
+    if (!client)
+        return std::string();
+    auto token = client->requestToken(cid, {"vortex.data.microsoft.com", "mbi_ssl"}, MSA_CLIENT_ID, true).call();
+    if (!token.success() || !token.data() || token.data()->getType() != msa::client::TokenType::Compact)
+        return std::string();
+    return msa::client::token_pointer_cast<msa::client::CompactToken>(token.data())->getBinaryToken();
 }
 
 void XboxLiveHelper::setJvm(FakeJni::Jvm *vm) { this->vm = vm; }
 
-std::string XboxLiveHelper::getCllXToken(bool refresh) {
-  FakeJni::LocalFrame env(*vm);
-  if (auto callback = XboxInterop::getDescriptor()->getMethod(
-          "(Z)Ljava/lang/String;", "get_uploader_x_token_callback")) {
-    if (auto xtokenRef =
-            callback
-                ->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(),
-                         (jboolean)refresh)
-                .l) {
-      if (auto xtoken = std::dynamic_pointer_cast<FakeJni::JString>(
-              env.getJniEnv().resolveReference(xtokenRef))) {
-        return xtoken->asStdString();
-      }
+std::string XboxLiveHelper::getCllXToken(bool refresh)
+{
+    FakeJni::LocalFrame env(*vm);
+    if (auto callback =
+            XboxInterop::getDescriptor()->getMethod("(Z)Ljava/lang/String;", "get_uploader_x_token_callback"))
+    {
+        if (auto xtokenRef = callback->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(), (jboolean)refresh).l)
+        {
+            if (auto xtoken = std::dynamic_pointer_cast<FakeJni::JString>(env.getJniEnv().resolveReference(xtokenRef)))
+            {
+                return xtoken->asStdString();
+            }
+        }
     }
-  }
-  return std::string();
+    return std::string();
 }
 
-std::string XboxLiveHelper::getCllXTicket(std::string const &xuid) {
-  FakeJni::LocalFrame env(*vm);
-  if (auto callback = XboxInterop::getDescriptor()->getMethod(
-          "(Ljava/lang/String;)Ljava/lang/String;",
-          "get_supporting_x_token_callback")) {
-    auto xuidRef = env.getJniEnv().createLocalReference(
-        std::make_shared<FakeJni::JString>(xuid));
-    if (auto xticketRef =
-            callback
-                ->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(),
-                         xuidRef)
-                .l) {
-      if (auto xticket = std::dynamic_pointer_cast<FakeJni::JString>(
-              env.getJniEnv().resolveReference(xticketRef))) {
-        return xticket->asStdString();
-      }
+std::string XboxLiveHelper::getCllXTicket(std::string const &xuid)
+{
+    FakeJni::LocalFrame env(*vm);
+    if (auto callback = XboxInterop::getDescriptor()->getMethod("(Ljava/lang/String;)Ljava/lang/String;",
+                                                                "get_supporting_x_token_callback"))
+    {
+        auto xuidRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(xuid));
+        if (auto xticketRef = callback->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(), xuidRef).l)
+        {
+            if (auto xticket =
+                    std::dynamic_pointer_cast<FakeJni::JString>(env.getJniEnv().resolveReference(xticketRef)))
+            {
+                return xticket->asStdString();
+            }
+        }
     }
-  }
-  return std::string();
+    return std::string();
 }
 
-void XboxLiveHelper::logCll(cll::Event const &event) {
-  initCll();
-  cll->add(event);
+void XboxLiveHelper::logCll(cll::Event const &event)
+{
+    initCll();
+    cll->add(event);
 }

--- a/src/xbox_live_helper.cpp
+++ b/src/xbox_live_helper.cpp
@@ -1,154 +1,190 @@
-#include <msa/client/compact_token.h>
-#include <log.h>
-#include <FileUtil.h>
-#include <mcpelauncher/path_helper.h>
-#include <mcpelauncher/minecraft_version.h>
 #include "xbox_live_helper.h"
 #include "jni/xbox_live.h"
+#include <FileUtil.h>
+#include <log.h>
+#include <mcpelauncher/minecraft_version.h>
+#include <mcpelauncher/path_helper.h>
+#include <msa/client/compact_token.h>
 
 using namespace simpleipc;
 
 XboxLiveHelper XboxLiveHelper::instance;
 
-std::string const XboxLiveHelper::MSA_CLIENT_ID = "android-app://com.mojang.minecraftpe.H62DKCBHJP6WXXIV7RBFOGOL4NAK4E6Y";
+std::string const XboxLiveHelper::MSA_CLIENT_ID =
+    "android-app://com.mojang.minecraftpe.H62DKCBHJP6WXXIV7RBFOGOL4NAK4E6Y";
 std::string const XboxLiveHelper::MSA_COBRAND_ID = "90023";
 
 std::string XboxLiveHelper::findMsa() {
-    std::string path;
+  std::string path;
 #ifdef MSA_DAEMON_PATH
-    if (EnvPathUtil::findInPath("msa-daemon", path, MSA_DAEMON_PATH, EnvPathUtil::getAppDir().c_str()))
-        return path;
+  if (EnvPathUtil::findInPath("msa-daemon", path, MSA_DAEMON_PATH,
+                              EnvPathUtil::getAppDir().c_str()))
+    return path;
 #endif
-    if (EnvPathUtil::findInPath("msa-daemon", path))
-        return path;
-    return std::string();
+  if (EnvPathUtil::findInPath("msa-daemon", path))
+    return path;
+  return std::string();
 }
 
-XboxLiveHelper::XboxLiveHelper() : launcher(findMsa()), triedToCreateClient(false) {
-}
+XboxLiveHelper::XboxLiveHelper()
+    : launcher(findMsa()), triedToCreateClient(false) {}
 
-msa::client::ServiceClient* XboxLiveHelper::getMsaClientOrNull() {
-    std::lock_guard<std::mutex> lock (clientMutex);
-    if (triedToCreateClient)
-        return client.get();
-    triedToCreateClient = true;
-    try {
-        client = std::unique_ptr<msa::client::ServiceClient>(new msa::client::ServiceClient(launcher));
-    } catch (std::exception& exception) {
-        Log::error("XboxLiveHelper", "Failed to connect to the daemon: %s", exception.what());
-    }
+msa::client::ServiceClient *XboxLiveHelper::getMsaClientOrNull() {
+  std::lock_guard<std::mutex> lock(clientMutex);
+  if (triedToCreateClient)
     return client.get();
+  triedToCreateClient = true;
+  try {
+    client = std::unique_ptr<msa::client::ServiceClient>(
+        new msa::client::ServiceClient(launcher));
+  } catch (std::exception &exception) {
+    Log::error("XboxLiveHelper", "Failed to connect to the daemon: %s",
+               exception.what());
+  }
+  return client.get();
 }
 
-msa::client::ServiceClient& XboxLiveHelper::getMsaClient() {
-    auto client = getMsaClientOrNull();
-    if (!client)
-        throw std::runtime_error("Could not connect to the daemon");
-    return *client;
+msa::client::ServiceClient &XboxLiveHelper::getMsaClient() {
+  auto client = getMsaClientOrNull();
+  if (!client)
+    throw std::runtime_error("Could not connect to the daemon");
+  return *client;
 }
 
 void XboxLiveHelper::invokeMsaAuthFlow(
-        std::function<void(std::string const& cid, std::string const& binaryToken)> success_cb,
-        std::function<void(simpleipc::rpc_error_code, std::string const&)> error_cb) {
-    auto client = getMsaClientOrNull();
-    if (!client) {
-        error_cb(simpleipc::rpc_error_codes::connection_closed, "Could not connect to the daemon");
-        return;
-    }
-    client->pickAccount(MSA_CLIENT_ID, MSA_COBRAND_ID).call([this, success_cb, error_cb](rpc_result<std::string> res) {
+    std::function<void(std::string const &cid, std::string const &binaryToken)>
+        success_cb,
+    std::function<void(simpleipc::rpc_error_code, std::string const &)>
+        error_cb) {
+  auto client = getMsaClientOrNull();
+  if (!client) {
+    error_cb(simpleipc::rpc_error_codes::connection_closed,
+             "Could not connect to the daemon");
+    return;
+  }
+  client->pickAccount(MSA_CLIENT_ID, MSA_COBRAND_ID)
+      .call([this, success_cb, error_cb](rpc_result<std::string> res) {
         if (!res.success()) {
-            error_cb(res.error_code(), res.error_text());
-            return;
+          error_cb(res.error_code(), res.error_text());
+          return;
         }
 
         requestXblToken(res.data(), false, success_cb, error_cb);
-    });
+      });
 }
 
-simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>> XboxLiveHelper::requestXblToken(std::string const& cid,
-                                                                                                 bool silent) {
-    return getMsaClient().requestToken(cid, {"user.auth.xboxlive.com", "mbi_ssl"}, MSA_CLIENT_ID, silent);
+simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>>
+XboxLiveHelper::requestXblToken(std::string const &cid, bool silent) {
+  return getMsaClient().requestToken(cid, {"user.auth.xboxlive.com", "mbi_ssl"},
+                                     MSA_CLIENT_ID, silent);
 }
 
-void XboxLiveHelper::requestXblToken
-        (std::string const& cid, bool silent,
-         std::function<void(std::string const& cid, std::string const& binaryToken)> success_cb,
-         std::function<void(simpleipc::rpc_error_code, std::string const&)> error_cb) {
-    if (!getMsaClientOrNull()) {
-        error_cb(simpleipc::rpc_error_codes::connection_closed, "Could not connect to the daemon");
-        return;
-    }
-    requestXblToken(cid, silent).call([cid, success_cb, error_cb](rpc_result<std::shared_ptr<msa::client::Token>> res) {
-        if (res.success() && res.data() && res.data()->getType() == msa::client::TokenType::Compact) {
-            auto token = msa::client::token_pointer_cast<msa::client::CompactToken>(res.data());
-            success_cb(cid, token->getBinaryToken());
+void XboxLiveHelper::requestXblToken(
+    std::string const &cid, bool silent,
+    std::function<void(std::string const &cid, std::string const &binaryToken)>
+        success_cb,
+    std::function<void(simpleipc::rpc_error_code, std::string const &)>
+        error_cb) {
+  if (!getMsaClientOrNull()) {
+    error_cb(simpleipc::rpc_error_codes::connection_closed,
+             "Could not connect to the daemon");
+    return;
+  }
+  requestXblToken(cid, silent)
+      .call([cid, success_cb,
+             error_cb](rpc_result<std::shared_ptr<msa::client::Token>> res) {
+        if (res.success() && res.data() &&
+            res.data()->getType() == msa::client::TokenType::Compact) {
+          auto token =
+              msa::client::token_pointer_cast<msa::client::CompactToken>(
+                  res.data());
+          success_cb(cid, token->getBinaryToken());
         } else {
-            if (res.success())
-                error_cb(simpleipc::rpc_error_codes::internal_error, "Invalid token received from the MSA daemon");
-            else
-                error_cb(res.error_code(), res.error_text());
+          if (res.success())
+            error_cb(simpleipc::rpc_error_codes::internal_error,
+                     "Invalid token received from the MSA daemon");
+          else
+            error_cb(res.error_code(), res.error_text());
         }
-    });
+      });
 }
 
-
-void XboxLiveHelper::initCll(std::string const& cid) {
-    std::lock_guard<std::mutex> lock (cllMutex);
-    if (!cid.empty())
-        cllAuthStep.setAccount(cid);
-    if (cll)
-        return;
-    std::string iKey = "P-XBL-T" + std::to_string(0); // TODO: Get tid properly
-    auto cllEvents = PathHelper::getPrimaryDataDirectory() + "cll_events";
-    auto cacheDir = PathHelper::getCacheDirectory() + "cll";
-    FileUtil::mkdirRecursive(cllEvents);
-    FileUtil::mkdirRecursive(cacheDir);
-    cll = std::unique_ptr<cll::EventManager>(new cll::EventManager(iKey, cllEvents, cacheDir));
-    cll->addUploadStep(cllAuthStep);
-    cll->setApp("A:com.mojang.minecraftpe", MinecraftVersion::getString());
-    cll->start();
+void XboxLiveHelper::initCll(std::string const &cid) {
+  std::lock_guard<std::mutex> lock(cllMutex);
+  if (!cid.empty())
+    cllAuthStep.setAccount(cid);
+  if (cll)
+    return;
+  std::string iKey = "P-XBL-T" + std::to_string(0); // TODO: Get tid properly
+  auto cllEvents = PathHelper::getPrimaryDataDirectory() + "cll_events";
+  auto cacheDir = PathHelper::getCacheDirectory() + "cll";
+  FileUtil::mkdirRecursive(cllEvents);
+  FileUtil::mkdirRecursive(cacheDir);
+  cll = std::unique_ptr<cll::EventManager>(
+      new cll::EventManager(iKey, cllEvents, cacheDir));
+  cll->addUploadStep(cllAuthStep);
+  cll->setApp("A:com.mojang.minecraftpe", MinecraftVersion::getString());
+  cll->start();
 }
 
-std::string XboxLiveHelper::getCllMsaToken(std::string const& cid) {
-    auto client = getMsaClientOrNull();
-    if (!client)
-        return std::string();
-    auto token = client->requestToken(cid, {"vortex.data.microsoft.com", "mbi_ssl"}, MSA_CLIENT_ID, true).call();
-    if (!token.success() || !token.data() || token.data()->getType() != msa::client::TokenType::Compact)
-        return std::string();
-    return msa::client::token_pointer_cast<msa::client::CompactToken>(token.data())->getBinaryToken();
+std::string XboxLiveHelper::getCllMsaToken(std::string const &cid) {
+  auto client = getMsaClientOrNull();
+  if (!client)
+    return std::string();
+  auto token = client
+                   ->requestToken(cid, {"vortex.data.microsoft.com", "mbi_ssl"},
+                                  MSA_CLIENT_ID, true)
+                   .call();
+  if (!token.success() || !token.data() ||
+      token.data()->getType() != msa::client::TokenType::Compact)
+    return std::string();
+  return msa::client::token_pointer_cast<msa::client::CompactToken>(
+             token.data())
+      ->getBinaryToken();
 }
 
-void XboxLiveHelper::setJvm(FakeJni::Jvm *vm) {
-    this->vm = vm;
-}
+void XboxLiveHelper::setJvm(FakeJni::Jvm *vm) { this->vm = vm; }
 
 std::string XboxLiveHelper::getCllXToken(bool refresh) {
-    FakeJni::LocalFrame env (*vm);
-    if (auto callback = XboxInterop::getDescriptor()->getMethod("(Z)Ljava/lang/String;", "get_uploader_x_token_callback")) {
-        if (auto xtokenRef = callback->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(), (jboolean)refresh).l) {
-            if (auto xtoken = std::dynamic_pointer_cast<FakeJni::JString>(env.getJniEnv().resolveReference(xtokenRef))) {
-                return xtoken->asStdString();
-            }
-        }
+  FakeJni::LocalFrame env(*vm);
+  if (auto callback = XboxInterop::getDescriptor()->getMethod(
+          "(Z)Ljava/lang/String;", "get_uploader_x_token_callback")) {
+    if (auto xtokenRef =
+            callback
+                ->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(),
+                         (jboolean)refresh)
+                .l) {
+      if (auto xtoken = std::dynamic_pointer_cast<FakeJni::JString>(
+              env.getJniEnv().resolveReference(xtokenRef))) {
+        return xtoken->asStdString();
+      }
     }
-    return std::string();
+  }
+  return std::string();
 }
 
-std::string XboxLiveHelper::getCllXTicket(std::string const& xuid) {
-    FakeJni::LocalFrame env (*vm);
-    if (auto callback = XboxInterop::getDescriptor()->getMethod("(Ljava/lang/String;)Ljava/lang/String;", "get_supporting_x_token_callback")) {
-        auto xuidRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(xuid));
-        if (auto xticketRef = callback->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(), xuidRef).l) {
-            if (auto xticket = std::dynamic_pointer_cast<FakeJni::JString>(env.getJniEnv().resolveReference(xticketRef))) {
-                return xticket->asStdString();
-            }
-        }
+std::string XboxLiveHelper::getCllXTicket(std::string const &xuid) {
+  FakeJni::LocalFrame env(*vm);
+  if (auto callback = XboxInterop::getDescriptor()->getMethod(
+          "(Ljava/lang/String;)Ljava/lang/String;",
+          "get_supporting_x_token_callback")) {
+    auto xuidRef = env.getJniEnv().createLocalReference(
+        std::make_shared<FakeJni::JString>(xuid));
+    if (auto xticketRef =
+            callback
+                ->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(),
+                         xuidRef)
+                .l) {
+      if (auto xticket = std::dynamic_pointer_cast<FakeJni::JString>(
+              env.getJniEnv().resolveReference(xticketRef))) {
+        return xticket->asStdString();
+      }
     }
-    return std::string();
+  }
+  return std::string();
 }
 
-void XboxLiveHelper::logCll(cll::Event const& event) {
-    initCll();
-    cll->add(event);
+void XboxLiveHelper::logCll(cll::Event const &event) {
+  initCll();
+  cll->add(event);
 }

--- a/src/xbox_live_helper.cpp
+++ b/src/xbox_live_helper.cpp
@@ -14,8 +14,7 @@ std::string const XboxLiveHelper::MSA_CLIENT_ID =
     "android-app://com.mojang.minecraftpe.H62DKCBHJP6WXXIV7RBFOGOL4NAK4E6Y";
 std::string const XboxLiveHelper::MSA_COBRAND_ID = "90023";
 
-std::string XboxLiveHelper::findMsa()
-{
+std::string XboxLiveHelper::findMsa() {
     std::string path;
 #ifdef MSA_DAEMON_PATH
     if (EnvPathUtil::findInPath("msa-daemon", path, MSA_DAEMON_PATH, EnvPathUtil::getAppDir().c_str()))
@@ -28,25 +27,20 @@ std::string XboxLiveHelper::findMsa()
 
 XboxLiveHelper::XboxLiveHelper() : launcher(findMsa()), triedToCreateClient(false) {}
 
-msa::client::ServiceClient *XboxLiveHelper::getMsaClientOrNull()
-{
+msa::client::ServiceClient *XboxLiveHelper::getMsaClientOrNull() {
     std::lock_guard<std::mutex> lock(clientMutex);
     if (triedToCreateClient)
         return client.get();
     triedToCreateClient = true;
-    try
-    {
+    try {
         client = std::unique_ptr<msa::client::ServiceClient>(new msa::client::ServiceClient(launcher));
-    }
-    catch (std::exception &exception)
-    {
+    } catch (std::exception &exception) {
         Log::error("XboxLiveHelper", "Failed to connect to the daemon: %s", exception.what());
     }
     return client.get();
 }
 
-msa::client::ServiceClient &XboxLiveHelper::getMsaClient()
-{
+msa::client::ServiceClient &XboxLiveHelper::getMsaClient() {
     auto client = getMsaClientOrNull();
     if (!client)
         throw std::runtime_error("Could not connect to the daemon");
@@ -55,66 +49,49 @@ msa::client::ServiceClient &XboxLiveHelper::getMsaClient()
 
 void XboxLiveHelper::invokeMsaAuthFlow(
     std::function<void(std::string const &cid, std::string const &binaryToken)> success_cb,
-    std::function<void(simpleipc::rpc_error_code, std::string const &)> error_cb)
-{
+    std::function<void(simpleipc::rpc_error_code, std::string const &)> error_cb) {
     auto client = getMsaClientOrNull();
-    if (!client)
-    {
+    if (!client) {
         error_cb(simpleipc::rpc_error_codes::connection_closed, "Could not connect to the daemon");
         return;
     }
-    client->pickAccount(MSA_CLIENT_ID, MSA_COBRAND_ID)
-        .call(
-            [this, success_cb, error_cb](rpc_result<std::string> res)
-            {
-                if (!res.success())
-                {
-                    error_cb(res.error_code(), res.error_text());
-                    return;
-                }
+    client->pickAccount(MSA_CLIENT_ID, MSA_COBRAND_ID).call([this, success_cb, error_cb](rpc_result<std::string> res) {
+        if (!res.success()) {
+            error_cb(res.error_code(), res.error_text());
+            return;
+        }
 
-                requestXblToken(res.data(), false, success_cb, error_cb);
-            });
+        requestXblToken(res.data(), false, success_cb, error_cb);
+    });
 }
 
 simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>> XboxLiveHelper::requestXblToken(std::string const &cid,
-                                                                                                 bool silent)
-{
+                                                                                                 bool silent) {
     return getMsaClient().requestToken(cid, {"user.auth.xboxlive.com", "mbi_ssl"}, MSA_CLIENT_ID, silent);
 }
 
 void XboxLiveHelper::requestXblToken(
     std::string const &cid, bool silent,
     std::function<void(std::string const &cid, std::string const &binaryToken)> success_cb,
-    std::function<void(simpleipc::rpc_error_code, std::string const &)> error_cb)
-{
-    if (!getMsaClientOrNull())
-    {
+    std::function<void(simpleipc::rpc_error_code, std::string const &)> error_cb) {
+    if (!getMsaClientOrNull()) {
         error_cb(simpleipc::rpc_error_codes::connection_closed, "Could not connect to the daemon");
         return;
     }
-    requestXblToken(cid, silent)
-        .call(
-            [cid, success_cb, error_cb](rpc_result<std::shared_ptr<msa::client::Token>> res)
-            {
-                if (res.success() && res.data() && res.data()->getType() == msa::client::TokenType::Compact)
-                {
-                    auto token = msa::client::token_pointer_cast<msa::client::CompactToken>(res.data());
-                    success_cb(cid, token->getBinaryToken());
-                }
-                else
-                {
-                    if (res.success())
-                        error_cb(simpleipc::rpc_error_codes::internal_error,
-                                 "Invalid token received from the MSA daemon");
-                    else
-                        error_cb(res.error_code(), res.error_text());
-                }
-            });
+    requestXblToken(cid, silent).call([cid, success_cb, error_cb](rpc_result<std::shared_ptr<msa::client::Token>> res) {
+        if (res.success() && res.data() && res.data()->getType() == msa::client::TokenType::Compact) {
+            auto token = msa::client::token_pointer_cast<msa::client::CompactToken>(res.data());
+            success_cb(cid, token->getBinaryToken());
+        } else {
+            if (res.success())
+                error_cb(simpleipc::rpc_error_codes::internal_error, "Invalid token received from the MSA daemon");
+            else
+                error_cb(res.error_code(), res.error_text());
+        }
+    });
 }
 
-void XboxLiveHelper::initCll(std::string const &cid)
-{
+void XboxLiveHelper::initCll(std::string const &cid) {
     std::lock_guard<std::mutex> lock(cllMutex);
     if (!cid.empty())
         cllAuthStep.setAccount(cid);
@@ -131,8 +108,7 @@ void XboxLiveHelper::initCll(std::string const &cid)
     cll->start();
 }
 
-std::string XboxLiveHelper::getCllMsaToken(std::string const &cid)
-{
+std::string XboxLiveHelper::getCllMsaToken(std::string const &cid) {
     auto client = getMsaClientOrNull();
     if (!client)
         return std::string();
@@ -144,16 +120,14 @@ std::string XboxLiveHelper::getCllMsaToken(std::string const &cid)
 
 void XboxLiveHelper::setJvm(FakeJni::Jvm *vm) { this->vm = vm; }
 
-std::string XboxLiveHelper::getCllXToken(bool refresh)
-{
+std::string XboxLiveHelper::getCllXToken(bool refresh) {
     FakeJni::LocalFrame env(*vm);
     if (auto callback =
-            XboxInterop::getDescriptor()->getMethod("(Z)Ljava/lang/String;", "get_uploader_x_token_callback"))
-    {
-        if (auto xtokenRef = callback->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(), (jboolean)refresh).l)
-        {
-            if (auto xtoken = std::dynamic_pointer_cast<FakeJni::JString>(env.getJniEnv().resolveReference(xtokenRef)))
-            {
+            XboxInterop::getDescriptor()->getMethod("(Z)Ljava/lang/String;", "get_uploader_x_token_callback")) {
+        if (auto xtokenRef =
+                callback->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(), (jboolean)refresh).l) {
+            if (auto xtoken =
+                    std::dynamic_pointer_cast<FakeJni::JString>(env.getJniEnv().resolveReference(xtokenRef))) {
                 return xtoken->asStdString();
             }
         }
@@ -161,18 +135,14 @@ std::string XboxLiveHelper::getCllXToken(bool refresh)
     return std::string();
 }
 
-std::string XboxLiveHelper::getCllXTicket(std::string const &xuid)
-{
+std::string XboxLiveHelper::getCllXTicket(std::string const &xuid) {
     FakeJni::LocalFrame env(*vm);
     if (auto callback = XboxInterop::getDescriptor()->getMethod("(Ljava/lang/String;)Ljava/lang/String;",
-                                                                "get_supporting_x_token_callback"))
-    {
+                                                                "get_supporting_x_token_callback")) {
         auto xuidRef = env.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>(xuid));
-        if (auto xticketRef = callback->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(), xuidRef).l)
-        {
+        if (auto xticketRef = callback->invoke(env.getJniEnv(), XboxInterop::getDescriptor().get(), xuidRef).l) {
             if (auto xticket =
-                    std::dynamic_pointer_cast<FakeJni::JString>(env.getJniEnv().resolveReference(xticketRef)))
-            {
+                    std::dynamic_pointer_cast<FakeJni::JString>(env.getJniEnv().resolveReference(xticketRef))) {
                 return xticket->asStdString();
             }
         }
@@ -180,8 +150,7 @@ std::string XboxLiveHelper::getCllXTicket(std::string const &xuid)
     return std::string();
 }
 
-void XboxLiveHelper::logCll(cll::Event const &event)
-{
+void XboxLiveHelper::logCll(cll::Event const &event) {
     initCll();
     cll->add(event);
 }

--- a/src/xbox_live_helper.h
+++ b/src/xbox_live_helper.h
@@ -1,70 +1,72 @@
 #pragma once
 
-#include <memory>
-#include <msa/client/service_launcher.h>
-#include <msa/client/service_client.h>
-#include <cll/event_manager.h>
 #include "cll_upload_auth_step.h"
+#include <cll/event_manager.h>
 #include <fake-jni/jvm.h>
+#include <memory>
+#include <msa/client/service_client.h>
+#include <msa/client/service_launcher.h>
 
 class XboxLiveHelper {
 
 private:
-    static std::string const MSA_CLIENT_ID;
-    static std::string const MSA_COBRAND_ID;
+  static std::string const MSA_CLIENT_ID;
+  static std::string const MSA_COBRAND_ID;
 
-    static XboxLiveHelper instance;
+  static XboxLiveHelper instance;
 
-    msa::client::ServiceLauncher launcher;
-    std::unique_ptr<msa::client::ServiceClient> client;
-    std::atomic_bool triedToCreateClient;
-    std::mutex clientMutex;
-    std::mutex cllMutex;
-    std::unique_ptr<cll::EventManager> cll;
-    CllUploadAuthStep cllAuthStep;
-    FakeJni::Jvm *vm;
+  msa::client::ServiceLauncher launcher;
+  std::unique_ptr<msa::client::ServiceClient> client;
+  std::atomic_bool triedToCreateClient;
+  std::mutex clientMutex;
+  std::mutex cllMutex;
+  std::unique_ptr<cll::EventManager> cll;
+  CllUploadAuthStep cllAuthStep;
+  FakeJni::Jvm *vm;
 
-    msa::client::ServiceClient* getMsaClientOrNull();
+  msa::client::ServiceClient *getMsaClientOrNull();
 
-    msa::client::ServiceClient& getMsaClient();
+  msa::client::ServiceClient &getMsaClient();
 
 public:
-    static XboxLiveHelper& getInstance() {
-        return instance;
-    }
+  static XboxLiveHelper &getInstance() { return instance; }
 
-    static std::string findMsa();
+  static std::string findMsa();
 
-    XboxLiveHelper();
+  XboxLiveHelper();
 
-    void shutdown() {
-        cll.reset();
-        client.reset();
-    }
+  void shutdown() {
+    cll.reset();
+    client.reset();
+  }
 
+  void invokeMsaAuthFlow(
+      std::function<void(std::string const &cid,
+                         std::string const &binaryToken)>
+          success_cb,
+      std::function<void(simpleipc::rpc_error_code, std::string const &)>
+          error_cb);
 
-    void invokeMsaAuthFlow(std::function<void (std::string const& cid, std::string const& binaryToken)> success_cb,
-                           std::function<void (simpleipc::rpc_error_code, std::string const&)> error_cb);
+  simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>>
+  requestXblToken(std::string const &cid, bool silent);
 
+  void requestXblToken(
+      std::string const &cid, bool silent,
+      std::function<void(std::string const &cid,
+                         std::string const &binaryToken)>
+          success_cb,
+      std::function<void(simpleipc::rpc_error_code, std::string const &)>
+          error_cb);
 
-    simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>> requestXblToken(std::string const& cid,
-                                                                                     bool silent);
+  std::string getCllMsaToken(std::string const &cid);
 
-    void requestXblToken(std::string const& cid, bool silent,
-                         std::function<void (std::string const& cid, std::string const& binaryToken)> success_cb,
-                         std::function<void (simpleipc::rpc_error_code, std::string const&)> error_cb);
+  void setJvm(FakeJni::Jvm *vm);
 
+  std::string getCllXToken(bool refresh);
 
-    std::string getCllMsaToken(std::string const& cid);
+  std::string getCllXTicket(std::string const &xuid);
 
-    void setJvm(FakeJni::Jvm *vm);
+  void initCll(std::string const &cid = std::string());
 
-    std::string getCllXToken(bool refresh);
-
-    std::string getCllXTicket(std::string const& xuid);
-
-    void initCll(std::string const& cid = std::string());
-
-    void logCll(cll::Event const& event);
-
+  void logCll(cll::Event const &event);
 };

--- a/src/xbox_live_helper.h
+++ b/src/xbox_live_helper.h
@@ -1,72 +1,65 @@
 #pragma once
 
-#include "cll_upload_auth_step.h"
 #include <cll/event_manager.h>
 #include <fake-jni/jvm.h>
-#include <memory>
 #include <msa/client/service_client.h>
 #include <msa/client/service_launcher.h>
+#include <memory>
+#include "cll_upload_auth_step.h"
 
-class XboxLiveHelper {
+class XboxLiveHelper
+{
+   private:
+    static std::string const MSA_CLIENT_ID;
+    static std::string const MSA_COBRAND_ID;
 
-private:
-  static std::string const MSA_CLIENT_ID;
-  static std::string const MSA_COBRAND_ID;
+    static XboxLiveHelper instance;
 
-  static XboxLiveHelper instance;
+    msa::client::ServiceLauncher launcher;
+    std::unique_ptr<msa::client::ServiceClient> client;
+    std::atomic_bool triedToCreateClient;
+    std::mutex clientMutex;
+    std::mutex cllMutex;
+    std::unique_ptr<cll::EventManager> cll;
+    CllUploadAuthStep cllAuthStep;
+    FakeJni::Jvm *vm;
 
-  msa::client::ServiceLauncher launcher;
-  std::unique_ptr<msa::client::ServiceClient> client;
-  std::atomic_bool triedToCreateClient;
-  std::mutex clientMutex;
-  std::mutex cllMutex;
-  std::unique_ptr<cll::EventManager> cll;
-  CllUploadAuthStep cllAuthStep;
-  FakeJni::Jvm *vm;
+    msa::client::ServiceClient *getMsaClientOrNull();
 
-  msa::client::ServiceClient *getMsaClientOrNull();
+    msa::client::ServiceClient &getMsaClient();
 
-  msa::client::ServiceClient &getMsaClient();
+   public:
+    static XboxLiveHelper &getInstance() { return instance; }
 
-public:
-  static XboxLiveHelper &getInstance() { return instance; }
+    static std::string findMsa();
 
-  static std::string findMsa();
+    XboxLiveHelper();
 
-  XboxLiveHelper();
+    void shutdown()
+    {
+        cll.reset();
+        client.reset();
+    }
 
-  void shutdown() {
-    cll.reset();
-    client.reset();
-  }
+    void invokeMsaAuthFlow(std::function<void(std::string const &cid, std::string const &binaryToken)> success_cb,
+                           std::function<void(simpleipc::rpc_error_code, std::string const &)> error_cb);
 
-  void invokeMsaAuthFlow(
-      std::function<void(std::string const &cid,
-                         std::string const &binaryToken)>
-          success_cb,
-      std::function<void(simpleipc::rpc_error_code, std::string const &)>
-          error_cb);
+    simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>> requestXblToken(std::string const &cid,
+                                                                                     bool silent);
 
-  simpleipc::client::rpc_call<std::shared_ptr<msa::client::Token>>
-  requestXblToken(std::string const &cid, bool silent);
+    void requestXblToken(std::string const &cid, bool silent,
+                         std::function<void(std::string const &cid, std::string const &binaryToken)> success_cb,
+                         std::function<void(simpleipc::rpc_error_code, std::string const &)> error_cb);
 
-  void requestXblToken(
-      std::string const &cid, bool silent,
-      std::function<void(std::string const &cid,
-                         std::string const &binaryToken)>
-          success_cb,
-      std::function<void(simpleipc::rpc_error_code, std::string const &)>
-          error_cb);
+    std::string getCllMsaToken(std::string const &cid);
 
-  std::string getCllMsaToken(std::string const &cid);
+    void setJvm(FakeJni::Jvm *vm);
 
-  void setJvm(FakeJni::Jvm *vm);
+    std::string getCllXToken(bool refresh);
 
-  std::string getCllXToken(bool refresh);
+    std::string getCllXTicket(std::string const &xuid);
 
-  std::string getCllXTicket(std::string const &xuid);
+    void initCll(std::string const &cid = std::string());
 
-  void initCll(std::string const &cid = std::string());
-
-  void logCll(cll::Event const &event);
+    void logCll(cll::Event const &event);
 };

--- a/src/xbox_live_helper.h
+++ b/src/xbox_live_helper.h
@@ -7,8 +7,7 @@
 #include <memory>
 #include "cll_upload_auth_step.h"
 
-class XboxLiveHelper
-{
+class XboxLiveHelper {
    private:
     static std::string const MSA_CLIENT_ID;
     static std::string const MSA_COBRAND_ID;
@@ -35,8 +34,7 @@ class XboxLiveHelper
 
     XboxLiveHelper();
 
-    void shutdown()
-    {
+    void shutdown() {
         cll.reset();
         client.reset();
     }

--- a/src/xbox_shutdown_patch.cpp
+++ b/src/xbox_shutdown_patch.cpp
@@ -14,25 +14,21 @@ std::atomic_int XboxShutdownPatch::runningTasks;
 std::condition_variable XboxShutdownPatch::runningTasksCv;
 std::mutex XboxShutdownPatch::runningTasksMutex;
 
-void XboxShutdownPatch::sleepHook(unsigned int ms)
-{
+void XboxShutdownPatch::sleepHook(unsigned int ms) {
     std::unique_lock<std::mutex> l(mutex);
     cv.wait_for(l, std::chrono::milliseconds(ms), []() { return shuttingDown; });
 }
 
-void XboxShutdownPatch::install(void *handle)
-{
+void XboxShutdownPatch::install(void *handle) {
     void *ptr = linker::dlsym(handle, "_ZN4xbox8services5utils5sleepEj");
-    if (ptr == nullptr)
-    {
+    if (ptr == nullptr) {
         Log::warn("XboxShutdownPatch", "sleep() symbol not found");
         return;
     }
     PatchUtils::patchCallInstruction(ptr, (void *)&sleepHook, true);
 }
 
-void XboxShutdownPatch::notifyShutdown()
-{
+void XboxShutdownPatch::notifyShutdown() {
     {
         std::unique_lock<std::mutex> l(mutex);
         shuttingDown = true;
@@ -40,8 +36,7 @@ void XboxShutdownPatch::notifyShutdown()
     }
     {
         std::unique_lock<std::mutex> l(runningTasksMutex);
-        while (XboxShutdownPatch::runningTasks > 0)
-        {
+        while (XboxShutdownPatch::runningTasks > 0) {
             Log::trace("XboxLive", "Waiting for %i tasks", (int)XboxShutdownPatch::runningTasks);
             cv.wait_for(l, std::chrono::seconds(1));
         }
@@ -52,10 +47,8 @@ void XboxShutdownPatch::notifyShutdown()
 extern "C" void xbox_shutdown_patch_run_one_enter() asm("xbox_shutdown_patch_run_one_enter");
 extern "C" void xbox_shutdown_patch_run_one_enter() { ++XboxShutdownPatch::runningTasks; }
 extern "C" void xbox_shutdown_patch_run_one_exit() asm("xbox_shutdown_patch_run_one_exit");
-extern "C" void xbox_shutdown_patch_run_one_exit()
-{
-    if (XboxShutdownPatch::runningTasks.fetch_sub(1) <= 1)
-    {
+extern "C" void xbox_shutdown_patch_run_one_exit() {
+    if (XboxShutdownPatch::runningTasks.fetch_sub(1) <= 1) {
         XboxShutdownPatch::runningTasksCv.notify_all();
     }
 }

--- a/src/xbox_shutdown_patch.cpp
+++ b/src/xbox_shutdown_patch.cpp
@@ -1,10 +1,10 @@
 #include "xbox_shutdown_patch.h"
 
-#include <cstring>
 #include <log.h>
 #include <mcpelauncher/linker.h>
 #include <mcpelauncher/minecraft_version.h>
 #include <mcpelauncher/patch_utils.h>
+#include <cstring>
 
 std::condition_variable XboxShutdownPatch::cv;
 std::mutex XboxShutdownPatch::mutex;
@@ -14,46 +14,48 @@ std::atomic_int XboxShutdownPatch::runningTasks;
 std::condition_variable XboxShutdownPatch::runningTasksCv;
 std::mutex XboxShutdownPatch::runningTasksMutex;
 
-void XboxShutdownPatch::sleepHook(unsigned int ms) {
-  std::unique_lock<std::mutex> l(mutex);
-  cv.wait_for(l, std::chrono::milliseconds(ms), []() { return shuttingDown; });
-}
-
-void XboxShutdownPatch::install(void *handle) {
-  void *ptr = linker::dlsym(handle, "_ZN4xbox8services5utils5sleepEj");
-  if (ptr == nullptr) {
-    Log::warn("XboxShutdownPatch", "sleep() symbol not found");
-    return;
-  }
-  PatchUtils::patchCallInstruction(ptr, (void *)&sleepHook, true);
-}
-
-void XboxShutdownPatch::notifyShutdown() {
-  {
+void XboxShutdownPatch::sleepHook(unsigned int ms)
+{
     std::unique_lock<std::mutex> l(mutex);
-    shuttingDown = true;
-    cv.notify_all();
-  }
-  {
-    std::unique_lock<std::mutex> l(runningTasksMutex);
-    while (XboxShutdownPatch::runningTasks > 0) {
-      Log::trace("XboxLive", "Waiting for %i tasks",
-                 (int)XboxShutdownPatch::runningTasks);
-      cv.wait_for(l, std::chrono::seconds(1));
-    }
-  }
-  Log::trace("XboxLive", "Finished waiting for tasks");
+    cv.wait_for(l, std::chrono::milliseconds(ms), []() { return shuttingDown; });
 }
 
-extern "C" void
-xbox_shutdown_patch_run_one_enter() asm("xbox_shutdown_patch_run_one_enter");
-extern "C" void xbox_shutdown_patch_run_one_enter() {
-  ++XboxShutdownPatch::runningTasks;
+void XboxShutdownPatch::install(void *handle)
+{
+    void *ptr = linker::dlsym(handle, "_ZN4xbox8services5utils5sleepEj");
+    if (ptr == nullptr)
+    {
+        Log::warn("XboxShutdownPatch", "sleep() symbol not found");
+        return;
+    }
+    PatchUtils::patchCallInstruction(ptr, (void *)&sleepHook, true);
 }
-extern "C" void
-xbox_shutdown_patch_run_one_exit() asm("xbox_shutdown_patch_run_one_exit");
-extern "C" void xbox_shutdown_patch_run_one_exit() {
-  if (XboxShutdownPatch::runningTasks.fetch_sub(1) <= 1) {
-    XboxShutdownPatch::runningTasksCv.notify_all();
-  }
+
+void XboxShutdownPatch::notifyShutdown()
+{
+    {
+        std::unique_lock<std::mutex> l(mutex);
+        shuttingDown = true;
+        cv.notify_all();
+    }
+    {
+        std::unique_lock<std::mutex> l(runningTasksMutex);
+        while (XboxShutdownPatch::runningTasks > 0)
+        {
+            Log::trace("XboxLive", "Waiting for %i tasks", (int)XboxShutdownPatch::runningTasks);
+            cv.wait_for(l, std::chrono::seconds(1));
+        }
+    }
+    Log::trace("XboxLive", "Finished waiting for tasks");
+}
+
+extern "C" void xbox_shutdown_patch_run_one_enter() asm("xbox_shutdown_patch_run_one_enter");
+extern "C" void xbox_shutdown_patch_run_one_enter() { ++XboxShutdownPatch::runningTasks; }
+extern "C" void xbox_shutdown_patch_run_one_exit() asm("xbox_shutdown_patch_run_one_exit");
+extern "C" void xbox_shutdown_patch_run_one_exit()
+{
+    if (XboxShutdownPatch::runningTasks.fetch_sub(1) <= 1)
+    {
+        XboxShutdownPatch::runningTasksCv.notify_all();
+    }
 }

--- a/src/xbox_shutdown_patch.cpp
+++ b/src/xbox_shutdown_patch.cpp
@@ -1,10 +1,10 @@
 #include "xbox_shutdown_patch.h"
 
-#include <mcpelauncher/linker.h>
-#include <mcpelauncher/patch_utils.h>
 #include <cstring>
 #include <log.h>
+#include <mcpelauncher/linker.h>
 #include <mcpelauncher/minecraft_version.h>
+#include <mcpelauncher/patch_utils.h>
 
 std::condition_variable XboxShutdownPatch::cv;
 std::mutex XboxShutdownPatch::mutex;
@@ -15,42 +15,45 @@ std::condition_variable XboxShutdownPatch::runningTasksCv;
 std::mutex XboxShutdownPatch::runningTasksMutex;
 
 void XboxShutdownPatch::sleepHook(unsigned int ms) {
-    std::unique_lock<std::mutex> l (mutex);
-    cv.wait_for(l, std::chrono::milliseconds(ms), []() { return shuttingDown; });
+  std::unique_lock<std::mutex> l(mutex);
+  cv.wait_for(l, std::chrono::milliseconds(ms), []() { return shuttingDown; });
 }
 
-void XboxShutdownPatch::install(void* handle) {
-    void* ptr = linker::dlsym(handle, "_ZN4xbox8services5utils5sleepEj");
-    if (ptr == nullptr) {
-        Log::warn("XboxShutdownPatch", "sleep() symbol not found");
-        return;
-    }
-    PatchUtils::patchCallInstruction(ptr, (void*) &sleepHook, true);
+void XboxShutdownPatch::install(void *handle) {
+  void *ptr = linker::dlsym(handle, "_ZN4xbox8services5utils5sleepEj");
+  if (ptr == nullptr) {
+    Log::warn("XboxShutdownPatch", "sleep() symbol not found");
+    return;
+  }
+  PatchUtils::patchCallInstruction(ptr, (void *)&sleepHook, true);
 }
 
 void XboxShutdownPatch::notifyShutdown() {
-    {
-        std::unique_lock<std::mutex> l(mutex);
-        shuttingDown = true;
-        cv.notify_all();
+  {
+    std::unique_lock<std::mutex> l(mutex);
+    shuttingDown = true;
+    cv.notify_all();
+  }
+  {
+    std::unique_lock<std::mutex> l(runningTasksMutex);
+    while (XboxShutdownPatch::runningTasks > 0) {
+      Log::trace("XboxLive", "Waiting for %i tasks",
+                 (int)XboxShutdownPatch::runningTasks);
+      cv.wait_for(l, std::chrono::seconds(1));
     }
-    {
-        std::unique_lock<std::mutex> l(runningTasksMutex);
-        while (XboxShutdownPatch::runningTasks > 0) {
-            Log::trace("XboxLive", "Waiting for %i tasks", (int) XboxShutdownPatch::runningTasks);
-            cv.wait_for(l, std::chrono::seconds(1));
-        }
-    }
-    Log::trace("XboxLive", "Finished waiting for tasks");
+  }
+  Log::trace("XboxLive", "Finished waiting for tasks");
 }
 
-extern "C" void xbox_shutdown_patch_run_one_enter() asm("xbox_shutdown_patch_run_one_enter");
+extern "C" void
+xbox_shutdown_patch_run_one_enter() asm("xbox_shutdown_patch_run_one_enter");
 extern "C" void xbox_shutdown_patch_run_one_enter() {
-    ++XboxShutdownPatch::runningTasks;
+  ++XboxShutdownPatch::runningTasks;
 }
-extern "C" void xbox_shutdown_patch_run_one_exit() asm("xbox_shutdown_patch_run_one_exit");
+extern "C" void
+xbox_shutdown_patch_run_one_exit() asm("xbox_shutdown_patch_run_one_exit");
 extern "C" void xbox_shutdown_patch_run_one_exit() {
-    if (XboxShutdownPatch::runningTasks.fetch_sub(1) <= 1) {
-        XboxShutdownPatch::runningTasksCv.notify_all();
-    }
+  if (XboxShutdownPatch::runningTasks.fetch_sub(1) <= 1) {
+    XboxShutdownPatch::runningTasksCv.notify_all();
+  }
 }

--- a/src/xbox_shutdown_patch.h
+++ b/src/xbox_shutdown_patch.h
@@ -4,21 +4,21 @@
 #include <condition_variable>
 #include <mutex>
 
-class XboxShutdownPatch {
+class XboxShutdownPatch
+{
+   private:
+    static std::condition_variable cv;
+    static std::mutex mutex;
+    static bool shuttingDown;
 
-private:
-  static std::condition_variable cv;
-  static std::mutex mutex;
-  static bool shuttingDown;
+    static void sleepHook(unsigned int ms);
 
-  static void sleepHook(unsigned int ms);
+   public:
+    static std::atomic_int runningTasks;
+    static std::mutex runningTasksMutex;
+    static std::condition_variable runningTasksCv;
 
-public:
-  static std::atomic_int runningTasks;
-  static std::mutex runningTasksMutex;
-  static std::condition_variable runningTasksCv;
+    static void install(void *handle);
 
-  static void install(void *handle);
-
-  static void notifyShutdown();
+    static void notifyShutdown();
 };

--- a/src/xbox_shutdown_patch.h
+++ b/src/xbox_shutdown_patch.h
@@ -1,25 +1,24 @@
 #pragma once
 
-#include <mutex>
-#include <condition_variable>
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 
 class XboxShutdownPatch {
 
 private:
-    static std::condition_variable cv;
-    static std::mutex mutex;
-    static bool shuttingDown;
+  static std::condition_variable cv;
+  static std::mutex mutex;
+  static bool shuttingDown;
 
-    static void sleepHook(unsigned int ms);
+  static void sleepHook(unsigned int ms);
 
 public:
-    static std::atomic_int runningTasks;
-    static std::mutex runningTasksMutex;
-    static std::condition_variable runningTasksCv;
+  static std::atomic_int runningTasks;
+  static std::mutex runningTasksMutex;
+  static std::condition_variable runningTasksCv;
 
-    static void install(void* handle);
+  static void install(void *handle);
 
-    static void notifyShutdown();
-
+  static void notifyShutdown();
 };

--- a/src/xbox_shutdown_patch.h
+++ b/src/xbox_shutdown_patch.h
@@ -4,8 +4,7 @@
 #include <condition_variable>
 #include <mutex>
 
-class XboxShutdownPatch
-{
+class XboxShutdownPatch {
    private:
     static std::condition_variable cv;
     static std::mutex mutex;


### PR DESCRIPTION
As title, this PR is to reformat the code using the included `.clang-format` file. 

It also included the following patch - although this was applied before the formatting:
```
diff --git a/src/fake_looper.cpp b/src/fake_looper.cpp
index c72969c..75dc3d7 100644
--- a/src/fake_looper.cpp
+++ b/src/fake_looper.cpp
@@ -18,10 +18,18 @@ JniSupport *FakeLooper::jniSupport;
 thread_local std::unique_ptr<FakeLooper> FakeLooper::currentLooper;
 
 void FakeLooper::initHybrisHooks(std::unordered_map<std::string, void*> &syms) {
-    syms["ALooper_prepare"] = (void *) +[]() {
+     Log::info("Launcher", "Loading gamepad mappings");
+    WindowCallbacks::loadGamepadMappings();
+#ifdef MCPELAUNCHER_ENABLE_ERROR_WINDOW
+    GameWindowManager::getManager()->setErrorHandler(std::make_shared<ErrorWindow>());
+#endif
+
+    Log::info("Launcher", "Creating window");
+    static auto associatedWindow = GameWindowManager::getManager()->createWindow("Minecraft",
+            options.windowWidth, options.windowHeight, options.graphicsApi);    syms["ALooper_prepare"] = (void *) +[]() {
         if (currentLooper)
             throw std::runtime_error("Looper already prepared");
-        currentLooper = std::make_unique<FakeLooper>();
+        currentLooper = std::make_unique<FakeLooper>();currentLooper->associatedWindow = associatedWindow;associatedWindow->makeCurrent(false);
         currentLooper->prepare();
         return (ALooper *) (void *) currentLooper.get();
     };
@@ -45,16 +53,6 @@ void FakeLooper::initHybrisHooks(std::unordered_map<std::string, void*> &syms) {
 void FakeLooper::prepare() {
     jniSupport->setLooperRunning(true);
 
-    Log::info("Launcher", "Loading gamepad mappings");
-    WindowCallbacks::loadGamepadMappings();
-#ifdef MCPELAUNCHER_ENABLE_ERROR_WINDOW
-    GameWindowManager::getManager()->setErrorHandler(std::make_shared<ErrorWindow>());
-#endif
-
-    Log::info("Launcher", "Creating window");
-    associatedWindow = GameWindowManager::getManager()->createWindow("Minecraft",
-            options.windowWidth, options.windowHeight, options.graphicsApi);
-    associatedWindow->makeCurrent(false);
     jniSupport->onWindowCreated((ANativeWindow *) (void *) associatedWindow.get(),
             (AInputQueue *) (void *) &fakeInputQueue);
     associatedWindowCallbacks = std::make_shared<WindowCallbacks>(*associatedWindow, *jniSupport, fakeInputQueue);
diff --git a/src/main.cpp b/src/main.cpp
index f10ab47..6d93949 100644
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,9 +146,32 @@ int main(int argc, char *argv[]) {
     }
     FakeEGL::setProcAddrFunction((void *(*)(const char*)) windowManager->getProcAddrFunc());
     FakeEGL::installLibrary();
-    MinecraftUtils::setupGLES2Symbols(fake_egl::eglGetProcAddress);
 
-    std::unordered_map<std::string, void*> android_syms;
+
+    std::unordered_map<std::string, void*> android_syms;    struct ___data {
+          size_t arena; 
+             
+            size_t ordblks; 
+             
+            size_t smblks; 
+             
+            size_t hblks; 
+             
+            size_t hblkhd; 
+             
+            size_t usmblks; 
+             
+            size_t fsmblks; 
+             
+            size_t uordblks; 
+             
+            size_t fordblks; 
+             
+            size_t keepcost;
+                };
+    android_syms["mallinfo"] = (void*)+[](void*) -> ___data {
+        return { .ordblks = 8000000, .usmblks= 8000000, .fordblks= 8000000 };
+    };
     FakeAssetManager::initHybrisHooks(android_syms);
     FakeInputQueue::initHybrisHooks(android_syms);
     FakeLooper::initHybrisHooks(android_syms);
@@ -156,7 +179,7 @@ int main(int argc, char *argv[]) {
     for (auto s = android_symbols; *s; s++) // stub missing symbols
         android_syms.insert({*s, (void *) +[]() { Log::warn("Main", "Android stub called"); }});
     linker::load_library("libandroid.so", android_syms);
-    ModLoader modLoader;
+     MinecraftUtils::setupGLES2Symbols(fake_egl::eglGetProcAddress);    ModLoader modLoader;
     modLoader.loadModsFromDirectory(PathHelper::getPrimaryDataDirectory() + "mods/", true);
 
     Log::trace("Launcher", "Loading Minecraft library");
diff --git a/src/window_callbacks.cpp b/src/window_callbacks.cpp
index a0f7b6c..c9e5a6a 100644
--- a/src/window_callbacks.cpp
+++ b/src/window_callbacks.cpp
@@ -9,7 +9,7 @@
 WindowCallbacks::WindowCallbacks(GameWindow &window, JniSupport &jniSupport, FakeInputQueue &inputQueue) :
     window(window), jniSupport(jniSupport), inputQueue(inputQueue) {
     useDirectMouseInput = true;
-    useDirectKeyboardInput = (Keyboard::_states && Keyboard::_inputs && Keyboard::_gameControllerId);
+    useDirectKeyboardInput = false;
 }
 
 void WindowCallbacks::registerCallbacks() {
```

I'd suggest this is squash-and-merged, as it's already touching every file so no need to pollute the master branch with more commits than necessary.