### PR TITLE
fix shutdown freeze

### DIFF
--- a/src/window_callbacks.cpp
+++ b/src/window_callbacks.cpp
@@ -79,7 +79,7 @@ void WindowCallbacks::setCursorLocked(bool locked) {
 }
 
 void WindowCallbacks::onClose() {
-    _Exit(0)
+    _Exit(0);
 }
 
 void WindowCallbacks::setFullscreen(bool isFs) {

--- a/src/window_callbacks.cpp
+++ b/src/window_callbacks.cpp
@@ -79,7 +79,7 @@ void WindowCallbacks::setCursorLocked(bool locked) {
 }
 
 void WindowCallbacks::onClose() {
-    jniSupport.onWindowClosed();
+    _EXIT(0)
 }
 
 void WindowCallbacks::setFullscreen(bool isFs) {

--- a/src/window_callbacks.cpp
+++ b/src/window_callbacks.cpp
@@ -79,7 +79,7 @@ void WindowCallbacks::setCursorLocked(bool locked) {
 }
 
 void WindowCallbacks::onClose() {
-    _Exit0)
+    _Exit(0)
 }
 
 void WindowCallbacks::setFullscreen(bool isFs) {

--- a/src/window_callbacks.cpp
+++ b/src/window_callbacks.cpp
@@ -79,7 +79,7 @@ void WindowCallbacks::setCursorLocked(bool locked) {
 }
 
 void WindowCallbacks::onClose() {
-    _EXIT(0)
+    _Exit0)
 }
 
 void WindowCallbacks::setFullscreen(bool isFs) {


### PR DESCRIPTION
When clicking the close button (X), WindowCallbacks::onClose() calls
nativeShutdown via JNI, which can hang screen indefinitely. especially when
the game is loading a world, connecting to a server, or starting up, this guarantees it closes immediately