### PR TITLE
Fix HTTP callback dispatch after JNI re-registration

### DIFF
--- a/src/jni/jni_support.cpp
+++ b/src/jni/jni_support.cpp
@@ -139,6 +139,11 @@ void JniSupport::registerMinecraftNatives(void* (*symResolver)(const char*)) {
                                                           },
                     symResolver);
     registerNatives(JellyBeanDeviceManager::getDescriptor(), {{"onInputDeviceAddedNative", "(I)V"}, {"onInputDeviceRemovedNative", "(I)V"}}, symResolver);
+    // Other JNI libraries may register callbacks with the same Java names later.
+    // Preserve libHttpClient's callbacks so requests can be routed back to their owner.
+    HttpClientRequest::setLibHttpClientCallbacks(
+        symResolver("Java_com_xbox_httpclient_HttpClientRequest_OnRequestCompleted"),
+        symResolver("Java_com_xbox_httpclient_HttpClientRequest_OnRequestFailed"));
     registerNatives(HttpClientRequest::getDescriptor(), {{"OnRequestCompleted", "(JLcom/xbox/httpclient/HttpClientResponse;)V"}, {"OnRequestFailed", "(JLjava/lang/String;)V"}, {"OnRequestFailed", "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V"}}, symResolver);
     registerNatives(HttpClientWebSocket::getDescriptor(), {{"onMessage", "(Ljava/lang/String;)V"}, {"onBinaryMessage", "(Ljava/nio/ByteBuffer;)V"}, {"onOpen", "()V"}, {"onClose", "(I)V"}, {"onFailure", "()V"}}, symResolver);
     registerNatives(WebView::getDescriptor(), {

--- a/src/jni/lib_http_client.cpp
+++ b/src/jni/lib_http_client.cpp
@@ -1,10 +1,54 @@
 #include "lib_http_client.h"
 #include "../util.h"
 #include <log.h>
+#include <mcpelauncher/linker.h>
 #include <curl/curl.h>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
 #include <thread>
 
 using namespace std::placeholders;
+
+namespace {
+void *libHttpOnRequestCompleted = nullptr;
+void *libHttpOnRequestFailed = nullptr;
+
+bool isLibHttpClientSourceCall(FakeJni::JLong sourceCall) {
+    if(sourceCall == 0) {
+        return false;
+    }
+
+    // The first pointer identifies the native implementation that created the call.
+    void *owner = nullptr;
+    auto sourceCallPtr = reinterpret_cast<const void *>(static_cast<uintptr_t>(sourceCall));
+    std::memcpy(&owner, sourceCallPtr, sizeof(owner));
+
+    Dl_info info{};
+    if(owner == nullptr || linker::dladdr(owner, &info) == 0 || info.dli_fname == nullptr) {
+        return false;
+    }
+
+    std::string_view path(info.dli_fname);
+    auto separator = path.find_last_of('/');
+    auto basename = separator == std::string_view::npos ? path : path.substr(separator + 1);
+    return basename == "libHttpClient.Android.so";
+}
+
+template <typename... Args>
+void invokeRequestCallback(jnivm::MethodProxy callback, FakeJni::Env &env, HttpClientRequest *request,
+                           FakeJni::JLong sourceCall, void *libHttpCallback, Args... args) {
+    if(libHttpCallback != nullptr && isLibHttpClientSourceCall(sourceCall)) {
+        jnivm::Method method;
+        method.native = libHttpCallback;
+        method.signature = static_cast<jnivm::Method *>(callback)->signature;
+        method.invoke(env, request, sourceCall, args...);
+        return;
+    }
+
+    callback->invoke(env, request, sourceCall, args...);
+}
+}  // namespace
 
 bool slist_contains(struct curl_slist *list, const char *str) {
     struct curl_slist *current = list;
@@ -37,6 +81,11 @@ FakeJni::JBoolean HttpClientRequest::isNetworkAvailable(std::shared_ptr<Context>
 
 std::shared_ptr<HttpClientRequest> HttpClientRequest::createClientRequest() {
     return std::make_shared<HttpClientRequest>();
+}
+
+void HttpClientRequest::setLibHttpClientCallbacks(void *completed, void *failed) {
+    libHttpOnRequestCompleted = completed;
+    libHttpOnRequestFailed = failed;
 }
 
 void HttpClientRequest::setHttpUrl(std::shared_ptr<FakeJni::JString> url) {
@@ -165,18 +214,21 @@ void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall) {
                 Log::trace("HttpClient", "Response: code: %ld", response_code);
 #endif
                 auto method = getClass().getMethod("(JLcom/xbox/httpclient/HttpClientResponse;)V", "OnRequestCompleted");
-                method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<HttpClientResponse>(sourceCall, response_code, response, headers)));
+                invokeRequestCallback(method, frame.getJniEnv(), this, sourceCall, libHttpOnRequestCompleted,
+                                      frame.getJniEnv().createLocalReference(std::make_shared<HttpClientResponse>(sourceCall, response_code, response, headers)));
             } else {
                 // Detect if https://github.com/microsoft/libHttpClient/commit/bea2069547e6d480342476cf328b651584e2ada5 is compiled into the binary
                 if(NetworkObserver::getDescriptor()->getMethod("(Ljava/lang/String;)V", "Log")) {
                     auto method = getClass().getMethod("(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V", "OnRequestFailed");
-                    method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")),
-                                   frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("")),
-                                   frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("")),
-                                   ret == CURLE_COULDNT_RESOLVE_PROXY || ret == CURLE_COULDNT_RESOLVE_HOST || ret == CURLE_COULDNT_CONNECT);
+                    invokeRequestCallback(method, frame.getJniEnv(), this, sourceCall, libHttpOnRequestFailed,
+                                          frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")),
+                                          frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("")),
+                                          frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("")),
+                                          ret == CURLE_COULDNT_RESOLVE_PROXY || ret == CURLE_COULDNT_RESOLVE_HOST || ret == CURLE_COULDNT_CONNECT);
                 } else {
                     auto method = getClass().getMethod("(JLjava/lang/String;)V", "OnRequestFailed");
-                    method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
+                    invokeRequestCallback(method, frame.getJniEnv(), this, sourceCall, libHttpOnRequestFailed,
+                                          frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
                 }
             }
         } catch(...) {
@@ -187,13 +239,15 @@ void HttpClientRequest::doRequestAsync(FakeJni::JLong sourceCall) {
             FakeJni::LocalFrame frame(*jvm);
             if(NetworkObserver::getDescriptor()->getMethod("(Ljava/lang/String;)V", "Log")) {
                 auto method = getClass().getMethod("(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V", "OnRequestFailed");
-                method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")),
-                               frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("")),
-                               frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("")),
-                               false);
+                invokeRequestCallback(method, frame.getJniEnv(), this, sourceCall, libHttpOnRequestFailed,
+                                      frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")),
+                                      frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("")),
+                                      frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("")),
+                                      false);
             } else {
                 auto method = getClass().getMethod("(JLjava/lang/String;)V", "OnRequestFailed");
-                method->invoke(frame.getJniEnv(), this, sourceCall, frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
+                invokeRequestCallback(method, frame.getJniEnv(), this, sourceCall, libHttpOnRequestFailed,
+                                      frame.getJniEnv().createLocalReference(std::make_shared<FakeJni::JString>("Error")));
             }
         }
     }).detach();

--- a/src/jni/lib_http_client.h
+++ b/src/jni/lib_http_client.h
@@ -33,6 +33,7 @@ public:
 
     static FakeJni::JBoolean isNetworkAvailable(std::shared_ptr<Context> context);
     static std::shared_ptr<HttpClientRequest> createClientRequest();
+    static void setLibHttpClientCallbacks(void *completed, void *failed);
 
     void setHttpUrl(std::shared_ptr<FakeJni::JString> url);
     void setHttpMethodAndBody(std::shared_ptr<FakeJni::JString> method, std::shared_ptr<FakeJni::JString> contentType, std::shared_ptr<FakeJni::JByteArray> body);


### PR DESCRIPTION
## Summary

- preserve the request callbacks resolved from libHttpClient.Android.so
- identify libHttpClient source calls through the launcher linker
- route each completion or failure callback to the native implementation that owns its source call

## Root cause

A later JNI library can register native methods with the same HttpClientRequest callback names. That replaces the callback stored in the shared FakeJni descriptor. Normal Minecraft HTTP requests are then delivered to a callback that expects a different sourceCall layout, which eventually tries to lock an invalid mutex and crashes in pthread_mutex_lock.

This keeps the later registration available for calls created by that library, while calls whose first native pointer belongs to libHttpClient.Android.so are sent back to the original libHttpClient callback.

## Validation

- built with the Trinity Flatpak SDK on x86_64
- tested with Minecraft Bedrock 1.26.31.1 and the official update module enabled
- before the fix: repeatable SIGSEGV immediately after the first successful HTTP response
- after the fix: two isolated startup tests reached MinecraftGame initialization and Play Games, then remained alive until the 20 s and 25 s test timeouts
- the dispatch behavior was also validated in a diagnostic build with Microsoft sign-in, online presence, and joining a friend world

Related to minecraft-linux/mcpelauncher-manifest#1759.