### PR TITLE
fix: audio buffer size regresses to 0 after suspend/resume, causing FMOD to loop-reopen the stream

### DIFF
--- a/src/fake_audio.cpp
+++ b/src/fake_audio.cpp
@@ -5,6 +5,7 @@
 #include <mcpelauncher/fmod_utils.h>
 #include <thread>
 #include "util.h"
+#include <log.h>
 
 int32_t FakeAudio::defaultSampleRate = 48000;
 int32_t FakeAudio::defaultNumChannels = 2;
@@ -137,13 +138,44 @@ void FakeAudio::initHybrisHooks(std::unordered_map<std::string, void *> &syms) {
 }
 
 void FakeAudio::updateDefaults() {
-    SDL_AudioSpec spec;
-    int sampleFrames;
-    SDL_GetAudioDeviceFormat(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, &sampleFrames);
+    // SDL_GetAudioDeviceFormat's return value was previously ignored, and
+    // sampleFrames was read uninitialized. Most of the time SDL_GetAudioDeviceFormat
+    // succeeds so this went unnoticed, but for roughly two minutes after a system
+    // suspend/resume (while the default playback device is being re-resolved) it
+    // can fail, or succeed while reporting a buffer size of 0 frames. Either way
+    // defaultBufSize would end up 0 or garbage.
+    //
+    // FakeAudioStreamBuilder::bufferCap and FakeAudioStream::bufferSize both default
+    // to defaultBufSize, so every stream opened during that window reported
+    // getBufferSizeInFrames()/getFramesPerBurst()/getBufferCapacityInFrames() as 0
+    // frames. FMOD (reasonably) treats that as unusable, closes the stream, and
+    // retries roughly once a second -- audible as silence plus a frame hitch on
+    // every attempt, for as long as the condition lasts (observed: up to ~150s,
+    // ~128 attempts, on Steam Deck / PipeWire after suspend).
+    //
+    // Fix: check the return value, and never let a failed or degenerate query
+    // overwrite the last known-good defaults.
+    SDL_AudioSpec spec{};
+    int sampleFrames = 0;
 
-    defaultSampleRate = ReadEnvInt("AUDIO_SAMPLE_RATE", spec.freq);
-    defaultNumChannels = spec.channels;
-    defaultBufSize = sampleFrames;
+    if (!SDL_GetAudioDeviceFormat(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, &sampleFrames)) {
+        auto err = SDL_GetError();
+        Log::warn("FakeAudio", "SDL_GetAudioDeviceFormat failed (%s), keeping previous audio defaults (rate=%d channels=%d bufSize=%d)",
+                  err ? err : "no message", defaultSampleRate, defaultNumChannels, defaultBufSize);
+        return;
+    }
+
+    if (spec.freq > 0) {
+        defaultSampleRate = ReadEnvInt("AUDIO_SAMPLE_RATE", spec.freq);
+    }
+    if (spec.channels > 0) {
+        defaultNumChannels = spec.channels;
+    }
+    if (sampleFrames > 0) {
+        defaultBufSize = sampleFrames;
+    } else {
+        Log::warn("FakeAudio", "SDL_GetAudioDeviceFormat reported a buffer size of 0 frames, keeping previous bufSize=%d", defaultBufSize);
+    }
 
     FmodUtils::setSampleRate(defaultSampleRate);
 }


### PR DESCRIPTION
## Symptom

On Steam Deck (SteamOS/PipeWire), after any system suspend/resume with Bedrock running: ~0.5s freeze roughly every 1-1.2s, and no audio, for up to ~150s, then both recover on their own with no user action.

100% reproducible across 7 suspend/resume cycles (suspend length ranging from 10s to 8 hours; recovery time does not depend on suspend duration).

## Root cause

`FakeAudio::updateDefaults()` in `src/fake_audio.cpp` ignored the return value of `SDL_GetAudioDeviceFormat()` and read from an uninitialized `sampleFrames`:

```cpp
SDL_AudioSpec spec;
int sampleFrames;
SDL_GetAudioDeviceFormat(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, &sampleFrames);
defaultBufSize = sampleFrames;
```

This is usually harmless, since the call usually succeeds. But for a window after suspend/resume, while the default playback device is being re-resolved, the call either fails outright or succeeds while reporting a buffer size of **0 frames**. Either way `defaultBufSize` ends up 0 (or garbage from the stack).

`FakeAudioStreamBuilder::bufferCap` and `FakeAudioStream::bufferSize` both default to `defaultBufSize`, so every AAudio stream FMOD opens during that window reports `getBufferSizeInFrames()` / `getFramesPerBurst()` / `getBufferCapacityInFrames()` as **0**. FMOD (reasonably) treats a 0-frame stream as unusable, closes it, and retries about once a second. Each attempt is silence plus a frame hitch, repeated for as long as the condition lasts — measured at up to ~150s / ~128 attempts before the device settles and playback resumes cleanly on its own.

I confirmed this with an instrumented build that traces every AAudio call FMOD makes (happy to share the diff/logs if useful, kept it out of this PR to keep the patch minimal). Immediately after `PM: suspend exit`, `defaultBufSize` measured 0 for the full ~150s storm across 7/7 reproductions; the moment it recovered to 1024, the storm stopped.

## Fix

Check the return value of `SDL_GetAudioDeviceFormat()`, and never let a failed or degenerate (0-frame) query overwrite the last known-good defaults — fall back to keeping the previous rate/channels/bufSize (logged via `Log::warn`) instead of propagating garbage/zero downstream.

## Verification

Same instrumented build, after the fix: across 3 further suspend/resume cycles, `SDL_GetAudioDeviceFormat` was observed actually returning `frames=0` post-resume (confirming the exact failure mode this fixes), and the new guard rejected it every time, holding `defaultBufSize=1024` throughout. No stutter, no audio dropout, on any of the 3 cycles.

Built and tested against Bedrock 1.26.32.2 / mcpelauncher-client commit a2f2a88 (flathub `io.mrarm.mcpelauncher` build `e58666a`), Steam Deck OLED, SteamOS 3.8.16, PipeWire backend (also reproduced on the pulseaudio SDL backend before the fix, with the same root cause and a longer per-attempt interval).

## Scope note

This fixes the *reopen storm* — FMOD closing a healthy-but-misreported stream every second for minutes. It does not investigate whether FMOD's very first stream teardown right after resume (which happens once, ~1s post-resume, before the loop starts) is itself avoidable; that one appears to be FMOD's own post-resume stream health check and is out of scope here.