### PR TITLE
Add functions for total and free space in JNI descriptors

### DIFF
--- a/src/jni/jni_descriptors.cpp
+++ b/src/jni/jni_descriptors.cpp
@@ -141,6 +141,8 @@ BEGIN_NATIVE_DESCRIPTOR(MainActivity){Constructor<MainActivity>{}},
     {Function<&MainActivity::getAllocatableBytes>{}, "getAllocatableBytes"},
     {Function<&MainActivity::calculateAvailableDiskFreeSpace>{}, "calculateAvailableDiskFreeSpace"},
     {Function<&MainActivity::getUsableSpace>{}, "getUsableSpace"},
+    {Function<&MainActivity::getTotalSpace>{}, "getTotalSpace"},
+    {Function<&MainActivity::getFreeSpace>{}, "getFreeSpace"},
     END_NATIVE_DESCRIPTOR
 
     BEGIN_NATIVE_DESCRIPTOR(AccountManager){Function<&AccountManager::get>{}, "get"},

--- a/src/jni/main_activity.h
+++ b/src/jni/main_activity.h
@@ -272,6 +272,14 @@ public:
         return 1024LL * 1024LL * 1024LL * 1024LL;
     }
 
+    FakeJni::JLong getTotalSpace(std::shared_ptr<FakeJni::JString> str) {
+        return 1024LL * 1024LL * 1024LL * 1024LL;
+    }
+
+    FakeJni::JLong getFreeSpace(std::shared_ptr<FakeJni::JString> str) {
+        return 1024LL * 1024LL * 1024LL * 1024LL;
+    }
+
     FakeJni::JInt getCaretPosition();
 
     void lockCursor();


### PR DESCRIPTION
In Minecraft 1.26.32, game successfully launches but UI locks creating worlds and downloading content because of out of storage errors. This pull request seems to fix it.