### PR TITLE
Fix ThreadMover moving threads created by mods

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -505,6 +505,7 @@ Hardware	: Qualcomm Technologies, Inc MSM8998
         return linker::dlsym(handle, sym);
     });
     std::thread startThread([&support]() {
+        ThreadMover::storeStartThreadId();
         support.startGame((ANativeActivity_createFunc*)linker::dlsym(handle, "ANativeActivity_onCreate"),
                           linker::dlsym(handle, "stbi_load_from_memory"),
                           linker::dlsym(handle, "stbi_image_free"));

--- a/src/thread_mover.cpp
+++ b/src/thread_mover.cpp
@@ -6,13 +6,19 @@ void ThreadMover::hookLibC(std::unordered_map<std::string, void *> &syms) {
     using pthread_create_fn = int (*)(void *, const void *, void *(*)(void *), void *);
     static pthread_create_fn pthread_create_orig = (pthread_create_fn)syms["pthread_create"];
     syms["pthread_create"] = (void *)+[](void *thread, const void *attr, void *(*start_routine)(void *), void *arg) {
-        bool expected = false;
-        if(ThreadMover::instance.main_thread_started.compare_exchange_strong(expected, true)) {
-            ThreadMover::instance.main_thread_promise.set_value({start_routine, arg});
-            return 0;
+        if(ThreadMover::instance.start_thread_id.load() == std::this_thread::get_id()) {
+            bool expected = false;
+            if(ThreadMover::instance.main_thread_started.compare_exchange_strong(expected, true)) {
+                ThreadMover::instance.main_thread_promise.set_value({start_routine, arg});
+                return 0;
+            }
         }
         return pthread_create_orig(thread, attr, start_routine, arg);
     };
+}
+
+void ThreadMover::storeStartThreadId() {
+    ThreadMover::instance.start_thread_id.store(std::this_thread::get_id());
 }
 
 void ThreadMover::executeMainThread() {

--- a/src/thread_mover.h
+++ b/src/thread_mover.h
@@ -3,10 +3,13 @@
 #include <unordered_map>
 #include <atomic>
 #include <future>
+#include <thread>
 
 class ThreadMover {
 private:
     static ThreadMover instance;
+
+    std::atomic<std::thread::id> start_thread_id;
 
     std::atomic_bool main_thread_started = false;
 
@@ -21,6 +24,8 @@ private:
 
 public:
     static void hookLibC(std::unordered_map<std::string, void *> &syms);
+
+    static void storeStartThreadId();
 
     static void executeMainThread();
 };


### PR DESCRIPTION
This allows mods to create threads before the main thread is created