### PR TITLE
Fix missing ImGui::End() in custom window rendering loop

### DIFF
--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1095,7 +1095,10 @@ void ImGuiUIDrawFrame(GameWindow* window) {
                 activeWindows[i]->modalOpened = true;
                 ImGui::OpenPopup(activeWindows[i]->title.data());
             }
-            if(activeWindows[i]->isModal ? ImGui::BeginPopupModal(activeWindows[i]->title.data(), &activeWindows[i]->open) : ImGui::Begin(activeWindows[i]->title.data(), &activeWindows[i]->open)) {
+            bool windowVisible = activeWindows[i]->isModal
+                    ? ImGui::BeginPopupModal(activeWindows[i]->title.data(), &activeWindows[i]->open)
+                    : ImGui::Begin(activeWindows[i]->title.data(), &activeWindows[i]->open);
+            if(windowVisible) {
                 for(auto&& control : activeWindows[i]->controls) {
                     switch(control.type) {
                     case 0:
@@ -1159,11 +1162,13 @@ void ImGuiUIDrawFrame(GameWindow* window) {
                         break;
                     }
                 }
-                if(activeWindows[i]->isModal) {
+            }
+            if(activeWindows[i]->isModal) {
+                if(windowVisible) {
                     ImGui::EndPopup();
-                } else {
-                    ImGui::End();
                 }
+            } else {
+                ImGui::End();
             }
             if(!activeWindows[i]->open) {
                 activeWindows[i]->onClose(activeWindows[i]->user);


### PR DESCRIPTION
While testing the custom window API, I found that opening a non-modal custom window caused the launcher to repeatedly log:

`[imgui-error] In window 'Example Mod': Missing End()` when trying to hide the imgui menu

The issue was in imgui_ui.cpp: for non-modal windows, ImGui::End() was only called when ImGui::Begin() returned true.

For regular ImGui windows, ImGui::End() must always be called after ImGui::Begin(). The return value only determines whether the window contents should be drawn.

This change stores the Begin() / BeginPopupModal() result in a local variable, renders controls only when the window is visible, and always calls ImGui::End() for non-modal windows. Modal windows still only call ImGui::EndPopup() when BeginPopupModal() succeeds.

I can provide the minimal reproduce mod if needed.