### PR TITLE
Fix direct keyboard input on renderdragon versions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,15 +205,6 @@ int main(int argc, char* argv[]) {
     SplitscreenPatch::install(handle);
     ShaderErrorPatch::install(handle);
 #endif
-    // If this Minecraft versions contains this bgfx symbol
-    // it is using the renderdragon engine
-    if(linker::dlsym(handle, "bgfx_init")) {
-        // The directinput mode is incompatible with the most of renderdragon enabled games
-        // Hide the availability of these symbols, until the bug is fixed
-        Keyboard::_states = nullptr;
-        Keyboard::_gameControllerId = nullptr;
-        Keyboard::_inputs = nullptr;
-    }
     if(options.graphicsApi == GraphicsApi::OPENGL) {
         try {
             GLCorePatch::install(handle);

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -3,8 +3,10 @@
 
 void (*Mouse::feed)(char, char, short, short, short, short);
 
+bool Keyboard::useLegacyKeyboard;
 int *Keyboard::_states;
 std::vector<Keyboard::InputEvent> *Keyboard::_inputs;
+std::vector<Keyboard::LegacyInputEvent> *Keyboard::_inputsLegacy;
 int *Keyboard::_gameControllerId;
 
 void SymbolsHelper::initSymbols(void *handle) {
@@ -14,7 +16,17 @@ void SymbolsHelper::initSymbols(void *handle) {
     }
     Mouse::feed = (void (*)(char, char, short, short, short, short))MouseFeedSym;
 
+    if(linker::dlsym(handle, "bgfx_init")) {
+        Keyboard::useLegacyKeyboard = false;
+    } else {
+        Keyboard::useLegacyKeyboard = true;
+    }
+
     Keyboard::_states = (int *)linker::dlsym(handle, "_ZN8Keyboard7_statesE");
-    Keyboard::_inputs = (std::vector<Keyboard::InputEvent> *)linker::dlsym(handle, "_ZN8Keyboard7_inputsE");
+    if (Keyboard::useLegacyKeyboard) {
+        Keyboard::_inputsLegacy = (std::vector<Keyboard::LegacyInputEvent> *)linker::dlsym(handle, "_ZN8Keyboard7_inputsE");
+    } else {
+        Keyboard::_inputs = (std::vector<Keyboard::InputEvent> *)linker::dlsym(handle, "_ZN8Keyboard7_inputsE");
+    }
     Keyboard::_gameControllerId = (int *)linker::dlsym(handle, "_ZN8Keyboard17_gameControllerIdE");
 }

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -7,14 +7,23 @@ struct Mouse {
 };
 
 struct Keyboard {
+    static bool useLegacyKeyboard;
     struct InputEvent {
         int event;
         unsigned int key;  // it's actually an unsigned char, but the asm code does suspicious stuff with the padding so use an int so it gets zeroed out
         int controllerId;
+        int modShift, modCtrl, modAlt;
+    };
+    struct LegacyInputEvent {
+        int event;
+        unsigned int key;  // it's actually an unsigned char, but the asm code does suspicious stuff with the padding so use an int so it gets zeroed out
+        int controllerId;
+        int modShift, modCtrl, modAlt;
     };
 
     static int* _states;
     static std::vector<Keyboard::InputEvent>* _inputs;
+    static std::vector<Keyboard::LegacyInputEvent>* _inputsLegacy;
     static int* _gameControllerId;
 };
 


### PR DESCRIPTION
Keys like `.`, `,`, numpad keys, and alt are now working