### PR TITLE
Android SDK 28

### DIFF
--- a/src/jni/jni_support.cpp
+++ b/src/jni/jni_support.cpp
@@ -204,7 +204,7 @@ void JniSupport::startGame(ANativeActivity_createFunc *activityOnCreate,
     auto clzRef = (jclass)frame.getJniEnv().createLocalReference(std::const_pointer_cast<FakeJni::JClass>(clz));
     auto sdkInt = frame.getJniEnv().GetStaticFieldID(clzRef, "SDK_INT", "I");
     jint test = frame.getJniEnv().GetStaticIntField(clzRef, sdkInt);
-    if(test != 27)
+    if(test != 28)
         abort();
 
     activity = std::make_shared<MainActivity>();

--- a/src/jni/main_activity.cpp
+++ b/src/jni/main_activity.cpp
@@ -15,7 +15,7 @@
 
 #include <log.h>
 
-FakeJni::JInt BuildVersion::SDK_INT = 27;
+FakeJni::JInt BuildVersion::SDK_INT = 28;
 std::shared_ptr<FakeJni::JString> BuildVersion::RELEASE = std::make_shared<FakeJni::JString>("AndroidX");
 
 std::shared_ptr<FakeJni::JString> MainActivity::createUUID() {

--- a/src/jni/main_activity.h
+++ b/src/jni/main_activity.h
@@ -109,7 +109,7 @@ public:
     GameWindow *window;
 
     int getAndroidVersion() {
-        return 27;
+        return 28;
     }
 
     int getScreenWidth() {


### PR DESCRIPTION
Fixes graphics fallback and grainy textures on 1.20.20.22

Also a heads up that Android 7 is entering sunsetting (idk if this is relevant to this launcher): https://www.youtube.com/watch?v=In30Gv0nSFg