### PR TITLE
Fix for 1.19.60.26 Beta

### DIFF
--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -8,7 +8,11 @@ std::vector<Keyboard::InputEvent> *Keyboard::_inputs;
 int *Keyboard::_gameControllerId;
 
 void SymbolsHelper::initSymbols(void *handle) {
-    Mouse::feed = (void (*)(char, char, short, short, short, short))linker::dlsym(handle, "_ZN5Mouse4feedEccssss");
+    void* MouseFeedSym;
+    if (!(MouseFeedSym = linker::dlsym(handle, "_ZN5Mouse4feedEccssss"))) {
+        MouseFeedSym = linker::dlsym(handle, "_ZN5Mouse4feedEcassss"); // 1.19.60.26 Beta Mouse::feed ABI changed
+    }
+    Mouse::feed = (void (*)(char, char, short, short, short, short))MouseFeedSym;
 
     Keyboard::_states = (int *)linker::dlsym(handle, "_ZN8Keyboard7_statesE");
     Keyboard::_inputs = (std::vector<Keyboard::InputEvent> *)linker::dlsym(handle, "_ZN8Keyboard7_inputsE");


### PR DESCRIPTION
Fix for changed ABI in 1.19.60.26 beta. They just changed signature of `Mouse::feed` from `(char, char, short, short, short, short)` to `(char, signed char, short, short, short, short)`.
Not tested on ARM platforms, macOS.
Code checks if `_ZN5Mouse4feedEccssss` exists, if not, it tries to use the symbol `_ZN5Mouse4feedEcassss` instead