### PR TITLE
Force-exit if the game does not finish shutting down after Quit

### DIFF
--- a/src/jni/jni_support.cpp
+++ b/src/jni/jni_support.cpp
@@ -2,6 +2,10 @@
 #include <mcpelauncher/path_helper.h>
 #include <mcpelauncher/linker.h>
 #include "jni_support.h"
+#include <chrono>
+#include <cstdlib>
+#include <thread>
+#include <unistd.h>
 #include "xbox_live.h"
 #include "fmod.h"
 #include "lib_http_client.h"
@@ -434,6 +438,14 @@ void JniSupport::requestExitGame() {
     gameExitCond.notify_all();
     std::thread([this]() {
         JniSupport::stopGame();
+    }).detach();
+    // The game's own teardown can wedge on the main thread (seen on macOS: localtime_r spinning inside a
+    // corrupted heap) and burn a core forever, so bound it. write()/_Exit() are chosen because they never allocate.
+    std::thread([]() {
+        std::this_thread::sleep_for(std::chrono::seconds(30));
+        static const char msg[] = "JniSupport: game did not exit within 30s of shutdown request, forcing exit\n";
+        write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        _Exit(0);
     }).detach();
 }
 


### PR DESCRIPTION
## Problem

On macOS, `mcpelauncher-client-arm64-v8a` can outlive the game session and spin at ~100% CPU indefinitely (minecraft-linux/mcpelauncher-manifest#1929). I finally caught one live and sampled it:

- reparented to `launchd` (PPID 1), **one thread**, 757 min system / 100 min user CPU after 14 h
- all 1,515 `sample` frames at the identical stack:

```
main + 20876  (mcpelauncher-client-arm64-v8a)
  ??? × 7      (libminecraftpe, via the launcher's linker)
    localtime_r → _st_tzset_basic → getenv_copy_np → reallocf
      → _xzm_xzone_malloc_freelist_outlined + 856     ← 100% of samples
```

So the game's own teardown, running on the main thread after every other thread has gone, calls `localtime_r`, which on macOS copies `$TZ` (the launcher sets it in `add_time_shimmed_symbols`) through `reallocf`, and malloc never returns — it is walking a corrupted (cyclic) freelist. `SIGTERM` was enough to kill it.

Closing the **window** cannot hit this: `WindowCallbacks::onClose()` is an immediate `_Exit(0)`. The in-game **Quit** button goes through `JniSupport::requestExitGame()`, which has no bound at all — `main()` only reaches its existing `_Exit(0)` ("Workaround for XboxLive ShutdownFreeze") once the game's main-thread function returns, and here it never does.

## Change

Arm a 30 s watchdog in `requestExitGame()`. After the timeout only `write(2)` and `_Exit(2)` run, so a corrupted heap cannot re-wedge the exit path. A normal quit finishes in a few seconds and is unaffected; the message lands in the game log if it ever fires.

I did not find the source of the heap corruption (no symbols for `libminecraftpe`), so this bounds the damage rather than fixing the root cause — the same posture as the existing `_Exit(0)` workarounds.

## Testing

Built at the shipped commit (`3180b05` / manifest `e75abc9`, macOS 26.5.1, Apple Silicon) and installed into `Minecraft Bedrock Launcher.app` 0.2.565: the game launches and plays normally. The hang itself is intermittent so I could not reproduce it on demand; the watchdog only affects the quit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bijEWrxdPwBcdeTP6iyXj
