### PR TITLE
Set isChromebook to true

### DIFF
--- a/src/jni/main_activity.h
+++ b/src/jni/main_activity.h
@@ -134,7 +134,7 @@ public:
     }
 
     FakeJni::JBoolean isChromebook() {
-        return false;
+        return true;
     }
 
     std::shared_ptr<FakeJni::JString> getLocale() {


### PR DESCRIPTION
Makes the game more optimized for computer by default (Classic UI by default, smaller GUI scale, outline selection on by default)