### PR TITLE
Fix keyboard on 1.19.70.22

### DIFF
--- a/src/jni/jni_descriptors.cpp
+++ b/src/jni/jni_descriptors.cpp
@@ -114,6 +114,7 @@ BEGIN_NATIVE_DESCRIPTOR(MainActivity){Constructor<MainActivity>{}},
     {Function<&MainActivity::openFile>{}, "openFile"},
     {Function<&MainActivity::saveFile>{}, "saveFile"},
     {Function<&MainActivity::setClipboard>{}, "setClipboard"},
+    {Function<&MainActivity::hasHardwareKeyboard>{}, "hasHardwareKeyboard"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(AccountManager){Function<&AccountManager::get>{}, "get"},

--- a/src/jni/main_activity.h
+++ b/src/jni/main_activity.h
@@ -215,7 +215,9 @@ public:
         if(textInput)
             textInput->disable();
     }
-
+    FakeJni::JBoolean hasHardwareKeyboard() {
+        return true;
+    }
     void updateTextboxText(std::shared_ptr<FakeJni::JString> newText) {
         if(textInput)
             textInput->update(newText->asStdString());


### PR DESCRIPTION
Mojang "Tweaked the keyboard interaction on Android devices for text input fields," which broke text input. This fixes that.