### PR TITLE
use static cpuinfo data from my devices

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,6 +140,7 @@ int main(int argc, char* argv[]) {
     Log::trace("Launcher", "linker loaded");
     auto windowManager = GameWindowManager::getManager();
 
+#if !defined(__linux__)
     // Fake /proc/cpuinfo
     // https://github.com/pytorch/cpuinfo depends on this file for linux builds
     auto fakeproc = PathHelper::getPrimaryDataDirectory() + "proc/";
@@ -194,7 +195,7 @@ Hardware	: Qualcomm Technologies, Inc MSM8998
 #endif
         fake_cpuinfo.close();
     }
-
+#endif
 
     // Fix saving to internal storage without write access to /data/*
     // TODO research how this path is constructed
@@ -212,8 +213,10 @@ Hardware	: Qualcomm Technologies, Inc MSM8998
     shim::rewrite_filesystem_access.emplace_back("/data/data", PathHelper::getPrimaryDataDirectory());
     // vanilla_music isn't loaded via AAssetManager, it uses libc-shim via relative filepath
     shim::rewrite_filesystem_access.emplace_back(".", PathHelper::getGameDir() + "assets/");
+#if !defined(__linux__)
     // fake proc fs needed for macOS and windows
     shim::rewrite_filesystem_access.emplace_back("/proc", fakeproc);
+#endif
     for(auto&& redir : shim::rewrite_filesystem_access) {
         Log::trace("REDIRECT", "%s to %s", redir.first.data(), redir.second.data());
     }


### PR DESCRIPTION
pytorch/cpuinfo fails to initialize if /proc/cpuinfo is missing, create a fake cpuinfo file and redirect /proc to it.

_For basic macOS support 1.20.20_