### PR TITLE
Fix making HEAD requests

### DIFF
--- a/src/jni/lib_http_client.cpp
+++ b/src/jni/lib_http_client.cpp
@@ -57,7 +57,11 @@ void HttpClientRequest::setHttpMethodAndBody2(std::shared_ptr<FakeJni::JString> 
     // if(this->method == "POST") {
     //     curl_easy_setopt(curl, CURLOPT_HTTPPOST, 1);
     // } else {
-    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
+    if (this->method == "HEAD") {
+        curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+    } else {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->method.c_str());
+    }
     // }
     if(contentLength > 0) {
         // static auto ___callback = (void*)+[](char *ptr, size_t size, size_t nmemb, void *userdata) -> size_t {


### PR DESCRIPTION
Fixes HEAD requests in libcurl by setting `CURLOPT_NOBODY` to 1 when a head request is made instead of by changing the http method. This fixes the marketplace download issue (it is now possible to download content from the marketplace.)
Closes minecraft-linux/mcpelauncher-manifest#754
Does NOT fix the CPU usage issue (minecraft-linux/mcpelauncher-manifest#768)