### PR TITLE
Http client improvements

### DIFF
--- a/src/jni/lib_http_client.cpp
+++ b/src/jni/lib_http_client.cpp
@@ -134,9 +134,7 @@ void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall) {
                 method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
             }
         } catch(...) {
-            FakeJni::LocalFrame frame(*jvm);
-            auto method = getClass().getMethod("(JLjava/lang/String;)V", "OnRequestFailed");
-            method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
+            _Exit(0);
         }
     }).detach();
 }

--- a/src/jni/lib_http_client.h
+++ b/src/jni/lib_http_client.h
@@ -22,11 +22,13 @@ public:
     NativeInputStream(FakeJni::JLong call_handle);
     size_t Read(void *buffer, size_t size);
 };
+    inline void *jvm;
 
 class HttpClientRequest : public FakeJni::JObject {
     std::shared_ptr<NativeInputStream> inputStream;
 
 public:
+
     DEFINE_CLASS_NAME("com/xbox/httpclient/HttpClientRequest")
     HttpClientRequest();
     ~HttpClientRequest();
@@ -55,11 +57,11 @@ private:
     std::vector<ResponseHeader> headers;
     std::vector<char> body;
     std::string method;
+    FakeJni::JLong call_handle;
 
     size_t write_callback(char *ptr, size_t size, size_t nmemb);
     size_t header_callback(char *buffer, size_t size, size_t nitems);
 };
-
 class HttpClientResponse : public FakeJni::JObject {
     FakeJni::JLong call_handle;
 


### PR DESCRIPTION
 HTTP client improvements
- nativeWrite is now called on write_callback (fixes download progress indicator)
- Setting http method is now handled correctly
-  Temporary fix for crash on exit 